### PR TITLE
Only allow Ace Unknown when no normal ace call is available

### DIFF
--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -255,10 +255,11 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
             </button>
           ))}
         </div>
-        {unknownSuits.length > 0 && (
+        {/* Under card calls are only allowed when there is no normal call available. */}
+        {normalSuits.length === 0 && unknownSuits.length > 0 && (
           <>
             <p style={{ fontSize: '0.8rem', color: '#ccc', marginTop: 8 }}>
-              These suits require placing an under card (you hold no fail card of the suit):
+              You hold no fail card of any callable suit. Place an under card and call Unknown:
             </p>
             <div className="suit-picker">
               {unknownSuits.map(suit => (

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -277,6 +277,19 @@ export function callAceUnknown(state, userId, suit, underCardId) {
     throw new Error(`Cannot call A${suit} unknown — picker holds fail card(s) of that suit. Use call_ace.`)
   }
 
+  // Under card calls are only legal when the picker has no normal call available.
+  // A normal call exists for any suit whose ace the picker neither holds nor buried,
+  // and in which the picker holds at least one fail card.
+  const hasNormalCall = ['C', 'H', 'S'].some(s => {
+    const a = `A${s}`
+    if (state.hands[userId].some(c => c.id === a)) return false
+    if (state.discard.some(c => c.id === a)) return false
+    return state.hands[userId].some(c => c.suit === s && !isTrump(c))
+  })
+  if (hasNormalCall) {
+    throw new Error('Cannot call an unknown ace when a normal ace call is available.')
+  }
+
   const cardIdx = state.hands[userId].findIndex(c => c.id === underCardId)
   if (cardIdx === -1) throw new Error(`Under card ${underCardId} not in hand.`)
 


### PR DESCRIPTION
## Summary

The under card (Ace Unknown) flow is the picker's escape hatch when they hold no fail card of any callable suit. It should not be offered as an alternative when a normal ace call exists. Previously the calling UI rendered both the normal-call buttons and the under-card buttons side by side, letting the picker opt into the under card flow even when they had a regular call available.

- `ActionPanel.jsx` — only renders the under-card suit picker when `normalSuits` is empty.
- `shared/gameEngine.js` — `callAceUnknown` now rejects the call if any suit has a normal call available (picker holds a fail card of a suit whose ace they neither hold nor buried), so the rule is enforced server-side too.

## Test plan

- [ ] Picker holds a fail card of at least one callable suit → only normal-call buttons shown, no under-card section
- [ ] Picker holds no fail card of any callable suit → only under-card buttons shown
- [ ] Manually invoke `call_ace_unknown` via the API when a normal call exists → server rejects with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)