### PR TITLE
Fix partner leading called suit with non-called card

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -147,8 +147,17 @@ function getLegalCardIds(state, userId, hand) {
   const hasUnderCard = hand.some(c => c.isUnderCard) && underCard && !underCard.played
 
   // Leading: any hand card, plus the under card if held (declares called suit as led)
+  // Exception: partner cannot lead the called suit unless they lead with the called card
   if (!currentTrick || currentTrick.length === 0) {
-    const ids = handCards.map(c => c.id)
+    const calledCardId = calledAce?.aceId || calledTen?.tenId || calledKing?.kingId
+    let ids
+    if (calledCardId && userId === partner && !partnerRevealed) {
+      ids = handCards
+        .filter(c => effectiveSuit(c) !== calledSuit || c.id === calledCardId)
+        .map(c => c.id)
+    } else {
+      ids = handCards.map(c => c.id)
+    }
     if (userId === picker && hasUnderCard) ids.push('UNDER_CARD')
     return ids
   }

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -466,7 +466,22 @@ function getLedSuit(trick, state) {
 
 function validatePlay(state, userId, card) {
   const trick = state.currentTrick
-  if (trick.length === 0) return  // Leader can play anything
+
+  // Partner cannot lead the called suit unless they lead with the called card
+  if (trick.length === 0) {
+    const calledCardId =
+      state.calledAce?.aceId || state.calledTen?.tenId || state.calledKing?.kingId
+    if (
+      calledCardId &&
+      userId === state.partner &&
+      !state.partnerRevealed &&
+      effectiveSuit(card) === state.calledSuit &&
+      card.id !== calledCardId
+    ) {
+      throw new Error(`Partner cannot lead the called suit without playing ${calledCardId}.`)
+    }
+    return
+  }
 
   const ledSuit = getLedSuit(trick, state)
   const hand = state.hands[userId]


### PR DESCRIPTION
## Summary
- Enforce that the unrevealed partner cannot lead a card of the called suit unless it is the actual called card (ace/ten/king)
- Added backend validation in `validatePlay()` to reject illegal leads
- Added frontend filtering in `getLegalCardIds()` to grey out illegal lead options

Closes #19

## Test plan
- [ ] Start a game where a partner holds the called ace plus another card of the same suit
- [ ] Verify the partner cannot lead the non-ace card of the called suit (greyed out in UI, rejected by server)
- [ ] Verify the partner CAN lead the called card itself
- [ ] Verify the partner can lead cards of other suits freely
- [ ] Verify the restriction lifts after the partner is revealed
- [ ] Test with callTen and callKing modes if reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)