### PR TITLE
Only end active game on leave when in test mode

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -289,7 +289,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
   }
 
   async function handleLeave() {
-    if (!window.confirm('Leave this game? If the game is active, it will end for everyone.')) return
+    if (!window.confirm('Leave this game?')) return
     setLeaving(true)
     try {
       await api.games.leave(gameId)

--- a/functions/api/games/[id]/leave.js
+++ b/functions/api/games/[id]/leave.js
@@ -33,8 +33,8 @@ export async function onRequestPost({ request, env, params }) {
       return json({ left: true, ended: true })
     }
 
-    if (game.status === 'active') {
-      // Can't continue with fewer than 5 — end the game
+    if (game.status === 'active' && game.is_test_mode) {
+      // Test mode: end the game immediately when anyone leaves
       await env.DB.prepare(
         "UPDATE games SET status = 'complete', updated_at = datetime('now') WHERE id = ?"
       ).bind(gameId).run()


### PR DESCRIPTION
## Summary
- Active games no longer end automatically when a player leaves outside test mode; the player is just removed and the game continues for the rest.
- Test mode keeps the existing behavior (leave ends the game immediately).
- Confirm dialog text simplified to `Leave this game?` — no longer alludes to ending the game for everyone.

## Notes / follow-ups
- The active game now keeps running with one fewer player. Downstream turn/picker/partner logic is not yet adapted to a missing seat — flagged for a follow-up if mid-hand leaves cause issues.

## Test plan
- [ ] In a non-test active game, have a non-picker leave; confirm the game stays active for the others.
- [ ] In a test-mode active game, have a player leave; confirm the game ends.
- [ ] Leave from a waiting (non-active) game; confirm player removed, game still waiting.
- [ ] Last player leaving still ends the game.
- [ ] Confirm dialog shows the new text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)