### PR TITLE
Document partner call rules and under card in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,3 +49,60 @@ npm run deploy
 ## Branching Rules
 
 Direct pushes to `main` are blocked by a pre-push hook (`.githooks/pre-push`). Always work on a feature branch and open a PR. After merging, local branches tracking deleted remotes are auto-deleted by the post-merge hook.
+
+## Partner Call Rules (Call an Ace + Under Card)
+
+After the picker discards, the engine picks one of three **call modes** based on
+their 8-card hand (`shared/gameEngine.js` `discard()`). The picker must then call
+a partner card according to that mode (or invoke `goAlone` instead):
+
+- **`callMode: 'ace'`** (default) — picker calls a fail ace they neither hold nor
+  buried. Two sub-paths per suit:
+  - *Normal call* (`callAce`) — picker holds at least one fail card of the called
+    suit. Standard partner reveal: when the called suit is led, the partner must
+    play the called ace.
+  - *Ace Unknown* (`callAceUnknown`) — picker holds **no** fail card of the
+    called suit. They pick any card from hand to place face-down as the **under
+    card**. The under card lives in `state.underCard` (off-hand). It has no
+    trick-taking power. The picker is **forced** to play it whenever the called
+    suit is led (by anyone, including themselves leading via the under card,
+    which declares the called suit as the led suit). It's revealed only to the
+    trick winner. Math: picker has 5 hand cards + 1 under card = 6 plays, so
+    the under card is naturally played by trick 6 at the latest.
+
+- **`callMode: 'ten'`** (`callTen`) — picker holds all 3 fail aces. Calls the
+  10 of a fail suit whose 10 they don't hold and didn't bury. Picker is forced
+  to play the Ace of the called suit when the called suit is led
+  (`pickerForcedPlays = ['A{suit}']`). `discard()` rejects burying any fail ace.
+
+- **`callMode: 'king'`** (`callKing`) — picker holds all 3 fail aces *and* all
+  3 fail tens. By card-count math (6 cards in hand post-discard = exactly 3
+  aces + 3 tens) the picker holds zero fail kings, so any fail king is callable.
+  Picker is forced to play A and 10 of the called suit (in either order) when
+  the called suit is led (`pickerForcedPlays = ['A{suit}','10{suit}']`).
+  `discard()` rejects burying any fail ace or ten.
+
+- **Going alone** (`goAlone`) — picker-initiated alternative to calling a
+  partner, available in any call mode. Sets `state.goingAlone = true`, clears
+  all called-card fields, and the picker plays solo against the other four.
+
+**Why "Unknown" exists**: without the under card mechanic, a picker who held no
+fail card of any callable suit could never lead the called suit, so the
+partnership could never be revealed organically. The under card gives the
+picker a face-down "card of the called suit" they can play (or lead with) to
+keep that mechanic intact.
+
+**Key invariants** (do not break when refactoring):
+- Calls of any suit whose target card (A/10/K) is in `state.discard` must be
+  rejected — the "partner" would be nobody.
+- The picker can see `state.discard` (they buried it); other players cannot.
+- The under card is hidden from everyone except the picker (who placed it) and
+  the trick winner of the trick where it's played. Hidden plays in tricks have
+  `faceDown: true`.
+- `resolveTrick()` and `beats()` take a `ledSuit` argument and skip face-down
+  plays when determining the winner. Face-down cards still contribute their
+  point value to the trick winner's pile.
+- When the under card is the lead, the trick entry has `declaredSuit` set to
+  the called suit; `getLedSuit()` honors this over the (hidden) card's real suit.
+- `state.calledSuit` is the unifying field across ace/ten/king calls — prefer
+  it over `state.calledAce?.suit` when checking "is the called suit being led."


### PR DESCRIPTION
## Summary

Adds a reference section to `CLAUDE.md` covering the partner-call rules so future Claude Code sessions can ramp on the engine without re-deriving them from source.

Covered:
- The three call modes (`ace` / `ten` / `king`) and how `discard()` selects between them.
- The under card mechanic (Situation B / Ace Unknown), why it exists, and the card-count math that ensures it gets played.
- The `goAlone` alternative.
- Invariants that must hold when refactoring `shared/gameEngine.js`: discard visibility, `ledSuit` threading through `beats()`/`resolveTrick()`, face-down play handling, and `state.calledSuit` as the unifying field.

## Test plan

- [ ] N/A — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)