### PR TITLE
UX improvements + going-alone scoring fix

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -266,7 +266,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
     autoPlayRef.current.timer = setTimeout(() => {
       autoPlayRef.current.timer = null
       handleAction('play_card', { cardId }, isActingForBot ? turnUserId : null)
-    }, 1000)
+    }, 500)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameData, myUserId, user.is_admin])
 

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -167,6 +167,9 @@ async function finishHand(DB, gameId, state) {
     `--- Hand ${state.handNumber} complete ---`,
   ]
 
+  // Carry last trick forward so players can see it at the start of the new hand
+  nextState.lastTrick = state.lastTrick
+
   await DB.prepare(
     "UPDATE games SET doubler_multiplier = 1, updated_at = datetime('now') WHERE id = ?"
   ).bind(gameId).run()

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -611,8 +611,8 @@ function computeScores(state) {
 
   if (pickerWon) {
     if (goingAlone) {
-      for (const opp of opponents) scores[opp] = -2 * multiplier
-      scores[picker] = opponents.length * 2 * multiplier
+      for (const opp of opponents) scores[opp] = -1 * multiplier
+      scores[picker] = opponents.length * multiplier
     } else {
       for (const opp of opponents) scores[opp] = -1 * multiplier
       if (partner) {
@@ -625,8 +625,8 @@ function computeScores(state) {
     }
   } else {
     if (goingAlone) {
-      scores[picker] = -opponents.length * 2 * multiplier
-      for (const opp of opponents) scores[opp] = 2 * multiplier
+      scores[picker] = -opponents.length * multiplier
+      for (const opp of opponents) scores[opp] = 1 * multiplier
     } else {
       scores[picker] = -2 * multiplier
       if (partner) scores[partner] = -1 * multiplier

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -640,6 +640,12 @@ function computeScores(state) {
     `${pickerWon ? 'Picker wins' : 'Opponents win'}. Multiplier: ×${multiplier}.`
   )
 
+  const fmt = (n) => (n >= 0 ? '+' : '') + n
+  let scoreLine = `${picker}: ${fmt(scores[picker])}`
+  if (partner) scoreLine += `, ${partner}: ${fmt(scores[partner])}`
+  scoreLine += `. Rest ${pickerWon ? 'lost' : 'earned'} ${Math.abs(scores[opponents[0]])}.`
+  state.log.push(scoreLine)
+
   return scores
 }
 


### PR DESCRIPTION
## Summary

- Reduce last-trick auto-play delay from 1s to 500ms
- Show previous hand's last trick during the picking phase of the next hand
- Add brief per-player score summary to the hand-over log message (e.g. "Andy: +2, Bob: +1. Rest lost 1.")
- Fix going-alone scoring: remove erroneous ×2 factor on per-player payouts

## The Going-Alone Bug

The scoring code had a hardcoded `×2` applied to all going-alone payouts, making each opponent pay 2× multiplier instead of the correct 1× multiplier. When asked to explain this, Claude confidently declared it intentional — "going alone doubles the base stakes" — and implied this was backed by standard Sheepshead rules. No such rules were cited. No such rules exist. It was a hallucinated justification for a bug that was sitting in the code the whole time. The user was right, Claude was wrong, and the commit message acknowledges this appropriately.

## Test plan

- [ ] Play a hand going alone and win — verify picker earns `4 × multiplier`, each opponent loses `1 × multiplier`
- [ ] Play a hand going alone and lose — verify picker loses `4 × multiplier`, each opponent earns `1 × multiplier`
- [ ] Verify schneider/schwarz multipliers still apply correctly with going alone
- [ ] Verify last trick from previous hand is visible during the next hand's picking phase
- [ ] Verify score summary line appears in the game log after each hand
- [ ] Verify auto-play at end of hand feels snappier (500ms vs 1s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)