### PR TITLE
Fix post-merge hook so gone branches actually get cleaned up

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -2,4 +2,5 @@
 
 # Auto-delete local branches whose remote tracking branch is gone
 git fetch --prune
-git branch -vv | grep ': gone]' | awk '{print $1}' | xargs -r git branch -d
+gone=$(git branch -vv | awk '/: gone\]/ {print $1}')
+[ -n "$gone" ] && echo "$gone" | xargs git branch -d

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build": "npm run build -w frontend",
     "deploy": "npm run build && wrangler pages deploy frontend/dist",
     "db:migrate:local": "wrangler d1 migrations apply sheepshead-db --local",
-    "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote"
+    "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote",
+    "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",


### PR DESCRIPTION
## Summary
- The `.githooks/post-merge` hook was never running because `core.hooksPath` is not set in fresh clones — git was looking in `.git/hooks/` instead.
- Even when run, the hook used `xargs -r`, which BSD `xargs` on macOS doesn't support; with no "gone" branches it would invoke `git branch -d` with no arguments and error.
- Added an `npm postinstall` step that runs `git config core.hooksPath .githooks` so the hook is wired up automatically after `npm install`.
- Rewrote the hook to capture the gone-branch list first and only invoke `xargs` when non-empty.

## Test plan
- [ ] `npm install` and confirm `git config --get core.hooksPath` returns `.githooks`
- [ ] On a branch whose upstream has been deleted, run `git pull` on `main` and confirm the local branch is auto-deleted
- [ ] With no gone branches, confirm `git pull` on `main` exits cleanly with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)