### PR TITLE
Implement cracks and recracks

### DIFF
--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -61,7 +61,8 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
 
   if (!state) return null
 
-  const { phase, picker, pickOrder, pickIndex, currentTrick, isLeaster, doublerMultiplier } = state
+  const { phase, picker, pickOrder, pickIndex, currentTrick, isLeaster, doublerMultiplier,
+          crackState, handCrackMultiplier } = state
 
   // ── Picking phase ─────────────────────────────────────────
   if (phase === 'picking') {
@@ -289,11 +290,56 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
   if (phase === 'playing') {
     const myTurn = currentPlayer(state) === myUserId
 
+    // Crack / recrack window: before the first card of the hand is played
+    const crackWindowOpen = !isLeaster && state.tricks.length === 0 && currentTrick.length === 0
+    const iAmOpponent = myUserId !== state.picker && myUserId !== state.partner
+    const canCrack = crackWindowOpen && iAmOpponent && crackState === null
+    const canRecrack = crackWindowOpen && !iAmOpponent && crackState === 'cracked'
+
+    if (crackWindowOpen && (canCrack || canRecrack || crackState !== null)) {
+      const crackLabel =
+        crackState === 'recracked' ? 'Recracked! Stakes ×4 for this hand.'
+        : crackState === 'cracked' ? 'Opponents cracked! Stakes ×2 for this hand.'
+        : null
+
+      return (
+        <div className="action-panel">
+          {crackLabel && (
+            <p style={{ color: '#fbbf24', fontWeight: 'bold', marginBottom: 8 }}>{crackLabel}</p>
+          )}
+          {canCrack && (
+            <div>
+              <p style={{ fontSize: '0.85rem', color: '#ccc', marginBottom: 6 }}>
+                Double this hand's stakes before play begins.
+              </p>
+              <button onClick={() => act('crack')} disabled={loading}>
+                Crack (×2)
+              </button>
+            </div>
+          )}
+          {canRecrack && (
+            <div>
+              <p style={{ fontSize: '0.85rem', color: '#ccc', marginBottom: 6 }}>
+                Double again — opponents cracked first.
+              </p>
+              <button onClick={() => act('recrack')} disabled={loading}>
+                Recrack (×4)
+              </button>
+            </div>
+          )}
+          {!canCrack && !canRecrack && crackState !== null && (
+            <p style={{ fontSize: '0.85rem', color: '#aaa' }}>Waiting for others to play…</p>
+          )}
+          {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
+        </div>
+      )
+    }
+
     if (!myTurn) {
       return (
         <div className="action-panel">
           <p>Waiting for others to play…</p>
-          {isLeaster && <p style={{ color: '#f59e0b' }}>🃏 Leaster — fewest points wins!</p>}
+          {isLeaster && <p style={{ color: '#f59e0b' }}>Leaster — fewest points wins!</p>}
         </div>
       )
     }
@@ -303,7 +349,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
       return (
         <div className="action-panel" style={botStyle}>
           <h4>{turnLabel} — play a card</h4>
-          {isLeaster && <p style={{ color: '#f59e0b', marginBottom: 4 }}>🃏 Leaster — fewest points wins!</p>}
+          {isLeaster && <p style={{ color: '#f59e0b', marginBottom: 4 }}>Leaster — fewest points wins!</p>}
         </div>
       )
     }

--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -293,7 +293,9 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     // Crack / recrack window: before the first card of the hand is played
     const crackWindowOpen = !isLeaster && state.tricks.length === 0 && currentTrick.length === 0
     const iAmOpponent = myUserId !== state.picker && myUserId !== state.partner
-    const canCrack = crackWindowOpen && iAmOpponent && crackState === null
+    const passedAtPicking = state.pickOrder.slice(0, state.pickIndex)
+    const iPassedAtPicking = passedAtPicking.includes(myUserId)
+    const canCrack = crackWindowOpen && iAmOpponent && crackState === null && !iPassedAtPicking
     const canRecrack = crackWindowOpen && !iAmOpponent && crackState === 'cracked'
 
     if (crackWindowOpen && (canCrack || canRecrack || crackState !== null)) {

--- a/frontend/src/components/PlayerSeat.jsx
+++ b/frontend/src/components/PlayerSeat.jsx
@@ -16,6 +16,8 @@ export default function PlayerSeat({
   playableIds,
   onCardClick,
   noOverlap,
+  onCrack,
+  onRecrack,
 }) {
   if (!player) {
     return (
@@ -29,12 +31,22 @@ export default function PlayerSeat({
 
   return (
     <div className={`player-seat${isActiveTurn ? ' active-turn' : ''}${noOverlap ? ' player-seat-wide' : ''}`}>
-      <div style={{ fontWeight: 600, fontSize: '0.9rem' }}>
+      <div style={{ fontWeight: 600, fontSize: '0.9rem', display: 'flex', alignItems: 'center', flexWrap: 'wrap', gap: 3 }}>
         {player.username}
         {isYou     && <span className="badge badge-you">you</span>}
         {isDealer  && <span className="badge badge-dealer">D</span>}
         {isPicker  && <span className="badge badge-picker">picker</span>}
         {isPartner && <span className="badge badge-partner">partner</span>}
+        {onCrack   && (
+          <button onClick={onCrack} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>
+            crack
+          </button>
+        )}
+        {onRecrack && (
+          <button onClick={onRecrack} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>
+            recrack
+          </button>
+        )}
       </div>
       <div className="player-scores">
         D: {formatScore(dayScore ?? 0)}, L: {formatScore(lifetimeScore ?? 0)}

--- a/frontend/src/components/PlayerSeat.jsx
+++ b/frontend/src/components/PlayerSeat.jsx
@@ -42,7 +42,7 @@ export default function PlayerSeat({
             crack
           </button>
         )}
-        {onRecrack && (
+{onRecrack && (
           <button onClick={onRecrack} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>
             recrack
           </button>

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -500,8 +500,9 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
     // Crack/recrack buttons: show in test mode during the cracking window
     const isSeatOpponent = uid !== state.picker && uid !== state.partner
+    const seatPassedAtPicking = state.pickOrder.slice(0, state.pickIndex).includes(uid)
     const actAs = uid !== myUserId ? uid : null
-    const onCrack   = crackWindowOpen && isSeatOpponent && state.crackState === null
+    const onCrack   = crackWindowOpen && isSeatOpponent && state.crackState === null && !seatPassedAtPicking
       ? () => handleAction('crack', {}, actAs)
       : undefined
     const onRecrack = crackWindowOpen && !isSeatOpponent && state.crackState === 'cracked'

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -466,6 +466,14 @@ export default function GamePage({ gameId, user, onNavigate }) {
     ? players.find(p => String(p.user_id) === String(state.partner))
     : null
 
+  // Crack/recrack window: test mode admin can act for any seat before first card
+  const crackWindowOpen =
+    isTestMode && user.is_admin
+    && state.phase === 'playing'
+    && !state.isLeaster
+    && (state.tricks ?? []).length === 0
+    && (state.currentTrick ?? []).length === 0
+
   function seatProps(player) {
     if (!player) return {}
     const uid  = String(player.user_id)
@@ -490,6 +498,16 @@ export default function GamePage({ gameId, user, onNavigate }) {
       ? getLegalCardIds(state, uid, hand)
       : undefined
 
+    // Crack/recrack buttons: show in test mode during the cracking window
+    const isSeatOpponent = uid !== state.picker && uid !== state.partner
+    const actAs = uid !== myUserId ? uid : null
+    const onCrack   = crackWindowOpen && isSeatOpponent && state.crackState === null
+      ? () => handleAction('crack', {}, actAs)
+      : undefined
+    const onRecrack = crackWindowOpen && !isSeatOpponent && state.crackState === 'cracked'
+      ? () => handleAction('recrack', {}, actAs)
+      : undefined
+
     return {
       isDealer:      uid === dealerUserId,
       isPicker:      uid === pickerUserId,
@@ -509,6 +527,8 @@ export default function GamePage({ gameId, user, onNavigate }) {
             }
           }
         : undefined,
+      onCrack,
+      onRecrack,
     }
   }
 

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -1,6 +1,7 @@
 import { json, err, requireUser, AuthError } from '../../_helpers.js'
 import {
   pick, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
+  crack, recrack,
   setupLeaster, awardLeasterBlind, resolveLeaster,
   dealHand,
 } from '../../../../shared/gameEngine.js'
@@ -99,6 +100,14 @@ export async function onRequestPost({ request, env, params }) {
 
       case 'go_alone':
         state = goAlone(state, userId)
+        break
+
+      case 'crack':
+        state = crack(state, userId)
+        break
+
+      case 'recrack':
+        state = recrack(state, userId)
         break
 
       case 'play_card': {

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -107,6 +107,8 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     currentTrick: [],          // in-progress: [{userId, card}]
     lastTrick: [],             // last completed trick — shown between tricks
     currentLeader: null,       // userId who leads next trick
+    handCrackMultiplier: 1,    // 1 | 2 | 4 — crack/recrack multiplier for this hand only
+    crackState: null,          // null | 'cracked' | 'recracked'
     log: [],                   // string messages
     scores: {},                // { userId: delta } — populated at scoring
   }
@@ -358,6 +360,47 @@ export function callKing(state, userId, suit) {
   newState.phase = 'playing'
   newState.currentLeader = newState.pickOrder[0]
   newState.log.push(`${userId} called the ${kingId}.`)
+  return newState
+}
+
+// ─── Crack / Recrack ─────────────────────────────────────────────────────────
+// Opponents crack before the first card is played to double the hand's stakes.
+// Picker/partner can recrack to double again (×4 total on top of doublerMultiplier).
+// Cracking is unavailable in leasters (no teams).
+
+function assertCrackWindow(state) {
+  assertPhase(state, 'playing')
+  if (state.isLeaster) throw new Error('Cannot crack during a leaster.')
+  if (state.tricks.length > 0 || state.currentTrick.length > 0) {
+    throw new Error('Cracking window is closed once the first card is played.')
+  }
+}
+
+function isOpponent(state, userId) {
+  return userId !== state.picker && userId !== state.partner
+}
+
+export function crack(state, userId) {
+  assertCrackWindow(state)
+  if (!isOpponent(state, userId)) throw new Error('Only opponents may crack.')
+  if (state.crackState !== null) throw new Error('Already cracked.')
+
+  const newState = deepClone(state)
+  newState.crackState = 'cracked'
+  newState.handCrackMultiplier = 2
+  newState.log.push(`${userId} cracked! Hand stakes ×2.`)
+  return newState
+}
+
+export function recrack(state, userId) {
+  assertCrackWindow(state)
+  if (isOpponent(state, userId)) throw new Error('Only the picker or partner may recrack.')
+  if (state.crackState !== 'cracked') throw new Error('Can only recrack after a crack.')
+
+  const newState = deepClone(state)
+  newState.crackState = 'recracked'
+  newState.handCrackMultiplier = 4
+  newState.log.push(`${userId} recracked! Hand stakes ×4.`)
   return newState
 }
 
@@ -630,7 +673,7 @@ function computeScores(state) {
   if (pickerTeamPoints >= 91 || (!pickerWon && pickerTeamPoints <= 29)) baseMultiplier = 2  // schneider
   if (pickerTeamTricks === 6 || pickerTeamTricks === 0) baseMultiplier = 3  // schwarz
 
-  const multiplier = baseMultiplier * doublerMultiplier
+  const multiplier = baseMultiplier * doublerMultiplier * (state.handCrackMultiplier ?? 1)
 
   const scores = {}
   for (const uid of Object.keys(state.hands)) scores[uid] = 0

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -384,6 +384,8 @@ export function crack(state, userId) {
   assertCrackWindow(state)
   if (!isOpponent(state, userId)) throw new Error('Only opponents may crack.')
   if (state.crackState !== null) throw new Error('Already cracked.')
+  const passedAtPicking = state.pickOrder.slice(0, state.pickIndex)
+  if (passedAtPicking.includes(userId)) throw new Error('Cannot crack — you passed at picking.')
 
   const newState = deepClone(state)
   newState.crackState = 'cracked'


### PR DESCRIPTION
## Summary

- Opponents who picked up the blind can crack before the first card is played, doubling the hand's stakes (×2)
- The picker or partner can recrack to double again (×4)
- Crack/recrack multiplier stacks with the existing doubler and schneider/schwarz multipliers
- Players who passed at picking are ineligible to crack
- Cracking is blocked during leasters and once the first card is played
- Test mode: crack/recrack buttons appear next to eligible player names so admins can act on behalf of bots

## Test plan

- Opponent who passed at picking: no crack button shown; crack action rejected by server
- Opponent who picked or was not offered the blind: crack button visible before first card
- After crack: picker/partner see recrack button; opponents no longer see crack
- After recrack: no further buttons; hand plays out at ×4
- Playing the first card closes the window for all players
- Leaster hand: no crack buttons at any point
- Scores reflect the crack multiplier (verify against an uncracked baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)