### PR TITLE
Update post-merge hook to keep local main in sync

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -4,3 +4,9 @@
 git fetch --prune
 gone=$(git branch -vv | awk '/: gone\]/ {print $1}')
 [ -n "$gone" ] && echo "$gone" | xargs git branch -d
+
+# Pull main down to latest when we're on a different branch
+current=$(git symbolic-ref --short HEAD 2>/dev/null)
+if [ "$current" != "main" ]; then
+  git fetch origin main:main 2>/dev/null && echo "Updated local main to origin/main"
+fi


### PR DESCRIPTION
## Summary
- When on a feature branch, the post-merge hook now fetches and updates local `main` to match `origin/main`
- This keeps local main current without needing to manually switch branches and pull

## Test plan
- [ ] Merge a PR while on a feature branch and verify local `main` is updated automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)