### PR TITLE
Fix admin flag missing from login/register responses

### DIFF
--- a/functions/api/auth/login.js
+++ b/functions/api/auth/login.js
@@ -9,7 +9,7 @@ export async function onRequestPost({ request, env }) {
   if (!username || !password) return err('Username and password are required.')
 
   const user = await DB.prepare(
-    'SELECT id, username, password_hash, salt, is_bot FROM users WHERE username = ?'
+    'SELECT id, username, password_hash, salt, is_bot, is_admin FROM users WHERE username = ?'
   ).bind(username).first()
 
   if (!user) return err('Invalid username or password.', 401)
@@ -25,7 +25,7 @@ export async function onRequestPost({ request, env }) {
     'INSERT INTO sessions (id, user_id, expires_at) VALUES (?, ?, ?)'
   ).bind(token, user.id, expiresAt).run()
 
-  return new Response(JSON.stringify({ id: user.id, username: user.username }), {
+  return new Response(JSON.stringify({ id: user.id, username: user.username, is_admin: user.is_admin === 1 }), {
     status: 200,
     headers: {
       'Content-Type': 'application/json',

--- a/functions/api/auth/register.js
+++ b/functions/api/auth/register.js
@@ -29,7 +29,7 @@ export async function onRequestPost({ request, env }) {
     'INSERT INTO sessions (id, user_id, expires_at) VALUES (?, ?, ?)'
   ).bind(token, userId, expiresAt).run()
 
-  return new Response(JSON.stringify({ id: userId, username }), {
+  return new Response(JSON.stringify({ id: userId, username, is_admin: false }), {
     status: 201,
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- `login.js` was not selecting `is_admin` from the DB, and not including it in the response body — so `user.is_admin` was `undefined` after login until a page refresh hit `/auth/me`
- `register.js` similarly omitted `is_admin`; hardcodes `false` since new users are never admins

Fixes #27

## Test plan
- [x] Log in as an admin user — admin badge, Accounts button, and test mode checkbox should appear immediately without a refresh
- [ ] Log in as a non-admin user — none of the above should appear
- [ ] Register a new account — no admin UI should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)