### PR TITLE
Implement under card rule and partner call escalation

### DIFF
--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -9,6 +9,8 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     : {}
   const turnLabel = actingForName ? `Acting for ${actingForName}` : 'Your turn'
   const [selectedDiscards, setSelectedDiscards] = useState([])
+  const [unknownSelectedSuit, setUnknownSelectedSuit] = useState(null)
+  const [selectedUnderCard, setSelectedUnderCard] = useState(null)
   const [error, setError] = useState(null)
 
   async function act(type, payload) {
@@ -88,24 +90,125 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
   // ── Calling phase ─────────────────────────────────────────
   if (phase === 'calling') {
     if (picker !== myUserId) {
-      return <div className="action-panel"><p>Waiting for picker to call an ace…</p></div>
+      return <div className="action-panel"><p>Waiting for picker to call a partner card…</p></div>
     }
-    const myAces = new Set(myHand.map(c => c.id))
-    // Under card rule: can only call a suit if picker holds ≥1 non-trump card of that suit
-    const callableSuits = ['C', 'H', 'S'].filter(s =>
-      !myAces.has(`A${s}`) &&
-      myHand.some(c => c.suit === s && c.rank !== 'Q' && c.rank !== 'J')
-    )
+
+    const callMode = state.callMode ?? 'ace'
+    const heldIds = new Set(myHand.map(c => c.id))
+    // Cards the picker buried — cannot call any of these since the "partner" would be
+    // nobody (the card is in the blind, never played).
+    const buriedIds = new Set((state.discard ?? []).filter(c => !c.hidden).map(c => c.id))
+
+    // ── King mode: picker holds all 3 fail aces and all 3 fail tens.
+    //    Calls the King of any fail suit they don't hold (mathematically all 3).
+    if (callMode === 'king') {
+      const callableSuits = ['C', 'H', 'S'].filter(s => !heldIds.has(`K${s}`) && !buriedIds.has(`K${s}`))
+      return (
+        <div className="action-panel" style={botStyle}>
+          <h4>Call a king</h4>
+          <p style={{ fontSize: '0.85rem', color: '#ccc' }}>
+            You hold all fail aces and tens. Call a king as your partner.
+            You'll be forced to play your A and 10 of the called suit when it's led.
+          </p>
+          <div className="suit-picker">
+            {callableSuits.map(suit => (
+              <button
+                key={suit}
+                className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
+                onClick={() => act('call_king', { suit })}
+                disabled={loading}
+                title={`Call K${suit}`}
+              >
+                K{SUIT_SYMBOLS[suit]}
+              </button>
+            ))}
+          </div>
+          {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
+        </div>
+      )
+    }
+
+    // ── Ten mode: picker holds all 3 fail aces but not all 3 fail tens.
+    //    Calls the 10 of a fail suit whose 10 they do not hold.
+    if (callMode === 'ten') {
+      const callableSuits = ['C', 'H', 'S'].filter(s => !heldIds.has(`10${s}`) && !buriedIds.has(`10${s}`))
+      return (
+        <div className="action-panel" style={botStyle}>
+          <h4>Call a ten</h4>
+          <p style={{ fontSize: '0.85rem', color: '#ccc' }}>
+            You hold all three fail aces. Call a 10 as your partner.
+            You'll be forced to play the Ace of the called suit when that suit is led.
+          </p>
+          <div className="suit-picker">
+            {callableSuits.map(suit => (
+              <button
+                key={suit}
+                className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
+                onClick={() => act('call_ten', { suit })}
+                disabled={loading}
+                title={`Call 10${suit}`}
+              >
+                10{SUIT_SYMBOLS[suit]}
+              </button>
+            ))}
+          </div>
+          {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
+        </div>
+      )
+    }
+
+    // ── Ace mode (default). Each suit is either a normal call or requires placing
+    //    an under card (Situation B) if the picker holds no fail card of that suit.
+    const isFailCard = (c, s) => c.suit === s && c.rank !== 'Q' && c.rank !== 'J'
+    const candidateSuits = ['C', 'H', 'S'].filter(s => !heldIds.has(`A${s}`) && !buriedIds.has(`A${s}`))
+    const normalSuits = candidateSuits.filter(s => myHand.some(c => isFailCard(c, s)))
+    const unknownSuits = candidateSuits.filter(s => !myHand.some(c => isFailCard(c, s)))
+
+    if (unknownSelectedSuit) {
+      // Situation B: pick the under card from hand
+      return (
+        <div className="action-panel" style={botStyle}>
+          <h4>Place an under card for A{SUIT_SYMBOLS[unknownSelectedSuit]} Unknown</h4>
+          <p style={{ fontSize: '0.85rem', color: '#ccc' }}>
+            Choose any card to place face-down as the under card. It has no power; it must be played
+            when the called suit is led.
+          </p>
+          <Hand
+            cards={myHand}
+            playableIds={myHand.map(c => c.id)}
+            selectedIds={selectedUnderCard ? [selectedUnderCard] : []}
+            onCardClick={(card) => setSelectedUnderCard(card.id)}
+          />
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 8 }}>
+            <button
+              disabled={!selectedUnderCard || loading}
+              onClick={() => act('call_ace_unknown', { suit: unknownSelectedSuit, underCardId: selectedUnderCard })
+                .then(() => { setUnknownSelectedSuit(null); setSelectedUnderCard(null) })}
+            >
+              Confirm
+            </button>
+            <button
+              className="secondary"
+              onClick={() => { setUnknownSelectedSuit(null); setSelectedUnderCard(null) }}
+              disabled={loading}
+            >
+              Back
+            </button>
+          </div>
+          {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
+        </div>
+      )
+    }
 
     return (
       <div className="action-panel" style={botStyle}>
         <h4>Call an ace</h4>
         <p style={{ fontSize: '0.85rem', color: '#ccc' }}>The holder of the called ace is your partner.</p>
         <div className="suit-picker">
-          {callableSuits.map(suit => (
+          {normalSuits.map(suit => (
             <button
               key={suit}
-              className={`suit-btn ${suit === 'H' || suit === 'D' ? 'red' : 'black'}`}
+              className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
               onClick={() => act('call_ace', { suit })}
               disabled={loading}
               title={`Call A${suit}`}
@@ -114,8 +217,28 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
             </button>
           ))}
         </div>
-        {callableSuits.length === 0 && (
-          <p style={{ color: '#f87171' }}>No valid suit to call — you have no under cards. Contact the game admin.</p>
+        {unknownSuits.length > 0 && (
+          <>
+            <p style={{ fontSize: '0.8rem', color: '#ccc', marginTop: 8 }}>
+              These suits require placing an under card (you hold no fail card of the suit):
+            </p>
+            <div className="suit-picker">
+              {unknownSuits.map(suit => (
+                <button
+                  key={suit}
+                  className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
+                  onClick={() => setUnknownSelectedSuit(suit)}
+                  disabled={loading}
+                  title={`Call A${suit} Unknown`}
+                >
+                  A{SUIT_SYMBOLS[suit]}?
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+        {normalSuits.length === 0 && unknownSuits.length === 0 && (
+          <p style={{ color: '#f87171' }}>No valid suit to call. Contact the game admin.</p>
         )}
         {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
       </div>

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -8,8 +8,19 @@ function cardImageSrc(cardId) {
 
 export default function Card({ card, playable = false, selected = false, onClick }) {
   if (!card || card.hidden) {
+    const hiddenClasses = [
+      'card', 'card-img', 'hidden',
+      playable ? 'playable' : '',
+      selected ? 'selected' : '',
+    ].filter(Boolean).join(' ')
     return (
-      <div className="card card-img hidden" aria-label="Hidden card">
+      <div
+        className={hiddenClasses}
+        aria-label={card?.isUnderCard ? 'Under card' : 'Hidden card'}
+        title={card?.isUnderCard ? 'Under card' : undefined}
+        onClick={playable ? onClick : undefined}
+        role={playable ? 'button' : undefined}
+      >
         <img src={CARD_BACK_SRC} alt="Card back" className="card-image" />
       </div>
     )

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -142,7 +142,15 @@ function TestModePanel({ state, players, currentTurnUserId, myUserId, onAction, 
           const hand         = state.hands?.[uid] ?? []
           const isTurn       = uid === currentTurnUserId
           const isMe         = uid === myUserId
-          const visibleCards = hand.filter(c => !c.hidden)
+          let visibleCards = hand.filter(c => !c.hidden)
+          // Append the under card as a clickable face-down tile if this player is the
+          // picker and there's an unplayed under card.
+          if (uid === state.picker && state.underCard && !state.underCard.played) {
+            visibleCards = [
+              ...visibleCards,
+              { id: 'UNDER_CARD', hidden: true, isUnderCard: true, faceDown: true },
+            ]
+          }
 
           if (isMe || visibleCards.length === 0) return null
 
@@ -187,17 +195,48 @@ function currentTurnPlayer(state) {
 }
 
 // ── Legal card computation (mirrors ActionPanel / engine logic) ───────────────
+// `hand` here may include the under card pseudo-entry (id 'UNDER_CARD', isUnderCard: true)
+// when the viewer is the picker.
 function getLegalCardIds(state, userId, hand) {
-  const { currentTrick, calledAce, partner, partnerRevealed } = state
-  if (!currentTrick || currentTrick.length === 0) return hand.map(c => c.id)
-  const ledSuit = effectiveSuit(currentTrick[0].card)
-  const hasSuit = hand.some(c => effectiveSuit(c) === ledSuit)
-  if (!hasSuit) return hand.map(c => c.id)
-  const mustFollow = hand.filter(c => effectiveSuit(c) === ledSuit).map(c => c.id)
-  if (calledAce && userId === partner && !partnerRevealed && ledSuit === calledAce.suit) {
-    const hasCalledAce = hand.some(c => c.id === calledAce.aceId)
-    if (hasCalledAce) return [calledAce.aceId]
+  const { currentTrick, calledAce, calledTen, calledKing, calledSuit, partner, partnerRevealed,
+          underCard, picker, pickerForcedPlays = [] } = state
+  const handCards = hand.filter(c => !c.isUnderCard)
+  const hasUnderCard = hand.some(c => c.isUnderCard) && underCard && !underCard.played
+
+  // Leading: any hand card, plus the under card if held (declares called suit as led)
+  if (!currentTrick || currentTrick.length === 0) {
+    const ids = handCards.map(c => c.id)
+    if (userId === picker && hasUnderCard) ids.push('UNDER_CARD')
+    return ids
   }
+
+  // Determine led suit (face-down lead means called suit is led)
+  const first = currentTrick[0]
+  const ledSuit = first.declaredSuit ?? effectiveSuit(first.card)
+
+  // Picker with under card: when called suit led, MUST play under card
+  if (userId === picker && hasUnderCard && ledSuit === calledSuit) {
+    return ['UNDER_CARD']
+  }
+
+  const hasSuit = handCards.some(c => effectiveSuit(c) === ledSuit)
+  const mustFollow = hasSuit
+    ? handCards.filter(c => effectiveSuit(c) === ledSuit).map(c => c.id)
+    : handCards.map(c => c.id)
+
+  // Partner must play the called card when called suit is led
+  const calledCardId = calledAce?.aceId || calledTen?.tenId || calledKing?.kingId
+  if (calledCardId && userId === partner && !partnerRevealed && ledSuit === calledSuit) {
+    if (handCards.some(c => c.id === calledCardId)) return [calledCardId]
+  }
+
+  // Picker forced plays (Situation A / King case): when called suit led, must play
+  // one of the still-held forced cards (Ace, or Ace/Ten in either order).
+  if (userId === picker && pickerForcedPlays.length > 0 && ledSuit === calledSuit) {
+    const heldForced = pickerForcedPlays.filter(cid => handCards.some(c => c.id === cid))
+    if (heldForced.length > 0) return heldForced
+  }
+
   return mustFollow
 }
 
@@ -343,9 +382,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const isActingForBot = isTestMode && user.is_admin && turnUserId !== myUserId && turnUserId !== null
   const actingForPlayer = isActingForBot ? players.find(p => String(p.user_id) === turnUserId) : null
   const effectiveUserId = isActingForBot ? turnUserId : myUserId
-  const activeHand      = isActingForBot
+  let activeHand        = isActingForBot
     ? (state.hands?.[turnUserId] ?? []).filter(c => !c.hidden)
     : myHand
+
+  // If the effective viewer is the picker and there is an unplayed under card,
+  // append it to the hand so it renders as a clickable face-down tile.
+  if (effectiveUserId === state.picker && state.underCard && !state.underCard.played) {
+    activeHand = [
+      ...activeHand,
+      { id: 'UNDER_CARD', hidden: true, isUnderCard: true, faceDown: true },
+    ]
+  }
 
   const dealerUserId  = state.pickOrder ? state.pickOrder[state.dealerSeat] : null
   const pickerUserId  = state.picker
@@ -361,7 +409,15 @@ export default function GamePage({ gameId, user, onNavigate }) {
   function seatProps(player) {
     if (!player) return {}
     const uid  = String(player.user_id)
-    const hand = state.hands?.[uid] ?? []
+    let hand = state.hands?.[uid] ?? []
+    // Append the under card pseudo entry for the picker so it renders as a
+    // face-down, clickable tile alongside the rest of their hand.
+    if (uid === state.picker && state.underCard && !state.underCard.played) {
+      hand = [
+        ...hand,
+        { id: 'UNDER_CARD', hidden: true, isUnderCard: true, faceDown: true },
+      ]
+    }
     return {
       isDealer:      uid === dealerUserId,
       isPicker:      uid === pickerUserId,

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -1,6 +1,6 @@
 import { json, err, requireUser, AuthError } from '../../_helpers.js'
 import {
-  pick, pass, discard, callAce, playCard,
+  pick, pass, discard, callAce, callAceUnknown, callTen, callKing, playCard,
   setupLeaster, awardLeasterBlind, resolveLeaster,
   dealHand,
 } from '../../../../shared/gameEngine.js'
@@ -83,6 +83,18 @@ export async function onRequestPost({ request, env, params }) {
 
       case 'call_ace':
         state = callAce(state, userId, payload?.suit)
+        break
+
+      case 'call_ace_unknown':
+        state = callAceUnknown(state, userId, payload?.suit, payload?.underCardId)
+        break
+
+      case 'call_ten':
+        state = callTen(state, userId, payload?.suit)
+        break
+
+      case 'call_king':
+        state = callKing(state, userId, payload?.suit)
         break
 
       case 'play_card': {

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -90,7 +90,14 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     pickIndex: 0,              // index into pickOrder of whose turn it is to pick/pass
     picker: null,              // userId of picker
     partner: null,             // userId of partner (set when ace is called)
-    calledAce: null,           // { suit } e.g. { suit: 'C' }
+    calledAce: null,           // { suit, aceId, unknown? } — set for ace and ace-unknown calls
+    calledTen: null,           // { suit, tenId } — set when picker holds all 3 fail aces
+    calledKing: null,          // { suit, kingId } — set when picker holds all 3 fail aces and tens
+    calledSuit: null,          // 'C'|'H'|'S' — unifying field across all call types
+    callMode: null,            // null | 'ace' | 'ten' | 'king'
+    underCard: null,           // { id, suit, rank, ownerId, played } — server-side full info
+    pickerMustHold: [],        // card ids the picker may not bury during discard
+    pickerForcedPlays: [],     // card ids the picker must play when called suit is led
     partnerRevealed: false,
     goingAlone: false,
     blind,
@@ -150,6 +157,29 @@ export function discard(state, userId, cardIds) {
   const newState = deepClone(state)
   const hand = newState.hands[userId]
 
+  // Determine calling mode based on the picker's 8-card hand BEFORE discard
+  const failAces = ['AC', 'AH', 'AS']
+  const failTens = ['10C', '10H', '10S']
+  const holdsAllAces = failAces.every(id => hand.some(c => c.id === id))
+  const holdsAllTens = failTens.every(id => hand.some(c => c.id === id))
+
+  let mustHold = []
+  let callMode = 'ace'
+  if (holdsAllAces && holdsAllTens) {
+    mustHold = [...failAces, ...failTens]
+    callMode = 'king'
+  } else if (holdsAllAces) {
+    mustHold = [...failAces]
+    callMode = 'ten'
+  }
+
+  // Reject discards that bury cards the picker must keep for the partner call
+  for (const cid of cardIds) {
+    if (mustHold.includes(cid)) {
+      throw new Error(`Cannot bury ${cid} — must keep for partner call.`)
+    }
+  }
+
   const discarded = []
   for (const cid of cardIds) {
     const idx = hand.findIndex(c => c.id === cid)
@@ -158,101 +188,208 @@ export function discard(state, userId, cardIds) {
   }
 
   newState.discard = discarded
+  newState.pickerMustHold = mustHold
+  newState.callMode = callMode
+  newState.phase = 'calling'
   newState.log.push(`${userId} discarded 2 cards.`)
-
-  // Check if picker holds all non-trump aces → goes alone
-  const nonTrumpAces = ['AC', 'AH', 'AS']
-  const pickerHasAll = nonTrumpAces.every(aid =>
-    newState.hands[userId].some(c => c.id === aid)
-  )
-
-  if (pickerHasAll) {
-    newState.goingAlone = true
-    newState.partner = null
-    newState.partnerRevealed = true
-    newState.phase = 'playing'
-    // Picker leads first trick
-    newState.currentLeader = userId
-    newState.log.push(`${userId} is going alone (holds all non-trump aces).`)
-  } else {
-    newState.phase = 'calling'
-  }
 
   return newState
 }
 
 // ─── Calling phase ───────────────────────────────────────────────────────────
+function findHolder(hands, cardId, exclude) {
+  for (const [pid, hand] of Object.entries(hands)) {
+    if (pid === exclude) continue
+    if (hand.some(c => c.id === cardId)) return pid
+  }
+  return null
+}
+
 export function callAce(state, userId, suit) {
   assertPhase(state, 'calling')
   if (state.picker !== userId) throw new Error('Only the picker calls the ace.')
+  if (state.callMode !== 'ace') throw new Error(`Picker must call a ${state.callMode}, not an ace.`)
   if (!['C', 'H', 'S'].includes(suit)) throw new Error('Must call a non-trump suit ace.')
 
   const aceId = `A${suit}`
-  // Picker cannot call an ace they hold
   if (state.hands[userId].some(c => c.id === aceId)) {
     throw new Error(`Picker holds the ${aceId} — cannot call it.`)
   }
+  if (state.discard.some(c => c.id === aceId)) {
+    throw new Error(`Picker buried the ${aceId} — cannot call it.`)
+  }
 
-  // Under card rule: picker must have at least one non-trump card of the called suit
-  const underCards = state.hands[userId].filter(c => c.suit === suit && !isTrump(c))
-  if (underCards.length === 0) {
-    throw new Error(`Under card rule: must hold at least one ${suit} card to call A${suit}.`)
+  // Picker must hold at least one fail card of the called suit (called-suit holding rule).
+  // If they don't, they must use call_ace_unknown with an under card instead.
+  const failOfSuit = state.hands[userId].filter(c => c.suit === suit && !isTrump(c))
+  if (failOfSuit.length === 0) {
+    throw new Error(`Cannot call A${suit} normally — picker holds no fail card of that suit. Use call_ace_unknown.`)
   }
 
   const newState = deepClone(state)
   newState.calledAce = { suit, aceId }
-
-  // Identify partner (may be in discard — picker buried it — handled at scoring)
-  let partner = null
-  for (const [pid, hand] of Object.entries(newState.hands)) {
-    if (pid === userId) continue
-    if (hand.some(c => c.id === aceId)) {
-      partner = pid
-      break
-    }
-  }
-
-  // Partner could be null if ace is buried in picker's discard (picker going with buried ace)
-  newState.partner = partner
+  newState.calledSuit = suit
+  newState.partner = findHolder(newState.hands, aceId, userId)
   newState.phase = 'playing'
-  newState.currentLeader = userId  // picker leads first trick
+  newState.currentLeader = userId
   newState.log.push(`${userId} called the A${suit}.`)
   return newState
 }
 
+// Situation B: picker calls an ace of a suit in which they hold no fail card,
+// placing one card from their hand face-down on the table as the "under card."
+export function callAceUnknown(state, userId, suit, underCardId) {
+  assertPhase(state, 'calling')
+  if (state.picker !== userId) throw new Error('Only the picker calls the ace.')
+  if (state.callMode !== 'ace') throw new Error(`Picker must call a ${state.callMode}, not an unknown ace.`)
+  if (!['C', 'H', 'S'].includes(suit)) throw new Error('Must call a non-trump suit ace.')
+
+  const aceId = `A${suit}`
+  if (state.hands[userId].some(c => c.id === aceId)) {
+    throw new Error(`Picker holds the ${aceId} — cannot call it.`)
+  }
+  if (state.discard.some(c => c.id === aceId)) {
+    throw new Error(`Picker buried the ${aceId} — cannot call it.`)
+  }
+
+  const failOfSuit = state.hands[userId].filter(c => c.suit === suit && !isTrump(c))
+  if (failOfSuit.length > 0) {
+    throw new Error(`Cannot call A${suit} unknown — picker holds fail card(s) of that suit. Use call_ace.`)
+  }
+
+  const cardIdx = state.hands[userId].findIndex(c => c.id === underCardId)
+  if (cardIdx === -1) throw new Error(`Under card ${underCardId} not in hand.`)
+
+  const newState = deepClone(state)
+  const card = newState.hands[userId].splice(cardIdx, 1)[0]
+  newState.underCard = { id: card.id, suit: card.suit, rank: card.rank, ownerId: userId, played: false }
+  newState.calledAce = { suit, aceId, unknown: true }
+  newState.calledSuit = suit
+  newState.partner = findHolder(newState.hands, aceId, userId)
+  newState.phase = 'playing'
+  newState.currentLeader = userId
+  newState.log.push(`${userId} called A${suit} Unknown and placed an under card.`)
+  return newState
+}
+
+// Situation A: picker holds all 3 fail aces and calls the 10 of a fail suit
+// whose 10 they do not hold. Picker is forced to play that suit's Ace when the
+// called suit is led; partner plays the called 10.
+export function callTen(state, userId, suit) {
+  assertPhase(state, 'calling')
+  if (state.picker !== userId) throw new Error('Only the picker calls the ten.')
+  if (state.callMode !== 'ten') throw new Error(`Picker must call a ${state.callMode}, not a ten.`)
+  if (!['C', 'H', 'S'].includes(suit)) throw new Error('Must call a non-trump suit ten.')
+
+  const tenId = `10${suit}`
+  if (state.hands[userId].some(c => c.id === tenId)) {
+    throw new Error(`Picker holds the ${tenId} — cannot call it.`)
+  }
+  if (state.discard.some(c => c.id === tenId)) {
+    throw new Error(`Picker buried the ${tenId} — cannot call it.`)
+  }
+
+  const newState = deepClone(state)
+  newState.calledTen = { suit, tenId }
+  newState.calledSuit = suit
+  newState.pickerForcedPlays = [`A${suit}`]
+  newState.partner = findHolder(newState.hands, tenId, userId)
+  newState.phase = 'playing'
+  newState.currentLeader = userId
+  newState.log.push(`${userId} called the ${tenId}.`)
+  return newState
+}
+
+// King escalation of Situation A: picker holds all 3 fail aces and all 3 fail tens
+// and calls the King of any fail suit. Picker plays the Ace and 10 of the called
+// suit when that suit is led (in either order).
+export function callKing(state, userId, suit) {
+  assertPhase(state, 'calling')
+  if (state.picker !== userId) throw new Error('Only the picker calls the king.')
+  if (state.callMode !== 'king') throw new Error(`Picker must call a ${state.callMode}, not a king.`)
+  if (!['C', 'H', 'S'].includes(suit)) throw new Error('Must call a non-trump suit king.')
+
+  const kingId = `K${suit}`
+  if (state.hands[userId].some(c => c.id === kingId)) {
+    throw new Error(`Picker holds the ${kingId} — cannot call it.`)
+  }
+  if (state.discard.some(c => c.id === kingId)) {
+    throw new Error(`Picker buried the ${kingId} — cannot call it.`)
+  }
+
+  const newState = deepClone(state)
+  newState.calledKing = { suit, kingId }
+  newState.calledSuit = suit
+  newState.pickerForcedPlays = [`A${suit}`, `10${suit}`]
+  newState.partner = findHolder(newState.hands, kingId, userId)
+  newState.phase = 'playing'
+  newState.currentLeader = userId
+  newState.log.push(`${userId} called the ${kingId}.`)
+  return newState
+}
+
 // ─── Play card ───────────────────────────────────────────────────────────────
+// Sentinel id used by clients to play the under card (its real id is hidden from them)
+export const UNDER_CARD_ID = 'UNDER_CARD'
+
 export function playCard(state, userId, cardId) {
   assertPhase(state, 'playing')
   assertTurn(state, userId, currentPlayer(state))
 
   const newState = deepClone(state)
-  const hand = newState.hands[userId]
-  const cardIdx = hand.findIndex(c => c.id === cardId)
-  if (cardIdx === -1) throw new Error(`Card ${cardId} not in hand.`)
 
-  const card = hand[cardIdx]
+  const isUnderCardPlay =
+    newState.underCard &&
+    !newState.underCard.played &&
+    userId === newState.picker &&
+    (cardId === UNDER_CARD_ID || cardId === newState.underCard.id)
 
-  // Validate legal play
-  validatePlay(newState, userId, card)
+  let card
+  if (isUnderCardPlay) {
+    validateUnderCardPlay(newState, userId)
+    const uc = newState.underCard
+    card = { id: uc.id, suit: uc.suit, rank: uc.rank, faceDown: true, hidden: true }
+    newState.underCard.played = true
 
-  hand.splice(cardIdx, 1)
-  newState.currentTrick.push({ userId, card })
+    const isLead = newState.currentTrick.length === 0
+    const entry = { userId, card, faceDown: true }
+    if (isLead) entry.declaredSuit = newState.calledSuit
+    newState.currentTrick.push(entry)
+    newState.log.push(`${userId} played the under card.`)
+  } else {
+    const hand = newState.hands[userId]
+    const cardIdx = hand.findIndex(c => c.id === cardId)
+    if (cardIdx === -1) throw new Error(`Card ${cardId} not in hand.`)
+    card = hand[cardIdx]
 
-  // Reveal partner if they just played the called ace
-  if (
-    !newState.partnerRevealed &&
-    newState.calledAce &&
-    card.id === newState.calledAce.aceId
-  ) {
-    newState.partnerRevealed = true
-    newState.log.push(`${userId} revealed as partner by playing the ${card.id}.`)
+    validatePlay(newState, userId, card)
+
+    hand.splice(cardIdx, 1)
+    newState.currentTrick.push({ userId, card })
+
+    // Track picker's forced plays (Situation A / King case)
+    if (userId === newState.picker && newState.pickerForcedPlays.includes(card.id)) {
+      newState.pickerForcedPlays = newState.pickerForcedPlays.filter(id => id !== card.id)
+    }
+
+    newState.log.push(`${userId} played ${card.id}.`)
   }
 
-  newState.log.push(`${userId} played ${card.id}.`)
+  // Reveal partner if they just played the called ace/ten/king
+  if (!newState.partnerRevealed) {
+    const calledCardId =
+      newState.calledAce?.aceId ||
+      newState.calledTen?.tenId ||
+      newState.calledKing?.kingId
+    if (calledCardId && card.id === calledCardId && userId === newState.partner) {
+      newState.partnerRevealed = true
+      newState.log.push(`${userId} revealed as partner by playing the ${card.id}.`)
+    }
+  }
 
   if (newState.currentTrick.length === 5) {
-    // Resolve trick
-    const winner = resolveTrick(newState.currentTrick)
+    const ledSuit = getLedSuit(newState.currentTrick, newState)
+    const winner = resolveTrick(newState.currentTrick, ledSuit)
     newState.tricks.push({
       leader: newState.currentLeader,
       plays: [...newState.currentTrick],
@@ -264,7 +401,6 @@ export function playCard(state, userId, cardId) {
     newState.log.push(`${winner} won the trick.`)
 
     if (newState.tricks.length === 6) {
-      // Hand over
       newState.phase = 'scoring'
       newState.scores = computeScores(newState)
     }
@@ -286,12 +422,32 @@ export function currentPlayer(state) {
   return null
 }
 
+// Determine the led suit for the current trick. When the under card is the lead,
+// the picker has declared the called suit, so we use that instead of the (hidden) card's suit.
+function getLedSuit(trick, state) {
+  if (!trick || trick.length === 0) return null
+  const first = trick[0]
+  if (first.declaredSuit) return first.declaredSuit
+  return effectiveSuit(first.card)
+}
+
 function validatePlay(state, userId, card) {
   const trick = state.currentTrick
   if (trick.length === 0) return  // Leader can play anything
 
-  const ledSuit = effectiveSuit(trick[0].card)
+  const ledSuit = getLedSuit(trick, state)
   const hand = state.hands[userId]
+
+  // If the picker still has an under card and the called suit is led, they MUST play the under card
+  if (
+    userId === state.picker &&
+    state.underCard &&
+    !state.underCard.played &&
+    ledSuit === state.calledSuit
+  ) {
+    throw new Error('Picker must play the under card when the called suit is led.')
+  }
+
   const hasSuit = hand.some(c => effectiveSuit(c) === ledSuit)
 
   // Must follow suit if possible
@@ -299,33 +455,71 @@ function validatePlay(state, userId, card) {
     throw new Error(`Must follow suit (${ledSuit}).`)
   }
 
-  // Special rule: if led suit is called suit, partner must play the called ace if they have it
+  // Partner must play the called card (ace/ten/king) when called suit is led
+  const calledCardId =
+    state.calledAce?.aceId || state.calledTen?.tenId || state.calledKing?.kingId
   if (
-    state.calledAce &&
+    calledCardId &&
     userId === state.partner &&
     !state.partnerRevealed &&
-    ledSuit === state.calledAce.suit
+    ledSuit === state.calledSuit
   ) {
-    const hasCalledAce = hand.some(c => c.id === state.calledAce.aceId)
-    if (hasCalledAce && card.id !== state.calledAce.aceId) {
-      throw new Error(`Partner must play the called ace (${state.calledAce.aceId}) when that suit is led.`)
+    const hasCalled = hand.some(c => c.id === calledCardId)
+    if (hasCalled && card.id !== calledCardId) {
+      throw new Error(`Partner must play ${calledCardId} when the called suit is led.`)
+    }
+  }
+
+  // Picker forced plays (Situation A / King case): when called suit led, picker must
+  // play one of the still-held forced cards (Ace, or Ace/Ten in either order).
+  if (
+    userId === state.picker &&
+    state.pickerForcedPlays?.length > 0 &&
+    ledSuit === state.calledSuit
+  ) {
+    const heldForced = state.pickerForcedPlays.filter(cid => hand.some(c => c.id === cid))
+    if (heldForced.length > 0 && !heldForced.includes(card.id)) {
+      throw new Error(
+        `Picker must play ${heldForced.join(' or ')} when the called suit is led.`
+      )
     }
   }
 }
 
-function resolveTrick(plays) {
-  const [first, ...rest] = plays
-  let winner = first
-
-  for (const play of rest) {
-    if (beats(play.card, winner.card)) {
-      winner = play
-    }
+// Validate that the picker is allowed to play the under card right now.
+function validateUnderCardPlay(state, userId) {
+  if (userId !== state.picker) throw new Error('Only the picker may play the under card.')
+  if (!state.underCard || state.underCard.played) {
+    throw new Error('No under card to play.')
   }
+
+  const trick = state.currentTrick
+  if (trick.length === 0) {
+    // Leading: legal — declares the called suit as the led suit
+    return
+  }
+
+  // Following: only legal if the called suit was led, OR the picker has no other cards
+  // (last-trick fallback when called suit was never led).
+  const ledSuit = getLedSuit(trick, state)
+  if (ledSuit === state.calledSuit) return
+  if (state.hands[userId].length === 0) return
+
+  throw new Error('Under card can only be played when the called suit is led.')
+}
+
+function resolveTrick(plays, ledSuit) {
+  let winner = null
+  for (const play of plays) {
+    if (play.card?.faceDown) continue  // face-down under card has no power
+    if (winner === null) { winner = play; continue }
+    if (beats(play.card, winner.card, ledSuit)) winner = play
+  }
+  if (winner === null) winner = plays[0]  // all face-down (shouldn't happen)
   return winner.userId
 }
 
-function beats(challenger, current) {
+function beats(challenger, current, ledSuit) {
   const cTrump = isTrump(challenger)
   const wTrump = isTrump(current)
 
@@ -333,7 +527,12 @@ function beats(challenger, current) {
   if (!cTrump && wTrump) return false
   if (cTrump && wTrump) return trumpRank(challenger) < trumpRank(current)
 
-  // Both non-trump: only beats if same suit and higher rank
+  // Both non-trump: a card of the led suit beats a card not of the led suit.
+  const cIsLed = challenger.suit === ledSuit
+  const wIsLed = current.suit === ledSuit
+  if (cIsLed && !wIsLed) return true
+  if (!cIsLed && wIsLed) return false
+
   if (challenger.suit !== current.suit) return false
   return suitRank(challenger) < suitRank(current)
 }
@@ -475,8 +674,53 @@ export function getPlayerView(state, userId) {
   }
 
   // Picker can see blind during picking (they just picked it up — this is after picking)
-  // Discard is always hidden
-  view.discard = view.discard.map(() => ({ id: 'HIDDEN', hidden: true }))
+  // Discard is visible to the picker (they buried it); hidden to everyone else.
+  if (userId !== view.picker) {
+    view.discard = view.discard.map(() => ({ id: 'HIDDEN', hidden: true }))
+  }
+
+  // Under card: picker (who placed it) can see its identity; other players cannot.
+  // Use a sentinel id ('UNDER_CARD') for the redacted form so the client can submit
+  // play_card with that id and the server resolves it.
+  if (view.underCard) {
+    if (userId === view.picker) {
+      view.underCard = { ...view.underCard, isUnderCard: true }
+    } else {
+      view.underCard = {
+        id: UNDER_CARD_ID,
+        hidden: true,
+        isUnderCard: true,
+        played: view.underCard.played,
+      }
+    }
+  }
+
+  // Redact face-down plays in currentTrick: the player who played it sees the real card,
+  // everyone else sees a hidden card. (Trick winner is unknown until resolution.)
+  view.currentTrick = view.currentTrick.map(p => {
+    if (!p.faceDown) return p
+    if (p.userId === userId) return p
+    return { ...p, card: { id: UNDER_CARD_ID, hidden: true, faceDown: true } }
+  })
+
+  // Redact face-down plays in completed tricks: the player who played it AND the trick winner
+  // can see the real card. Everyone else sees a hidden card.
+  view.tricks = view.tricks.map(t => ({
+    ...t,
+    plays: t.plays.map(p => {
+      if (!p.faceDown) return p
+      if (p.userId === userId || t.winner === userId) return p
+      return { ...p, card: { id: UNDER_CARD_ID, hidden: true, faceDown: true } }
+    }),
+  }))
+
+  // Redact lastTrick face-down plays the same way (using the most recent completed trick's winner).
+  const mostRecent = view.tricks[view.tricks.length - 1]
+  view.lastTrick = view.lastTrick.map(p => {
+    if (!p.faceDown) return p
+    if (p.userId === userId || mostRecent?.winner === userId) return p
+    return { ...p, card: { id: UNDER_CARD_ID, hidden: true, faceDown: true } }
+  })
 
   return view
 }


### PR DESCRIPTION
## Summary

The previous PR (#7) labeled a "must hold a fail card of called suit" check as the under card rule. That check is real but it isn't the under card rule — the actual *under card* is the face-down card the picker places when calling an ace of a suit they hold no fail card in. This PR implements the real rule and the related partner-call escalation hierarchy.

### Calling-phase escalation

- **Ace mode** (default): picker calls a fail ace they don't hold. If they also hold no fail card of that suit, they pick any card from hand to place face-down as the **under card** and call `A{suit} Unknown`. The under card has no trick-taking power; it must be played when the called suit is led (forced) and is revealed only to the trick winner.
- **Ten mode**: when picker holds all 3 fail aces, they call the 10 of a fail suit whose 10 they don't hold. Picker is forced to play the Ace of the called suit when that suit is led. Discard rejects burying any fail ace.
- **King mode**: when picker holds all 3 fail aces *and* all 3 fail tens, they call any fail King. Picker plays the Ace and 10 of the called suit (in either order) when the called suit is led. Discard rejects burying any fail ace or ten.

### Other fixes folded in

- Calls of any suit whose target card (A/10/K) sits in the picker's own discard pile are rejected — the partner would otherwise be nobody.
- The discard pile is now visible to the picker in the player view (they buried it). Still hidden from everyone else.
- The under card is rendered as a face-down clickable tile in the picker's seat-bottom hand and in the test mode panel.
- `beats()` and `resolveTrick()` now take a `ledSuit` argument so face-down leads (under card as lead) resolve correctly.

### Removed

- The previous auto-going-alone branch (triggered by holding all fail aces) is gone, since that scenario now routes to Ten/King mode. Going alone will be reintroduced later as a picker-initiated action.

## Test plan

- [ ] Normal call with fail-card-of-suit holding still works
- [ ] Picker buries an ace; calling that suit is no longer offered
- [ ] Situation B: picker holds no fail card of called suit → under card flow appears, picker selects a card, the under card is forced when the called suit is led
- [ ] Picker leads the under card → declares called suit; followers must follow
- [ ] Under card never led organically → played on trick 6
- [ ] Situation A (call a 10): picker holding all 3 fail aces is forced to play the called Ace when its suit is led
- [ ] King case: picker holding all 3 fail aces + tens may play the A and 10 of called suit in either order
- [ ] Discard validation rejects burying fail aces (Ten/King mode) or fail tens (King mode)
- [ ] Trick winner sees the under card's true identity in the resolved trick

🤖 Generated with [Claude Code](https://claude.com/claude-code)