### PR TITLE
Repurpose account management as admin panel (#30)

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,7 @@ import RegisterPage from './pages/RegisterPage.jsx'
 import LobbyPage from './pages/LobbyPage.jsx'
 import GamePage from './pages/GamePage.jsx'
 import AccountManagementPage from './pages/AccountManagementPage.jsx'
+import AdminPanelPage from './pages/AdminPanelPage.jsx'
 
 function getRoute() {
   return window.location.hash.replace('#', '') || '/'
@@ -15,6 +16,7 @@ function parseRoute(route) {
   if (gameMatch) return { page: 'game', gameId: gameMatch[1] }
   if (route === '/register')           return { page: 'register' }
   if (route === '/lobby')              return { page: 'lobby' }
+  if (route === '/admin')              return { page: 'admin' }
   if (route === '/account-management') return { page: 'account-management' }
   return { page: 'login' }
 }
@@ -68,6 +70,11 @@ export default function App() {
 
   if (page === 'game' && gameId) {
     return <GamePage gameId={gameId} user={user} onNavigate={navigate} />
+  }
+
+  if (page === 'admin') {
+    if (!user.is_admin) { navigate('/lobby'); return null }
+    return <AdminPanelPage onNavigate={navigate} />
   }
 
   if (page === 'account-management') {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -32,8 +32,9 @@ export const api = {
     updateSettings: (id, settings)                  => request('PATCH', `/games/${id}/settings`, settings),
   },
   admin: {
-    listUsers:  ()          => request('GET',   '/admin/users'),
-    getUser:    (id)        => request('GET',   `/admin/users/${id}`),
-    updateUser: (id, patch) => request('PATCH', `/admin/users/${id}`, patch),
+    listUsers:  ()          => request('GET',    '/admin/users'),
+    getUser:    (id)        => request('GET',    `/admin/users/${id}`),
+    updateUser: (id, patch) => request('PATCH',  `/admin/users/${id}`, patch),
+    deleteUser: (id)        => request('DELETE', `/admin/users/${id}`),
   },
 }

--- a/frontend/src/pages/AccountManagementPage.jsx
+++ b/frontend/src/pages/AccountManagementPage.jsx
@@ -1,13 +1,14 @@
 import { useState, useEffect } from 'react'
 import { api } from '../lib/api.js'
 
-function UserRow({ user, currentUserId, onSaved }) {
+function UserRow({ user, currentUserId, onSaved, onDeleted }) {
   const [editing, setEditing]     = useState(false)
   const [username, setUsername]   = useState(user.username)
   const [isAdmin, setIsAdmin]     = useState(!!user.is_admin)
   const [isBot, setIsBot]         = useState(!!user.is_bot)
   const [password, setPassword]   = useState('')
   const [saving, setSaving]       = useState(false)
+  const [deleting, setDeleting]   = useState(false)
   const [error, setError]         = useState(null)
 
   // Keep local state in sync when parent data refreshes
@@ -53,6 +54,20 @@ function UserRow({ user, currentUserId, onSaved }) {
     setEditing(false)
   }
 
+  async function handleDelete() {
+    if (!window.confirm(`Delete account "${user.username}"? This cannot be undone.`)) return
+    setDeleting(true)
+    setError(null)
+    try {
+      await api.admin.deleteUser(user.id)
+      onDeleted(user.id)
+    } catch (e) {
+      setError(e.message)
+    } finally {
+      setDeleting(false)
+    }
+  }
+
   if (!editing) {
     return (
       <tr>
@@ -60,18 +75,30 @@ function UserRow({ user, currentUserId, onSaved }) {
         <td>
           {user.username}
           {isSelf && <span className="badge badge-you" style={{ marginLeft: 6 }}>you</span>}
-          {user.is_bot && <span className="badge" style={{ background: '#6b7280', color: '#fff', marginLeft: 6 }}>bot</span>}
+          {!!user.is_bot && <span className="badge" style={{ background: '#6b7280', color: '#fff', marginLeft: 6 }}>bot</span>}
         </td>
         <td>{user.is_admin ? '✓' : '—'}</td>
         <td>{user.is_bot ? '✓' : '—'}</td>
-        <td style={{ color: '#888', fontSize: '0.8rem' }}>
+        <td style={{ color: '#888' }}>
           {new Date(user.created_at).toLocaleDateString()}
         </td>
         <td>
-          <button className="outline" style={{ padding: '2px 10px', fontSize: '0.8rem' }}
-            onClick={() => setEditing(true)}>
-            Edit
-          </button>
+          <div style={{ display: 'flex', gap: 4 }}>
+            <button className="outline" style={{ padding: '2px 8px' }} onClick={() => setEditing(true)}>
+              Edit
+            </button>
+            <button
+              className="outline"
+              style={{ padding: '2px 8px', color: '#ef4444', borderColor: '#ef4444' }}
+              onClick={handleDelete}
+              aria-busy={deleting}
+              disabled={deleting || isSelf}
+              title={isSelf ? 'You cannot delete your own account' : undefined}
+            >
+              Delete
+            </button>
+          </div>
+          {error && <div style={{ color: '#ef4444', fontSize: '0.75rem', marginTop: 2 }}>{error}</div>}
         </td>
       </tr>
     )
@@ -85,7 +112,7 @@ function UserRow({ user, currentUserId, onSaved }) {
           type="text"
           value={username}
           onChange={e => setUsername(e.target.value)}
-          style={{ margin: 0, padding: '2px 6px', fontSize: '0.85rem' }}
+          style={{ margin: 0, padding: '2px 6px', width: '100%', boxSizing: 'border-box' }}
         />
       </td>
       <td>
@@ -96,7 +123,7 @@ function UserRow({ user, currentUserId, onSaved }) {
           style={{ margin: 0 }}
         />
         {removingOwnAdmin && (
-          <span style={{ color: '#ef4444', fontSize: '0.75rem', marginLeft: 4 }}>⚠ removes your access</span>
+          <span style={{ color: '#ef4444', fontSize: '0.7rem', marginLeft: 4 }}>⚠ removes your access</span>
         )}
       </td>
       <td>
@@ -110,16 +137,16 @@ function UserRow({ user, currentUserId, onSaved }) {
       <td>
         <input
           type="password"
-          placeholder="New password (optional)"
+          placeholder="New password"
           value={password}
           onChange={e => setPassword(e.target.value)}
-          style={{ margin: 0, padding: '2px 6px', fontSize: '0.85rem' }}
+          style={{ margin: 0, padding: '2px 6px', width: '100%', boxSizing: 'border-box' }}
         />
       </td>
       <td>
-        <div style={{ display: 'flex', gap: 6 }}>
+        <div style={{ display: 'flex', gap: 4 }}>
           <button
-            style={{ padding: '2px 10px', fontSize: '0.8rem' }}
+            style={{ padding: '2px 8px' }}
             onClick={handleSave}
             aria-busy={saving}
             disabled={saving}
@@ -128,7 +155,7 @@ function UserRow({ user, currentUserId, onSaved }) {
           </button>
           <button
             className="secondary outline"
-            style={{ padding: '2px 8px', fontSize: '0.8rem' }}
+            style={{ padding: '2px 8px' }}
             onClick={handleCancel}
             disabled={saving}
           >
@@ -141,10 +168,25 @@ function UserRow({ user, currentUserId, onSaved }) {
   )
 }
 
+function sortUsers(users, col, dir) {
+  return [...users].sort((a, b) => {
+    let av = a[col], bv = b[col]
+    if (col === 'username') {
+      av = av.toLowerCase(); bv = bv.toLowerCase()
+      return dir === 'asc' ? av.localeCompare(bv) : bv.localeCompare(av)
+    }
+    if (av < bv) return dir === 'asc' ? -1 : 1
+    if (av > bv) return dir === 'asc' ? 1 : -1
+    return 0
+  })
+}
+
 export default function AccountManagementPage({ currentUser, onNavigate }) {
-  const [users, setUsers]   = useState([])
+  const [users, setUsers]     = useState([])
   const [loading, setLoading] = useState(true)
-  const [error, setError]   = useState(null)
+  const [error, setError]     = useState(null)
+  const [sortCol, setSortCol] = useState('id')
+  const [sortDir, setSortDir] = useState('asc')
 
   async function load() {
     try {
@@ -168,11 +210,41 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
     }
   }
 
+  function handleDeleted(id) {
+    setUsers(prev => prev.filter(u => u.id !== id))
+  }
+
+  function handleSort(col) {
+    if (col === sortCol) {
+      setSortDir(d => d === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortCol(col)
+      setSortDir('asc')
+    }
+  }
+
+  const sortedUsers = sortUsers(users, sortCol, sortDir)
+
+  function SortTh({ col, children }) {
+    const active = sortCol === col
+    return (
+      <th
+        onClick={() => handleSort(col)}
+        style={{ cursor: 'pointer', userSelect: 'none', whiteSpace: 'nowrap' }}
+      >
+        {children}
+        <span style={{ marginLeft: 4, opacity: active ? 1 : 0.25 }}>
+          {active && sortDir === 'desc' ? '↓' : '↑'}
+        </span>
+      </th>
+    )
+  }
+
   return (
     <div style={{ maxWidth: 900, margin: '0 auto', padding: 24 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
         <h2 style={{ margin: 0 }}>Account Management</h2>
-        <button className="outline" onClick={() => onNavigate('/lobby')}>← Back to lobby</button>
+        <button className="outline" onClick={() => onNavigate('/admin')}>← Back to admin panel</button>
       </div>
 
       {error && <p style={{ color: 'var(--pico-del-color)' }}>{error}</p>}
@@ -180,30 +252,37 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
       {loading
         ? <p aria-busy="true">Loading users…</p>
         : (
-          <div style={{ overflowX: 'auto' }}>
-            <table>
+          <table style={{ width: '100%', tableLayout: 'fixed', fontSize: '0.78rem' }}>
+              <colgroup>
+                <col style={{ width: '4%' }} />
+                <col style={{ width: '22%' }} />
+                <col style={{ width: '7%' }} />
+                <col style={{ width: '6%' }} />
+                <col style={{ width: '27%' }} />
+                <col style={{ width: '34%' }} />
+              </colgroup>
               <thead>
                 <tr>
-                  <th>ID</th>
-                  <th>Username</th>
-                  <th>Admin</th>
-                  <th>Bot</th>
-                  <th>Created / New password</th>
+                  <SortTh col="id">ID</SortTh>
+                  <SortTh col="username">Username</SortTh>
+                  <SortTh col="is_admin">Admin</SortTh>
+                  <SortTh col="is_bot">Bot</SortTh>
+                  <SortTh col="created_at">Created / New password</SortTh>
                   <th>Actions</th>
                 </tr>
               </thead>
               <tbody>
-                {users.map(u => (
+                {sortedUsers.map(u => (
                   <UserRow
                     key={u.id}
                     user={u}
                     currentUserId={currentUser.id}
                     onSaved={handleSaved}
+                    onDeleted={handleDeleted}
                   />
                 ))}
               </tbody>
             </table>
-          </div>
         )
       }
     </div>

--- a/frontend/src/pages/AdminPanelPage.jsx
+++ b/frontend/src/pages/AdminPanelPage.jsx
@@ -1,0 +1,20 @@
+export default function AdminPanelPage({ onNavigate }) {
+  return (
+    <div style={{ maxWidth: 600, margin: '0 auto', padding: 24 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 24 }}>
+        <h2 style={{ margin: 0 }}>Admin Panel</h2>
+        <button className="outline" onClick={() => onNavigate('/lobby')}>← Back to lobby</button>
+      </div>
+
+      <article
+        style={{ cursor: 'pointer', marginBottom: 0 }}
+        onClick={() => onNavigate('/account-management')}
+      >
+        <h4 style={{ margin: '0 0 4px' }}>Account Management</h4>
+        <p style={{ margin: 0, color: '#888', fontSize: '0.9rem' }}>
+          View, edit, and delete user accounts.
+        </p>
+      </article>
+    </div>
+  )
+}

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -75,8 +75,8 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
         </hgroup>
         <div style={{ display: 'flex', gap: 8 }}>
           {user.is_admin && (
-            <button className="outline" onClick={() => onNavigate('/account-management')} style={{ fontSize: '0.85rem' }}>
-              ⚙ Accounts
+            <button className="outline" onClick={() => onNavigate('/admin')} style={{ fontSize: '0.85rem' }}>
+              ⚙ Admin
             </button>
           )}
           <button

--- a/functions/api/admin/users/[id]/index.js
+++ b/functions/api/admin/users/[id]/index.js
@@ -2,8 +2,9 @@ import { json, err, requireAdmin, hashPassword, randomHex, AuthError } from '../
 
 export async function onRequest({ request, env, params }) {
   try {
-    if (request.method === 'GET')   return await getUser({ request, env, params })
-    if (request.method === 'PATCH') return await updateUser({ request, env, params })
+    if (request.method === 'GET')    return await getUser({ request, env, params })
+    if (request.method === 'PATCH')  return await updateUser({ request, env, params })
+    if (request.method === 'DELETE') return await deleteUser({ request, env, params })
     return err('Method not allowed.', 405)
   } catch (e) {
     if (e instanceof AuthError) return err(e.message, e.message === 'Admin access required.' ? 403 : 401)
@@ -97,4 +98,34 @@ async function updateUser({ request, env, params }) {
   const removedOwnAdmin = userId === admin.user_id && body.is_admin === false
 
   return json({ ...updated, removedOwnAdmin })
+}
+
+async function deleteUser({ request, env, params }) {
+  const admin = await requireAdmin(request, env.DB)
+  const userId = Number(params.id)
+
+  if (userId === admin.user_id) return err('You cannot delete your own account.', 403)
+
+  const target = await env.DB.prepare(
+    'SELECT id FROM users WHERE id = ?'
+  ).bind(userId).first()
+  if (!target) return err('User not found.', 404)
+
+  // Block deletion if user is in an active or waiting game
+  const activeGame = await env.DB.prepare(`
+    SELECT g.name FROM game_players gp
+    JOIN games g ON g.id = gp.game_id
+    WHERE gp.user_id = ? AND g.status IN ('waiting', 'active')
+    LIMIT 1
+  `).bind(userId).first()
+  if (activeGame) return err(`Cannot delete: user is currently in game "${activeGame.name}".`, 409)
+
+  // Clean up related rows (sessions will cascade, but clean others explicitly)
+  await env.DB.batch([
+    env.DB.prepare('DELETE FROM game_players WHERE user_id = ?').bind(userId),
+    env.DB.prepare('DELETE FROM score_events WHERE user_id = ?').bind(userId),
+    env.DB.prepare('DELETE FROM users WHERE id = ?').bind(userId),
+  ])
+
+  return json({ deleted: true, id: userId })
 }


### PR DESCRIPTION
## Summary
- Adds a new `/admin` hub page that replaces the direct "Accounts" button in the lobby; account management is now a sub-page of the panel
- Adds delete user with confirmation, self-deletion guard, and active-game block (cleans up `game_players` and `score_events` rows)
- Fixes the "Andy0" display bug — SQLite integer `0` for `is_bot` was leaking as rendered text in React
- Adds client-side column sorting to the user table (default: ID ascending); clickable headers toggle asc/desc
- Tightens table layout (fixed column widths, smaller font, removes `overflowX: auto` wrapper that caused resize jank)

## Test plan
- [x] Lobby admin button now reads "⚙ Admin" and lands on the new admin panel page
- [x] Admin panel card navigates to account management; back button returns to panel
- [ ] Non-admin navigating to `/admin` or `/account-management` is redirected to lobby
- [x] User list shows usernames without trailing "0" for non-bot accounts
- [x] Clicking each column header sorts the table; clicking again reverses direction; ID ascending is the default
- [x] Delete button is disabled (with tooltip) on your own row
- [x] Deleting another user shows a confirmation dialog; confirmed delete removes the row
- [ ] Attempting to delete a user in an active/waiting game returns a 409 error message
- [x] Table fits without horizontal scrollbar at typical window widths; resizing doesn't cause layout jumps

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)