### PR TITLE
Enforce under card rule for Call an Ace

### DIFF
--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -91,7 +91,11 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
       return <div className="action-panel"><p>Waiting for picker to call an ace…</p></div>
     }
     const myAces = new Set(myHand.map(c => c.id))
-    const callableSuits = ['C', 'H', 'S'].filter(s => !myAces.has(`A${s}`))
+    // Under card rule: can only call a suit if picker holds ≥1 non-trump card of that suit
+    const callableSuits = ['C', 'H', 'S'].filter(s =>
+      !myAces.has(`A${s}`) &&
+      myHand.some(c => c.suit === s && c.rank !== 'Q' && c.rank !== 'J')
+    )
 
     return (
       <div className="action-panel" style={botStyle}>
@@ -111,7 +115,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
           ))}
         </div>
         {callableSuits.length === 0 && (
-          <p style={{ color: '#f87171' }}>You hold all non-trump aces — you go alone!</p>
+          <p style={{ color: '#f87171' }}>No valid suit to call — you have no under cards. Contact the game admin.</p>
         )}
         {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
       </div>

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -193,6 +193,12 @@ export function callAce(state, userId, suit) {
     throw new Error(`Picker holds the ${aceId} — cannot call it.`)
   }
 
+  // Under card rule: picker must have at least one non-trump card of the called suit
+  const underCards = state.hands[userId].filter(c => c.suit === suit && !isTrump(c))
+  if (underCards.length === 0) {
+    throw new Error(`Under card rule: must hold at least one ${suit} card to call A${suit}.`)
+  }
+
   const newState = deepClone(state)
   newState.calledAce = { suit, aceId }
 


### PR DESCRIPTION
## Summary

- Picker may only call an ace if they hold at least one non-trump card of that suit (an "under card")
- Without this rule, a picker could bury all cards of a suit and call that ace anyway, making the called suit unplayable and the partner unrevealed
- Engine (`callAce`) rejects invalid calls server-side; UI (`ActionPanel`) filters the callable suit buttons client-side to match

## Test plan

- [ ] Picker with no clubs (non-trump) cannot call AC — button does not appear in UI
- [ ] Picker attempts to call via direct API with no under cards → server returns 400 with under card error
- [ ] Picker with at least one club (e.g. 7C) can call AC normally
- [ ] Going alone (holding all 3 non-trump aces) still works — engine bypasses calling phase entirely
- [ ] Ace buried in discard with no under cards for that suit: picker cannot call that suit

🤖 Generated with [Claude Code](https://claude.com/claude-code)