### PR TITLE
Add 1-second delay before clearing completed trick cards

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -196,6 +196,11 @@ export default function GamePage({ gameId, user, onNavigate }) {
   // `${turnUserId}:${trickLen}` so each "pending play" only schedules once,
   // even though state polling produces a new state object every 2s.
   const autoPlayRef = useRef({ key: null, timer: null })
+  // Displayed trick — trails the server state by 1 s after each trick completes
+  // so the completed trick stays visible before clearing.
+  const [displayedTrick, setDisplayedTrick] = useState([])
+  const trickClearTimerRef = useRef(null)
+  const lastProcessedTrickCountRef = useRef(null)
 
   const myUserId = String(user.id)
 
@@ -270,6 +275,50 @@ export default function GamePage({ gameId, user, onNavigate }) {
     if (autoPlayRef.current.timer) {
       clearTimeout(autoPlayRef.current.timer)
       autoPlayRef.current.timer = null
+    }
+  }, [])
+
+  // ── Trick clear delay ───────────────────────────────────────────────────────
+  // When a trick completes the server returns currentTrick: []. Keep the cards
+  // visible for 1 s before clearing, so players can see who played what.
+  useEffect(() => {
+    const trick      = gameData?.state?.currentTrick ?? []
+    const trickCount = gameData?.state?.tricks?.length ?? 0
+
+    if (trick.length > 0) {
+      // Cards are being played — update immediately and cancel any pending clear.
+      if (trickClearTimerRef.current) {
+        clearTimeout(trickClearTimerRef.current)
+        trickClearTimerRef.current = null
+      }
+      setDisplayedTrick(trick)
+    } else if (trickCount !== lastProcessedTrickCountRef.current) {
+      // A new trick just completed — guard by trickCount so repeated polls of
+      // the same state don't re-trigger.
+      lastProcessedTrickCountRef.current = trickCount
+      if (trickClearTimerRef.current) clearTimeout(trickClearTimerRef.current)
+
+      // Skip the delay on the last trick of the hand (phase has already moved on).
+      if (gameData?.state?.phase !== 'playing') {
+        setDisplayedTrick([])
+        return
+      }
+
+      // Show all 5 cards for 1 s then clear.
+      const lastTrick = gameData?.state?.lastTrick ?? []
+      if (lastTrick.length > 0) setDisplayedTrick(lastTrick)
+      trickClearTimerRef.current = setTimeout(() => {
+        trickClearTimerRef.current = null
+        setDisplayedTrick([])
+      }, 1000)
+    }
+  }, [gameData])
+
+  // Cancel pending trick clear on unmount.
+  useEffect(() => () => {
+    if (trickClearTimerRef.current) {
+      clearTimeout(trickClearTimerRef.current)
+      trickClearTimerRef.current = null
     }
   }, [])
 
@@ -481,7 +530,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
       {/* ── Center trick ── */}
       <TrickArea
-        trick={currentTrick}
+        trick={displayedTrick}
         seats={seats}
         blind={state.phase === 'picking' ? (state.blind ?? []) : []}
       />


### PR DESCRIPTION
## Summary
- Keeps all 5 played cards visible in the center trick area for 1 s after each trick completes so players can see the result before the area clears
- Shows the full completed trick (from `lastTrick`) during the delay, so the 5th card isn't missing
- Skips the delay on the final trick of a hand (phase has already advanced past `'playing'`)
- Guards against re-triggering on repeated polls of the same state by keying on `tricks.length`

Closes #17

## Test plan
- [ ] Play a full hand and confirm each completed trick lingers for ~1 second before clearing
- [ ] Confirm all 5 cards are visible during the delay (not just 4)
- [ ] Confirm the last trick of a hand clears immediately without delay
- [ ] Confirm no blinking/flicker while waiting for the next trick to be led

🤖 Generated with [Claude Code](https://claude.com/claude-code)