### PR TITLE
Add go-alone option for picker

### DIFF
--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -11,7 +11,43 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
   const [selectedDiscards, setSelectedDiscards] = useState([])
   const [unknownSelectedSuit, setUnknownSelectedSuit] = useState(null)
   const [selectedUnderCard, setSelectedUnderCard] = useState(null)
+  const [confirmingAlone, setConfirmingAlone] = useState(false)
   const [error, setError] = useState(null)
+
+  const goAloneSection = (
+    <div style={{ marginTop: 12, paddingTop: 10, borderTop: '1px solid rgba(255,255,255,0.15)' }}>
+      {confirmingAlone ? (
+        <>
+          <p style={{ fontSize: '0.85rem', color: '#fbbf24', marginBottom: 6 }}>
+            Play this hand alone against all four opponents?
+          </p>
+          <div style={{ display: 'flex', gap: 8, justifyContent: 'center' }}>
+            <button
+              onClick={() => act('go_alone').then(() => setConfirmingAlone(false))}
+              disabled={loading}
+            >
+              Confirm Go Alone
+            </button>
+            <button
+              className="secondary"
+              onClick={() => setConfirmingAlone(false)}
+              disabled={loading}
+            >
+              Cancel
+            </button>
+          </div>
+        </>
+      ) : (
+        <button
+          className="secondary"
+          onClick={() => setConfirmingAlone(true)}
+          disabled={loading}
+        >
+          Go Alone
+        </button>
+      )}
+    </div>
+  )
 
   async function act(type, payload) {
     setError(null)
@@ -123,6 +159,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
               </button>
             ))}
           </div>
+          {goAloneSection}
           {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
         </div>
       )
@@ -152,6 +189,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
               </button>
             ))}
           </div>
+          {goAloneSection}
           {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
         </div>
       )
@@ -240,6 +278,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
         {normalSuits.length === 0 && unknownSuits.length === 0 && (
           <p style={{ color: '#f87171' }}>No valid suit to call. Contact the game admin.</p>
         )}
+        {goAloneSection}
         {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
       </div>
     )

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -473,6 +473,11 @@ export default function GamePage({ gameId, user, onNavigate }) {
             {partnerPlayer ? ` (${partnerPlayer.username})` : ''}
           </span>
         )}
+        {state.goingAlone && (
+          <span className="called-ace-badge" style={{ background: 'rgba(168,85,247,0.35)' }}>
+            Picker is going alone
+          </span>
+        )}
         {state.isLeaster && (
           <span className="called-ace-badge" style={{ background: 'rgba(245,158,11,0.3)' }}>
             🃏 Leaster

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -1,6 +1,6 @@
 import { json, err, requireUser, AuthError } from '../../_helpers.js'
 import {
-  pick, pass, discard, callAce, callAceUnknown, callTen, callKing, playCard,
+  pick, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
   setupLeaster, awardLeasterBlind, resolveLeaster,
   dealHand,
 } from '../../../../shared/gameEngine.js'
@@ -95,6 +95,10 @@ export async function onRequestPost({ request, env, params }) {
 
       case 'call_king':
         state = callKing(state, userId, payload?.suit)
+        break
+
+      case 'go_alone':
+        state = goAlone(state, userId)
         break
 
       case 'play_card': {

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -236,6 +236,26 @@ export function callAce(state, userId, suit) {
   return newState
 }
 
+// Picker chooses to go alone instead of calling a partner. Available in any call mode.
+// No partner is selected; picker plays solo against the other four.
+export function goAlone(state, userId) {
+  assertPhase(state, 'calling')
+  if (state.picker !== userId) throw new Error('Only the picker can go alone.')
+
+  const newState = deepClone(state)
+  newState.goingAlone = true
+  newState.partner = null
+  newState.calledAce = null
+  newState.calledTen = null
+  newState.calledKing = null
+  newState.calledSuit = null
+  newState.pickerForcedPlays = []
+  newState.phase = 'playing'
+  newState.currentLeader = userId
+  newState.log.push(`${userId} is going alone.`)
+  return newState
+}
+
 // Situation B: picker calls an ace of a suit in which they hold no fail card,
 // placing one card from their hand face-down on the table as the "under card."
 export function callAceUnknown(state, userId, suit, underCardId) {


### PR DESCRIPTION
## Summary
- Picker can now choose to go alone in the calling phase, in any call mode (ace/ten/king), instead of choosing a partner.
- Adds `goAlone` engine action, `go_alone` API action type, a confirm-style "Go Alone" button in the calling UI, and a "Picker is going alone" badge in the info bar.
- Scoring already supported the `goingAlone` path; no changes needed there.

## Test plan
- [ ] Pick the blind, discard, then choose Go Alone — confirm phase moves directly to playing with picker leading.
- [ ] Verify across all three call modes (ace, ten, king) that the Go Alone button is visible.
- [ ] Play a full hand alone and confirm scoring pays 2× per opponent (or -2× per opponent on a loss).
- [ ] Confirm the info bar shows the "Picker is going alone" badge during play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)