### PR TITLE
Fix called card being played illegally when called suit not led

### DIFF
--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -518,6 +518,17 @@ function validatePlay(state, userId, card) {
     }
   }
 
+  // Called card cannot be played unless the called suit is led
+  // (except when it's the player's only remaining card)
+  if (
+    calledCardId &&
+    card.id === calledCardId &&
+    ledSuit !== state.calledSuit &&
+    hand.some(c => c.id !== calledCardId)
+  ) {
+    throw new Error(`Cannot play ${calledCardId} unless the called suit is led.`)
+  }
+
   // Picker forced plays (Situation A / King case): when called suit led, picker must
   // play one of the still-held forced cards (Ace, or Ace/Ten in either order).
   if (


### PR DESCRIPTION
## Summary

- Prevents the called ace/ten/king from being thrown off on a trick where a different suit was led (e.g. partner dumping the called ace on a trump trick when they have no trump)
- The called card is locked until the called suit is led, except when it is the player's only remaining card (forced play)
- Partner can still lead the called card freely

## Test plan

- [ ] Verify partner cannot play called ace when trump is led and they have no trump but hold other fail cards
- [ ] Verify partner cannot play called ace when a different fail suit is led and they have no other cards of that suit
- [ ] Verify partner CAN lead the called ace normally
- [ ] Verify partner CAN play the called ace when the called suit is led
- [ ] Verify a player with only the called ace remaining can play it on any trick

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)