### PR TITLE
Add leave game, admin role, and one-game-at-a-time enforcement

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -79,9 +79,10 @@ body {
     "left . center . right"
     ". . bottom . ."
     ". . action . ."
-    "log log log scores scores";
+    "log log log scores scores"
+    "admin admin admin admin admin";
   grid-template-columns: 1fr 1fr 2fr 1fr 1fr;
-  grid-template-rows: auto auto auto auto auto;
+  grid-template-rows: auto auto auto auto auto auto;
   gap: 8px;
   padding: 16px;
   min-height: 100vh;
@@ -98,6 +99,7 @@ body {
 .action-panel { grid-area: action; }
 .game-log    { grid-area: log; }
 .score-board { grid-area: scores; }
+.admin-panel-area { grid-area: admin; }
 
 /* ── Player seat ─────────────────────────────────────────── */
 .player-seat {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -27,6 +27,8 @@ export const api = {
     create: (name, noPickVariant) => request('POST', '/games', { name, no_pick_variant: noPickVariant }),
     get: (id) => request('GET', `/games/${id}`),
     join: (id) => request('POST', `/games/${id}/join`),
+    leave: (id) => request('POST', `/games/${id}/leave`),
     action: (id, type, payload) => request('POST', `/games/${id}/action`, { type, payload }),
+    updateSettings: (id, settings) => request('PATCH', `/games/${id}/settings`, settings),
   },
 }

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -7,20 +7,19 @@ import GameLog from '../components/GameLog.jsx'
 import ScoreBoard from '../components/ScoreBoard.jsx'
 import Hand from '../components/Hand.jsx'
 
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers' }
+
 // Seat layout relative to current player (always at bottom)
-// slots: bottom(you), left, top-left, top, top-right, right
-// For 5 players, seats rotate so "you" are always at bottom
 function getRelativeSeats(players, myUserId) {
   const sorted = [...players].sort((a, b) => a.seat - b.seat)
   const myIdx = sorted.findIndex(p => String(p.user_id) === String(myUserId))
   if (myIdx === -1) return { bottom: null, left: null, topLeft: null, top: null, topRight: null }
-
   const get = (offset) => sorted[(myIdx + offset) % sorted.length] ?? null
   return {
-    bottom: get(0),
-    left:   get(4),
-    topLeft: get(3),
-    top:    get(2),
+    bottom:   get(0),
+    left:     get(4),
+    topLeft:  get(3),
+    top:      get(2),
     topRight: get(1),
   }
 }
@@ -28,11 +27,9 @@ function getRelativeSeats(players, myUserId) {
 function ScoringOverlay({ state, players, onNextHand, loading }) {
   const scores = state.scores ?? {}
   const sorted = [...players].sort((a, b) => (scores[b.user_id] ?? 0) - (scores[a.user_id] ?? 0))
-
   const pickerTeam = state.goingAlone
     ? [state.picker]
     : [state.picker, state.partner].filter(Boolean)
-
   const pickerWon = pickerTeam.reduce((s, uid) => s + (scores[uid] ?? 0), 0) > 0
 
   return (
@@ -43,9 +40,7 @@ function ScoringOverlay({ state, players, onNextHand, loading }) {
           <p style={{ color: '#f59e0b' }}>Doubler multiplier: ×{state.doublerMultiplier}</p>
         )}
         <table style={{ width: '100%', marginBottom: 16 }}>
-          <thead>
-            <tr><th>Player</th><th>This hand</th></tr>
-          </thead>
+          <thead><tr><th>Player</th><th>This hand</th></tr></thead>
           <tbody>
             {sorted.map(p => {
               const delta = scores[p.user_id] ?? 0
@@ -65,9 +60,66 @@ function ScoringOverlay({ state, players, onNextHand, loading }) {
             })}
           </tbody>
         </table>
-        <button onClick={onNextHand} aria-busy={loading} disabled={loading}>
-          Next hand →
-        </button>
+        <button onClick={onNextHand} aria-busy={loading} disabled={loading}>Next hand →</button>
+      </div>
+    </div>
+  )
+}
+
+function AdminSettingsPanel({ gameId, currentVariant, onUpdated }) {
+  const [variant, setVariant] = useState(currentVariant)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+
+  // Keep local state in sync if parent changes (e.g. on poll)
+  useEffect(() => { setVariant(currentVariant) }, [currentVariant])
+
+  async function handleChange(newVariant) {
+    setVariant(newVariant)
+    setSaving(true)
+    setSaved(false)
+    try {
+      await api.games.updateSettings(gameId, { no_pick_variant: newVariant })
+      setSaved(true)
+      onUpdated?.(newVariant)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e) {
+      // revert on error
+      setVariant(currentVariant)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div style={{
+      background: 'rgba(0,0,0,0.5)',
+      border: '1px solid rgba(255,255,255,0.15)',
+      borderRadius: 8,
+      padding: '10px 14px',
+      color: '#fff',
+      fontSize: '0.82rem',
+    }}>
+      <strong>⚙ Admin — No-pick variant</strong>
+      <small style={{ color: '#aaa', display: 'block', marginBottom: 6 }}>
+        Change takes effect next no-pick hand
+      </small>
+      <div style={{ display: 'flex', gap: 8 }}>
+        {['leasters', 'doublers'].map(v => (
+          <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
+            <input
+              type="radio"
+              name="variant"
+              value={v}
+              checked={variant === v}
+              onChange={() => handleChange(v)}
+              disabled={saving}
+            />
+            {VARIANT_LABELS[v]}
+          </label>
+        ))}
+        {saving && <span style={{ color: '#aaa' }}>Saving…</span>}
+        {saved && <span style={{ color: '#4ade80' }}>✓ Saved</span>}
       </div>
     </div>
   )
@@ -77,6 +129,8 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const [gameData, setGameData] = useState(null)
   const [error, setError] = useState(null)
   const [actionLoading, setActionLoading] = useState(false)
+  const [leaving, setLeaving] = useState(false)
+  const [currentVariant, setCurrentVariant] = useState(null)
   const pollingRef = useRef(null)
 
   const myUserId = String(user.id)
@@ -85,6 +139,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
     try {
       const data = await api.games.get(gameId)
       setGameData(data)
+      setCurrentVariant(prev => prev ?? data.no_pick_variant)
       setError(null)
     } catch (e) {
       setError(e.message)
@@ -107,6 +162,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
     }
   }
 
+  async function handleLeave() {
+    if (!window.confirm('Leave this game? If the game is active, it will end for everyone.')) return
+    setLeaving(true)
+    try {
+      await api.games.leave(gameId)
+      onNavigate('/lobby')
+    } catch (e) {
+      setError(e.message)
+      setLeaving(false)
+    }
+  }
+
   if (error) return (
     <div style={{ padding: 32, color: '#fff' }}>
       <p>Error: {error}</p>
@@ -118,22 +185,65 @@ export default function GamePage({ gameId, user, onNavigate }) {
     <div style={{ padding: 32, color: '#fff' }} aria-busy="true">Loading game…</div>
   )
 
-  const { players, state, status, no_pick_variant: noPickVariant } = gameData
+  const { players, state, status, is_admin: isAdmin, no_pick_variant: noPickVariant } = gameData
 
-  // Waiting for players
+  // ── Game ended (someone left mid-game) ─────────────────────────────────────
+  if (status === 'complete') {
+    return (
+      <div style={{ padding: 32, color: '#fff', maxWidth: 500, margin: '40px auto', textAlign: 'center' }}>
+        <h2>Game Over</h2>
+        <p>This game has ended (a player left or the game was completed).</p>
+        <ScoreBoard players={players} />
+        <button style={{ marginTop: 16 }} onClick={() => onNavigate('/lobby')}>Back to lobby</button>
+      </div>
+    )
+  }
+
+  // ── Waiting for players ─────────────────────────────────────────────────────
   if (status === 'waiting') {
     const amIn = players.some(p => String(p.user_id) === myUserId)
     return (
       <div style={{ padding: 32, color: '#fff', maxWidth: 500, margin: '0 auto' }}>
-        <h2>{gameData.name}</h2>
-        <p>Waiting for players… ({players.length}/5)</p>
-        <ul>
-          {players.map(p => <li key={p.user_id}>{p.username}</li>)}
-        </ul>
-        {!amIn && players.length < 5 && (
-          <button onClick={() => handleAction('join')}>Join game</button>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <h2 style={{ margin: 0 }}>{gameData.name}</h2>
+          {amIn && (
+            <button
+              className="outline contrast"
+              onClick={handleLeave}
+              aria-busy={leaving}
+              disabled={leaving}
+              style={{ fontSize: '0.85rem' }}
+            >
+              Leave game
+            </button>
+          )}
+        </div>
+
+        {isAdmin && (
+          <AdminSettingsPanel
+            gameId={gameId}
+            currentVariant={currentVariant ?? noPickVariant}
+            onUpdated={setCurrentVariant}
+          />
         )}
-        <button className="outline" onClick={() => onNavigate('/lobby')} style={{ marginLeft: 8 }}>
+        {!isAdmin && (
+          <p style={{ fontSize: '0.85rem', color: '#aaa' }}>
+            No-pick variant: <strong style={{ color: '#fff' }}>{VARIANT_LABELS[currentVariant ?? noPickVariant]}</strong>
+          </p>
+        )}
+
+        <p style={{ marginTop: 12 }}>Waiting for players… ({players.length}/5)</p>
+        <ul>
+          {players.map(p => (
+            <li key={p.user_id}>
+              {p.username}
+              {String(p.user_id) === myUserId && <span className="badge badge-you" style={{ marginLeft: 6 }}>you</span>}
+              {gameData.created_by === p.user_id && <span className="badge badge-dealer" style={{ marginLeft: 4 }}>admin</span>}
+            </li>
+          ))}
+        </ul>
+
+        <button className="outline" onClick={() => onNavigate('/lobby')} style={{ marginTop: 8 }}>
           Back to lobby
         </button>
       </div>
@@ -143,11 +253,9 @@ export default function GamePage({ gameId, user, onNavigate }) {
   if (!state) return <div style={{ padding: 32, color: '#fff' }}>Waiting for game state…</div>
 
   const seats = getRelativeSeats(players, myUserId)
-  const myPlayer = players.find(p => String(p.user_id) === myUserId)
   const myHand = state.hands?.[myUserId] ?? []
 
   const dealerUserId = state.pickOrder ? state.pickOrder[state.dealerSeat] : null
-  const pickerUserId = state.picker
   const partnerUserId = state.partnerRevealed ? state.partner : null
 
   function seatProps(player) {
@@ -155,16 +263,13 @@ export default function GamePage({ gameId, user, onNavigate }) {
     const uid = String(player.user_id)
     return {
       isDealer: uid === dealerUserId,
-      isPicker: uid === pickerUserId,
+      isPicker: uid === state.picker,
       isPartner: uid === partnerUserId,
       isYou: uid === myUserId,
       isActiveTurn: uid === currentTurnPlayer(state),
       cardCount: state.hands?.[uid]?.length ?? 0,
     }
   }
-
-  const log = state.log ?? []
-  const currentTrick = state.currentTrick ?? []
 
   return (
     <div className="game-table">
@@ -190,7 +295,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
       {/* Center trick area */}
       <TrickArea
-        trick={currentTrick}
+        trick={state.currentTrick ?? []}
         players={players}
         blind={state.phase === 'picking' ? (state.blind ?? []) : []}
       />
@@ -200,9 +305,20 @@ export default function GamePage({ gameId, user, onNavigate }) {
         <PlayerSeat player={seats.right} {...seatProps(seats.right)} />
       </div>
 
-      {/* Bottom — your hand */}
+      {/* Bottom — your hand + leave button */}
       <div className="seat-bottom" style={{ textAlign: 'center' }}>
-        <PlayerSeat player={seats.bottom} {...seatProps(seats.bottom)} />
+        <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+          <PlayerSeat player={seats.bottom} {...seatProps(seats.bottom)} />
+          <button
+            className="outline contrast"
+            onClick={handleLeave}
+            aria-busy={leaving}
+            disabled={leaving}
+            style={{ fontSize: '0.75rem', padding: '4px 10px', whiteSpace: 'nowrap' }}
+          >
+            Leave game
+          </button>
+        </div>
         {state.phase !== 'discarding' && state.phase !== 'playing' && (
           <Hand cards={myHand} />
         )}
@@ -218,7 +334,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
       />
 
       {/* Game log */}
-      <GameLog entries={log} />
+      <GameLog entries={state.log ?? []} />
+
+      {/* Admin settings panel (active game) */}
+      <div className="admin-panel-area">
+        {isAdmin && (
+          <AdminSettingsPanel
+            gameId={gameId}
+            currentVariant={currentVariant ?? noPickVariant}
+            onUpdated={setCurrentVariant}
+          />
+        )}
+      </div>
 
       {/* Score board */}
       <ScoreBoard players={players} />

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -13,6 +13,9 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState(null)
 
+  // Game the user is currently a member of (waiting or active)
+  const myGame = games.find(g => g.is_member)
+
   async function loadGames() {
     try {
       const list = await api.games.list()
@@ -32,6 +35,7 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
 
   async function handleCreate(e) {
     e.preventDefault()
+    if (myGame) return setError('Leave your current game before creating a new one.')
     setCreating(true)
     setError(null)
     try {
@@ -62,16 +66,37 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
           <p style={{ margin: 0, fontSize: '0.85rem' }}>Welcome, {user.username}</p>
         </hgroup>
         <div style={{ display: 'flex', gap: 8 }}>
-          <button onClick={() => setShowCreate(s => !s)} className="secondary">
+          <button
+            onClick={() => setShowCreate(s => !s)}
+            className="secondary"
+            disabled={!!myGame}
+            title={myGame ? 'Leave your current game first' : undefined}
+          >
             {showCreate ? 'Cancel' : 'New game'}
           </button>
           <button className="outline" onClick={onLogout}>Sign out</button>
         </div>
       </div>
 
+      {/* Banner if user is already in a game */}
+      {myGame && (
+        <article style={{ background: 'rgba(245,158,11,0.15)', borderLeft: '3px solid #f59e0b', marginBottom: 16 }}>
+          <p style={{ margin: 0 }}>
+            You are in <strong>{myGame.name}</strong> ({STATUS_LABELS[myGame.status]}).{' '}
+            <a
+              href={`#/game/${myGame.id}`}
+              style={{ fontWeight: 600 }}
+              onClick={e => { e.preventDefault(); onNavigate(`/game/${myGame.id}`) }}
+            >
+              Rejoin →
+            </a>
+          </p>
+        </article>
+      )}
+
       {error && <p style={{ color: 'var(--pico-del-color)' }}>{error}</p>}
 
-      {showCreate && (
+      {showCreate && !myGame && (
         <article style={{ marginBottom: 24 }}>
           <h4>Create a game</h4>
           <form onSubmit={handleCreate}>
@@ -119,13 +144,16 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
       )}
 
       {games.map(game => {
-        const isMine = game.player_count > 0  // heuristic — full join info not loaded here
+        const canJoin = game.status === 'waiting' && game.player_count < 5 && !game.is_member && !myGame
         return (
           <article key={game.id} style={{ marginBottom: 12 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
               <div>
                 <strong>{game.name}</strong>
-                <span style={{ marginLeft: 8, fontSize: '0.75rem', color: '#888' }}>
+                {game.is_admin && (
+                  <span className="badge badge-dealer" style={{ marginLeft: 6 }}>your game</span>
+                )}
+                <span style={{ marginLeft: 6, fontSize: '0.75rem', color: '#888' }}>
                   by {game.created_by_username}
                 </span>
                 <br />
@@ -138,16 +166,25 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
                 </small>
               </div>
               <div style={{ display: 'flex', gap: 8 }}>
-                {game.status === 'active' && (
-                  <button className="secondary" onClick={() => onNavigate(`/game/${game.id}`)}>
-                    Spectate / Rejoin
-                  </button>
-                )}
-                {game.status === 'waiting' && game.player_count < 5 && (
-                  <button onClick={() => handleJoin(game.id)}>Join</button>
-                )}
-                {game.status === 'waiting' && game.player_count >= 5 && (
-                  <button disabled>Full</button>
+                {game.is_member ? (
+                  <button onClick={() => onNavigate(`/game/${game.id}`)}>Rejoin</button>
+                ) : (
+                  <>
+                    {game.status === 'active' && (
+                      <button className="secondary" onClick={() => onNavigate(`/game/${game.id}`)}>
+                        Spectate
+                      </button>
+                    )}
+                    {game.status === 'waiting' && (
+                      <button
+                        onClick={() => handleJoin(game.id)}
+                        disabled={!canJoin}
+                        title={myGame && !game.is_member ? 'Leave your current game first' : undefined}
+                      >
+                        {game.player_count >= 5 ? 'Full' : 'Join'}
+                      </button>
+                    )}
+                  </>
                 )}
               </div>
             </div>

--- a/functions/api/games/[id]/index.js
+++ b/functions/api/games/[id]/index.js
@@ -42,6 +42,7 @@ export async function onRequestGet({ request, env, params }) {
 
     return json({
       ...game,
+      is_admin: game.created_by === user.user_id,
       players: playersWithScores,
       state: stateView,
     })

--- a/functions/api/games/[id]/join.js
+++ b/functions/api/games/[id]/join.js
@@ -11,11 +11,21 @@ export async function onRequestPost({ request, env, params }) {
     if (!game) return err('Game not found.', 404)
     if (game.status !== 'waiting') return err('Game is not open for joining.')
 
+    // Block joining if already in any active/waiting game
+    const existingGame = await env.DB.prepare(`
+      SELECT g.id, g.name FROM game_players gp
+      JOIN games g ON g.id = gp.game_id
+      WHERE gp.user_id = ? AND g.status IN ('waiting', 'active')
+      LIMIT 1
+    `).bind(user.user_id).first()
+    if (existingGame) {
+      return err(`You are already in a game ("${existingGame.name}"). Leave it before joining another.`, 409)
+    }
+
     const { results: players } = await env.DB.prepare(
       'SELECT seat, user_id FROM game_players WHERE game_id = ? ORDER BY seat'
     ).bind(gameId).all()
 
-    if (players.some(p => String(p.user_id) === userId)) return err('Already in this game.')
     if (players.length >= 5) return err('Game is full.')
 
     // Find next open seat

--- a/functions/api/games/[id]/leave.js
+++ b/functions/api/games/[id]/leave.js
@@ -1,0 +1,49 @@
+import { err, requireUser, AuthError, json } from '../../_helpers.js'
+
+export async function onRequestPost({ request, env, params }) {
+  try {
+    const user = await requireUser(request, env.DB)
+    const gameId = params.id
+    const userId = user.user_id
+
+    const game = await env.DB.prepare('SELECT * FROM games WHERE id = ?').bind(gameId).first()
+    if (!game) return err('Game not found.', 404)
+    if (game.status === 'complete') return err('Game is already complete.')
+
+    const membership = await env.DB.prepare(
+      'SELECT id FROM game_players WHERE game_id = ? AND user_id = ?'
+    ).bind(gameId, userId).first()
+    if (!membership) return err('You are not in this game.', 403)
+
+    // Remove the player
+    await env.DB.prepare(
+      'DELETE FROM game_players WHERE game_id = ? AND user_id = ?'
+    ).bind(gameId, userId).run()
+
+    // Check remaining players
+    const { results: remaining } = await env.DB.prepare(
+      'SELECT id FROM game_players WHERE game_id = ?'
+    ).bind(gameId).all()
+
+    if (remaining.length === 0) {
+      // Last player left — end the game
+      await env.DB.prepare(
+        "UPDATE games SET status = 'complete', updated_at = datetime('now') WHERE id = ?"
+      ).bind(gameId).run()
+      return json({ left: true, ended: true })
+    }
+
+    if (game.status === 'active') {
+      // Can't continue with fewer than 5 — end the game
+      await env.DB.prepare(
+        "UPDATE games SET status = 'complete', updated_at = datetime('now') WHERE id = ?"
+      ).bind(gameId).run()
+      return json({ left: true, ended: true })
+    }
+
+    return json({ left: true, ended: false, player_count: remaining.length })
+  } catch (e) {
+    if (e instanceof AuthError) return err(e.message, 401)
+    return err(e.message, 500)
+  }
+}

--- a/functions/api/games/[id]/settings.js
+++ b/functions/api/games/[id]/settings.js
@@ -1,0 +1,35 @@
+import { json, err, requireUser, AuthError } from '../../_helpers.js'
+
+export async function onRequestPatch({ request, env, params }) {
+  try {
+    const user = await requireUser(request, env.DB)
+    const gameId = params.id
+    const userId = user.user_id
+
+    const game = await env.DB.prepare('SELECT * FROM games WHERE id = ?').bind(gameId).first()
+    if (!game) return err('Game not found.', 404)
+    if (game.status === 'complete') return err('Game is already complete.')
+
+    // Only admin (creator) may change settings
+    if (game.created_by !== userId) return err('Only the game admin can change settings.', 403)
+
+    let body
+    try { body = await request.json() } catch { return err('Invalid JSON.') }
+
+    const { no_pick_variant } = body ?? {}
+    if (no_pick_variant && !['leasters', 'doublers'].includes(no_pick_variant)) {
+      return err('no_pick_variant must be "leasters" or "doublers".')
+    }
+
+    if (no_pick_variant) {
+      await env.DB.prepare(
+        "UPDATE games SET no_pick_variant = ?, updated_at = datetime('now') WHERE id = ?"
+      ).bind(no_pick_variant, gameId).run()
+    }
+
+    return json({ ok: true, no_pick_variant: no_pick_variant ?? game.no_pick_variant })
+  } catch (e) {
+    if (e instanceof AuthError) return err(e.message, 401)
+    return err(e.message, 500)
+  }
+}

--- a/functions/api/games/index.js
+++ b/functions/api/games/index.js
@@ -17,7 +17,9 @@ async function listGames({ request, env }) {
   const { results } = await env.DB.prepare(`
     SELECT g.id, g.name, g.status, g.no_pick_variant,
            u.username as created_by_username,
-           COUNT(gp.id) as player_count
+           g.created_by,
+           COUNT(gp.id) as player_count,
+           MAX(CASE WHEN gp.user_id = ? THEN 1 ELSE 0 END) as is_member
     FROM games g
     JOIN users u ON u.id = g.created_by
     LEFT JOIN game_players gp ON gp.game_id = g.id
@@ -25,9 +27,13 @@ async function listGames({ request, env }) {
     GROUP BY g.id
     ORDER BY g.created_at DESC
     LIMIT 50
-  `).all()
+  `).bind(user.user_id).all()
 
-  return json(results)
+  return json(results.map(g => ({
+    ...g,
+    is_member: g.is_member === 1,
+    is_admin: g.created_by === user.user_id,
+  })))
 }
 
 async function createGame({ request, env }) {


### PR DESCRIPTION
## Summary

- **Leave game**: players can leave from the waiting room (removes them from the game) or an active game (ends the game for everyone); last player out marks the game complete and hides it from the lobby
- **Admin role**: game creator gets an admin badge and exclusive access to change the no-pick variant (leasters/doublers) at any time via a settings panel; change takes effect on the next no-pick hand
- **One game at a time**: joining or creating a game is blocked if the user is already in a waiting/active game; lobby shows a rejoin banner and disables join/create buttons with tooltips

## Test plan

- [ ] Create a game, leave from the waiting room — confirm you are removed and the game still shows for others
- [ ] Last player leaves waiting room — confirm game disappears from lobby
- [ ] Join an active game and leave — confirm game ends and all players see the "Game Over" screen
- [ ] Try joining a second game while already in one — confirm it is blocked with an error message
- [ ] As admin, change variant from leasters to doublers mid-hand — confirm the change shows saved and takes effect on the next no-pick hand
- [ ] Verify non-admin players see the variant as read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)