### PR TITLE
Fix dealer label and first-trick leader to be left of dealer

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -397,7 +397,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
     ]
   }
 
-  const dealerUserId  = state.pickOrder ? state.pickOrder[state.dealerSeat] : null
+  const dealerUserId  = state.pickOrder ? state.pickOrder[4] : null
   const pickerUserId  = state.picker
   const partnerUserId = state.partnerRevealed ? state.partner : null
 

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -231,7 +231,7 @@ export function callAce(state, userId, suit) {
   newState.calledSuit = suit
   newState.partner = findHolder(newState.hands, aceId, userId)
   newState.phase = 'playing'
-  newState.currentLeader = userId
+  newState.currentLeader = newState.pickOrder[0]
   newState.log.push(`${userId} called the A${suit}.`)
   return newState
 }
@@ -251,7 +251,7 @@ export function goAlone(state, userId) {
   newState.calledSuit = null
   newState.pickerForcedPlays = []
   newState.phase = 'playing'
-  newState.currentLeader = userId
+  newState.currentLeader = newState.pickOrder[0]
   newState.log.push(`${userId} is going alone.`)
   return newState
 }
@@ -300,7 +300,7 @@ export function callAceUnknown(state, userId, suit, underCardId) {
   newState.calledSuit = suit
   newState.partner = findHolder(newState.hands, aceId, userId)
   newState.phase = 'playing'
-  newState.currentLeader = userId
+  newState.currentLeader = newState.pickOrder[0]
   newState.log.push(`${userId} called A${suit} Unknown and placed an under card.`)
   return newState
 }
@@ -328,7 +328,7 @@ export function callTen(state, userId, suit) {
   newState.pickerForcedPlays = [`A${suit}`]
   newState.partner = findHolder(newState.hands, tenId, userId)
   newState.phase = 'playing'
-  newState.currentLeader = userId
+  newState.currentLeader = newState.pickOrder[0]
   newState.log.push(`${userId} called the ${tenId}.`)
   return newState
 }
@@ -356,7 +356,7 @@ export function callKing(state, userId, suit) {
   newState.pickerForcedPlays = [`A${suit}`, `10${suit}`]
   newState.partner = findHolder(newState.hands, kingId, userId)
   newState.phase = 'playing'
-  newState.currentLeader = userId
+  newState.currentLeader = newState.pickOrder[0]
   newState.log.push(`${userId} called the ${kingId}.`)
   return newState
 }


### PR DESCRIPTION
## Summary

- **Dealer badge** was computed as `pickOrder[dealerSeat]`, but `pickOrder` is indexed by pick sequence (not seat index), so it identified the wrong player as dealer. The dealer is always last in `pickOrder` (index 4).
- **First-trick leader** was set to the picker in all five calling functions (`callAce`, `goAlone`, `callAceUnknown`, `callTen`, `callKing`). Standard Sheepshead rules give the opening lead to the player left of the dealer (`pickOrder[0]`), regardless of who picked.

## Test plan

- [ ] Verify the correct player is badged as "Dealer" each hand
- [ ] Verify the player to the left of the dealer leads trick 1 (not the picker)
- [ ] Verify pick order is unaffected (left-of-dealer still picks first, dealer picks last)
- [ ] Verify leasters first-leader is unchanged (`pickOrder[(dealerSeat + 1) % 5]` was already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)