### PR TITLE
Trick area layout, last-trick auto-play, in-seat test mode

### DIFF
--- a/frontend/src/components/TrickArea.jsx
+++ b/frontend/src/components/TrickArea.jsx
@@ -1,22 +1,48 @@
 import Card from './Card.jsx'
 
-export default function TrickArea({ trick = [], lastTrick = [], players = [], blind = [] }) {
-  const getUsername = (userId) => {
-    const p = players.find(p => String(p.user_id) === String(userId))
-    return p?.username ?? userId
+// Map a played-card entry to one of the 5 seat slots based on `seats`
+// (the relative-seat layout passed in from GamePage).
+function slotForUserId(seats, userId) {
+  const u = String(userId)
+  for (const slot of ['bottom', 'left', 'topLeft', 'topRight', 'right']) {
+    if (seats?.[slot] && String(seats[slot].user_id) === u) return slot
+  }
+  return null
+}
+
+// 3x3 sub-grid that places cards in front of their seat positions:
+//   [topLeft]  .       [topRight]
+//   [left]     .       [right]
+//   .          [bottom] .
+function TrickGrid({ entries = [], seats = {}, mini = false }) {
+  const slots = { topLeft: null, topRight: null, left: null, right: null, bottom: null }
+  for (const entry of entries) {
+    const slot = slotForUserId(seats, entry.userId)
+    if (slot) slots[slot] = entry
   }
 
-  const trickCards = (entries, dim = false) => (
-    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, justifyContent: 'center', opacity: dim ? 0.45 : 1 }}>
-      {entries.map(({ userId, card }) => (
-        <div key={userId} style={{ textAlign: 'center' }}>
-          <div style={{ color: '#ccc', fontSize: '0.7rem', marginBottom: 2 }}>{getUsername(userId)}</div>
-          <Card card={card} />
-        </div>
-      ))}
+  const cell = (slot) => {
+    const entry = slots[slot]
+    return (
+      <div className={`trick-slot trick-slot-${slot}`}>
+        {entry && <Card card={entry.card} />}
+      </div>
+    )
+  }
+
+  return (
+    <div className={`trick-grid${mini ? ' trick-grid-mini' : ''}`}>
+      {cell('topLeft')}
+      <div className="trick-slot trick-slot-spacer" />
+      {cell('topRight')}
+      {cell('left')}
+      {cell('bottom')}
+      {cell('right')}
     </div>
   )
+}
 
+export default function TrickArea({ trick = [], seats = {}, blind = [] }) {
   return (
     <div className="trick-area">
       {blind.length > 0 && (
@@ -28,22 +54,23 @@ export default function TrickArea({ trick = [], lastTrick = [], players = [], bl
         </div>
       )}
 
-      {trick.length === 0 && lastTrick.length === 0 && blind.length === 0 && (
+      {trick.length === 0 && blind.length === 0 && (
         <span style={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.85rem' }}>
           Waiting for first play…
         </span>
       )}
 
-      {trick.length > 0 && trickCards(trick)}
+      {trick.length > 0 && <TrickGrid entries={trick} seats={seats} />}
+    </div>
+  )
+}
 
-      {lastTrick.length > 0 && (
-        <div style={{ width: '100%', marginTop: trick.length > 0 ? 12 : 0 }}>
-          <div style={{ color: 'rgba(255,255,255,0.4)', fontSize: '0.7rem', textAlign: 'center', marginBottom: 4 }}>
-            Last trick
-          </div>
-          {trickCards(lastTrick, true)}
-        </div>
-      )}
+export function LastTrickArea({ lastTrick = [], seats = {} }) {
+  if (!lastTrick || lastTrick.length === 0) return null
+  return (
+    <div className="last-trick-area">
+      <div className="last-trick-label">Last trick</div>
+      <TrickGrid entries={lastTrick} seats={seats} mini />
     </div>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -2,6 +2,9 @@
   --card-width: 90px;
   --card-height: 126px;
   --card-radius: 6px;
+  /* Width of the left/right seat columns in the .game-table grid.
+     Fits a full 8-card overlapping mini-card-stack (~384px) plus padding. */
+  --side-col-width: 400px;
 }
 
 body {
@@ -102,7 +105,6 @@ body {
 .mini-card-playable {
   cursor: pointer;
   transition: transform 0.1s;
-  outline: 2px solid var(--pico-primary);
 }
 
 .mini-card-playable:hover {
@@ -124,13 +126,18 @@ body {
   grid-template-areas:
     "top-left  center    top-right"
     "left      center    right"
-    ".         info-bar  ."
-    ".         bottom    ."
+    ".         info-bar  last-trick"
+    ".         bottom    last-trick"
     ".         action    ."
-    "log       log       scores"
-    "admin     admin     admin";
-  grid-template-columns: auto calc(6 * var(--card-width) + 5px + 16px) auto;
-  grid-template-rows: auto auto auto auto auto auto auto;
+    "log       log       scores";
+  /* Side columns are a fixed width so left and right seats stay symmetric
+     regardless of hand size or whether the last-trick widget is showing.
+     Width is sized to comfortably hold a full 8-card mini-card-stack. */
+  grid-template-columns:
+    var(--side-col-width)
+    calc(6 * var(--card-width) + 5px + 16px)
+    var(--side-col-width);
+  grid-template-rows: auto auto auto auto auto auto;
   gap: 12px;
   padding: 16px;
   margin: 0 auto;
@@ -138,17 +145,17 @@ body {
   box-sizing: border-box;
 }
 
-.seat-top-left  { grid-area: top-left; }
-.seat-top-right { grid-area: top-right; }
-.seat-left      { grid-area: left; }
-.seat-right     { grid-area: right; }
+.seat-top-left  { grid-area: top-left;  justify-self: center; }
+.seat-top-right { grid-area: top-right; justify-self: center; }
+.seat-left      { grid-area: left;      justify-self: center; }
+.seat-right     { grid-area: right;     justify-self: center; }
 .seat-bottom    { grid-area: bottom; }
 .trick-area     { grid-area: center; }
 .info-bar       { grid-area: info-bar; }
 .action-panel   { grid-area: action; }
 .game-log       { grid-area: log; }
 .score-board    { grid-area: scores; }
-.admin-panel-area { grid-area: admin; }
+.last-trick-area  { grid-area: last-trick; }
 
 /* ── Player seat ─────────────────────────────────────────── */
 .player-seat {
@@ -158,6 +165,9 @@ body {
   text-align: center;
   color: #fff;
   min-width: 80px;
+  /* Reserve space for the mini-card stack so the seat doesn't collapse
+     vertically when a player runs out of cards mid-hand. */
+  min-height: calc(var(--card-height) + 48px);
 }
 
 /* Wide enough for 6 non-overlapping cards + gaps + padding */
@@ -217,6 +227,68 @@ body {
   justify-content: center;
   align-items: center;
   min-height: 160px;
+}
+
+/* 3x3 sub-grid that places each played card in front of its seat. */
+.trick-grid {
+  display: grid;
+  grid-template-columns: repeat(3, var(--card-width));
+  grid-template-rows: repeat(2, var(--card-height));
+  gap: 6px;
+  justify-items: center;
+  align-items: center;
+}
+
+.trick-grid-mini {
+  --card-width: 70px;
+  --card-height: 98px;
+  gap: 4px;
+}
+
+.trick-slot {
+  width: var(--card-width);
+  height: var(--card-height);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Nudge each played card toward the seat of the player who played it.
+   Y offsets line each card up vertically with the center of the corresponding
+   seat box (top seats in row 1, side seats in row 2, bottom seat below). */
+.trick-slot-topLeft  { transform: translate(-90px, -36px); }
+.trick-slot-topRight { transform: translate( 90px, -36px); }
+.trick-slot-left     { transform: translate(-90px,  36px); }
+.trick-slot-right    { transform: translate( 90px,  36px); }
+.trick-slot-bottom   { transform: translate(   0,   60px); }
+
+/* Mini last-trick keeps cards in the plain 3x2 grid (no nudging). */
+.trick-grid-mini .trick-slot-topLeft,
+.trick-grid-mini .trick-slot-topRight,
+.trick-grid-mini .trick-slot-left,
+.trick-grid-mini .trick-slot-right,
+.trick-grid-mini .trick-slot-bottom { transform: none; }
+
+/* Last trick — sits below right seat / right of bottom seat.
+   Stretches to fill the right column so it lines up with the right seats. */
+.last-trick-area {
+  background: rgba(0,0,0,0.25);
+  border-radius: 8px;
+  padding: 8px;
+  opacity: 0.7;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  align-self: stretch;
+  justify-self: stretch;
+  box-sizing: border-box;
+}
+
+.last-trick-label {
+  color: rgba(255,255,255,0.55);
+  font-size: 0.7rem;
+  margin-bottom: 4px;
 }
 
 /* ── Action panel ────────────────────────────────────────── */

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -2,11 +2,10 @@ import { useState, useEffect, useCallback, useRef } from 'react'
 import { effectiveSuit } from '@shared/gameEngine.js'
 import { api } from '../lib/api.js'
 import PlayerSeat from '../components/PlayerSeat.jsx'
-import TrickArea from '../components/TrickArea.jsx'
+import TrickArea, { LastTrickArea } from '../components/TrickArea.jsx'
 import ActionPanel from '../components/ActionPanel.jsx'
 import GameLog from '../components/GameLog.jsx'
 import ScoreBoard from '../components/ScoreBoard.jsx'
-import Hand from '../components/Hand.jsx'
 
 const SUIT_SYMBOLS   = { C: '♣', D: '♦', H: '♥', S: '♠' }
 const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers' }
@@ -121,62 +120,6 @@ function AdminSettingsPanel({ gameId, currentVariant, revealPartner, onUpdated }
   )
 }
 
-// ── Test mode panel — shows ALL players' hands ────────────────────────────────
-function TestModePanel({ state, players, currentTurnUserId, myUserId, onAction, loading }) {
-  if (!state) return null
-
-  return (
-    <div style={{
-      background: 'rgba(124,58,237,0.15)',
-      border: '1px solid rgba(124,58,237,0.4)',
-      borderRadius: 8,
-      padding: 12,
-      color: '#fff',
-    }}>
-      <div style={{ fontWeight: 700, marginBottom: 8, fontSize: '0.85rem', color: '#c4b5fd' }}>
-        🧪 Test Mode — all hands visible
-      </div>
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16 }}>
-        {players.map(p => {
-          const uid          = String(p.user_id)
-          const hand         = state.hands?.[uid] ?? []
-          const isTurn       = uid === currentTurnUserId
-          const isMe         = uid === myUserId
-          let visibleCards = hand.filter(c => !c.hidden)
-          // Append the under card as a clickable face-down tile if this player is the
-          // picker and there's an unplayed under card.
-          if (uid === state.picker && state.underCard && !state.underCard.played) {
-            visibleCards = [
-              ...visibleCards,
-              { id: 'UNDER_CARD', hidden: true, isUnderCard: true, faceDown: true },
-            ]
-          }
-
-          if (isMe || visibleCards.length === 0) return null
-
-          return (
-            <div key={uid} style={{
-              background: isTurn ? 'rgba(124,58,237,0.3)' : 'rgba(0,0,0,0.2)',
-              borderRadius: 6,
-              padding: 8,
-              outline: isTurn ? '2px solid #a78bfa' : 'none',
-            }}>
-              <div style={{ fontSize: '0.75rem', marginBottom: 4, color: isTurn ? '#c4b5fd' : '#aaa' }}>
-                {p.username}{isTurn && ' ← turn'}{p.is_bot && <span style={{ color: '#6b7280' }}> (bot)</span>}
-              </div>
-              <Hand
-                cards={visibleCards}
-                playableIds={isTurn && state.phase === 'playing' ? visibleCards.map(c => c.id) : []}
-                onCardClick={isTurn ? (card) => onAction('play_card', { cardId: card.id }, uid) : undefined}
-              />
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
 // ── Current turn helper ───────────────────────────────────────────────────────
 function currentTurnPlayer(state) {
   if (!state) return null
@@ -249,6 +192,10 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const [currentVariant, setCurrentVariant] = useState(null)
   const [revealPartner, setRevealPartner]   = useState(null)
   const pollingRef = useRef(null)
+  // Tracks the auto-play timer for the last trick. We key by
+  // `${turnUserId}:${trickLen}` so each "pending play" only schedules once,
+  // even though state polling produces a new state object every 2s.
+  const autoPlayRef = useRef({ key: null, timer: null })
 
   const myUserId = String(user.id)
 
@@ -270,6 +217,61 @@ export default function GamePage({ gameId, user, onNavigate }) {
     pollingRef.current = setInterval(fetchGame, 2000)
     return () => clearInterval(pollingRef.current)
   }, [fetchGame])
+
+  // ── Auto-play the last trick ────────────────────────────────────────────────
+  // Once we're down to the final trick (every player has exactly 1 card left),
+  // there are no more decisions to make, so the client auto-dispatches each
+  // play with a 1s pause for a smoother end-of-hand cadence. In test mode the
+  // admin acts on behalf of any player whose turn it is.
+  useEffect(() => {
+    const state    = gameData?.state
+    const isTestMode = gameData?.is_test_mode
+    if (!state || state.phase !== 'playing') return
+
+    const turnUserId = currentTurnPlayer(state)
+    if (!turnUserId) return
+
+    // The "effective" user — me, or in test mode the player whose turn it is.
+    const isActingForBot = isTestMode && user.is_admin && String(turnUserId) !== myUserId
+    const effectiveUserId = isActingForBot ? String(turnUserId) : myUserId
+    if (String(turnUserId) !== effectiveUserId) return
+
+    // Are we in the last trick? Total cards remaining (across all hands +
+    // any unplayed under card + the current trick) should equal pickOrder.length.
+    const handsSum = Object.values(state.hands ?? {}).reduce((s, h) => s + (h?.length ?? 0), 0)
+    const underCount = state.underCard && !state.underCard.played ? 1 : 0
+    const totalRemaining = handsSum + underCount + (state.currentTrick?.length ?? 0)
+    if (totalRemaining !== (state.pickOrder?.length ?? 5)) return
+
+    // Compute the legal play (there should be exactly one in the last trick).
+    let hand = state.hands?.[effectiveUserId] ?? []
+    if (effectiveUserId === state.picker && state.underCard && !state.underCard.played) {
+      hand = [...hand, { id: 'UNDER_CARD', hidden: true, isUnderCard: true, faceDown: true }]
+    }
+    const ids = getLegalCardIds(state, effectiveUserId, hand)
+    if (ids.length === 0) return
+    const cardId = ids[0]
+
+    // Schedule the play — but only once per (turn, trick-progress) pair so
+    // repeated polling of an unchanged state doesn't keep resetting the timer.
+    const key = `${turnUserId}:${state.currentTrick?.length ?? 0}`
+    if (autoPlayRef.current.key === key) return
+    if (autoPlayRef.current.timer) clearTimeout(autoPlayRef.current.timer)
+    autoPlayRef.current.key = key
+    autoPlayRef.current.timer = setTimeout(() => {
+      autoPlayRef.current.timer = null
+      handleAction('play_card', { cardId }, isActingForBot ? turnUserId : null)
+    }, 1000)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [gameData, myUserId, user.is_admin])
+
+  // Cancel any pending auto-play timer on unmount.
+  useEffect(() => () => {
+    if (autoPlayRef.current.timer) {
+      clearTimeout(autoPlayRef.current.timer)
+      autoPlayRef.current.timer = null
+    }
+  }, [])
 
   async function handleAction(type, payload, actAs = null) {
     setActionLoading(true)
@@ -418,6 +420,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
         { id: 'UNDER_CARD', hidden: true, isUnderCard: true, faceDown: true },
       ]
     }
+    // In test mode, the global admin can play directly out of any seat's hand
+    // when it's that player's turn. (For the bottom seat — i.e. yourself —
+    // playability is wired up below in the JSX as before.)
+    const seatIsActingTarget =
+      isTestMode && user.is_admin
+      && state.phase === 'playing'
+      && uid === turnUserId
+      && uid !== myUserId
+    const seatLegalIds = seatIsActingTarget
+      ? getLegalCardIds(state, uid, hand)
+      : undefined
+
     return {
       isDealer:      uid === dealerUserId,
       isPicker:      uid === pickerUserId,
@@ -429,6 +443,14 @@ export default function GamePage({ gameId, user, onNavigate }) {
       lifetimeScore: player.lifetime_score ?? 0,
       hand,
       showFaceUp:    isTestMode && user.is_admin,
+      playableIds:   seatLegalIds,
+      onCardClick:   seatIsActingTarget
+        ? (card) => {
+            if (seatLegalIds.includes(card.id)) {
+              handleAction('play_card', { cardId: card.id }, uid)
+            }
+          }
+        : undefined,
     }
   }
 
@@ -460,10 +482,12 @@ export default function GamePage({ gameId, user, onNavigate }) {
       {/* ── Center trick ── */}
       <TrickArea
         trick={currentTrick}
-        lastTrick={lastTrick}
-        players={players}
+        seats={seats}
         blind={state.phase === 'picking' ? (state.blind ?? []) : []}
       />
+
+      {/* ── Last trick (mini, mirrors seat positions) ── */}
+      <LastTrickArea lastTrick={lastTrick} seats={seats} />
 
       {/* ── Info bar: called ace + partner reveal ── */}
       <div className="info-bar">
@@ -529,20 +553,6 @@ export default function GamePage({ gameId, user, onNavigate }) {
             currentVariant={currentVariant ?? noPickVariant}
             revealPartner={revealPartner ?? gameData.reveal_partner ?? true}
             onUpdated={handleSettingsUpdate}
-          />
-        </div>
-      )}
-
-      {/* ── Test mode panel (global admin only) ── */}
-      {isTestMode && user.is_admin && (
-        <div className="admin-panel-area">
-          <TestModePanel
-            state={state}
-            players={players}
-            currentTurnUserId={turnUserId}
-            myUserId={myUserId}
-            onAction={handleAction}
-            loading={actionLoading}
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- Lay out played cards inside the trick area in front of the player who played them; the bottom (you) card sits in the center. Each card is nudged toward its seat for a "thrown into the middle" feel.
- Add a mini "Last trick" panel below the right seat / right of the bottom seat that mirrors the same seat-positioned layout.
- Make the table horizontally symmetric: side columns are a fixed width (`--side-col-width`), seats are centered in their columns, and the right column no longer drifts wider because of the last-trick widget.
- Reserve vertical space in `.player-seat` so a seat doesn't collapse when a player runs out of cards mid-hand.
- Test mode: play cards directly out of the seat hands (the seat that's the active turn becomes clickable). Removed the now-redundant `TestModePanel`.
- Removed the blue outline on playable mini cards; the hover lift is preserved.
- Auto-play the final trick: once total cards remaining = `pickOrder.length`, the client schedules the (only legal) play with a 1s delay. Uses a ref keyed by `${turnUserId}:${trickLen}` so polling refreshes don't reset or duplicate the timer.

## Test plan
- [ ] Play through a hand and verify each played card appears in front of the correct seat, with your card centered.
- [ ] Verify the "Last trick" mini panel appears after the first trick and uses the same seat positions.
- [ ] Confirm left and right seats are visually symmetric throughout a hand (including late game when hands shrink).
- [ ] Empty out a player mid-hand and check the seat does not collapse vertically.
- [ ] In test mode, click cards directly from a non-bottom seat's hand on that player's turn and confirm the play works.
- [ ] Confirm there is no blue outline on playable cards but hover still bumps them.
- [ ] Reach the last trick of a hand and verify each play happens automatically about 1 second apart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)