### PR TITLE
Implement Blitzing (Black and Red Blitz)

### DIFF
--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -77,12 +77,19 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
         </div>
       )
     }
+    const playerBlitz = (state.blitzes ?? []).find(b => b.userId === myUserId)
     return (
       <div className="action-panel" style={botStyle}>
         <h4>{turnLabel} — pick or pass?</h4>
         {doublerMultiplier > 1 && <p style={{ color: '#f59e0b' }}>⚠ Stakes are ×{doublerMultiplier}</p>}
         <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginTop: 8 }}>
-          <button onClick={() => act('pick')} disabled={loading}>Pick the blind</button>
+          {playerBlitz?.type === 'black' && (
+            <button onClick={() => act('pick')} disabled={loading}>Black Blitz?</button>
+          )}
+          {playerBlitz?.type === 'red' && (
+            <button onClick={() => act('pick')} disabled={loading}>Red Blitz?</button>
+          )}
+          <button onClick={() => act('pick')} disabled={loading}>Pick the Blind?</button>
           <button className="secondary" onClick={() => act('pass')} disabled={loading}>Pass</button>
         </div>
         {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}

--- a/frontend/src/components/PlayerSeat.jsx
+++ b/frontend/src/components/PlayerSeat.jsx
@@ -19,8 +19,6 @@ export default function PlayerSeat({
   noOverlap,
   onCrack,
   onRecrack,
-  onBlitz,
-  blitzLabel,
 }) {
   if (!player) {
     return (
@@ -42,11 +40,6 @@ export default function PlayerSeat({
         {isPicker && blitzType === 'black' && <span className="badge badge-blitz-black">Black Blitz</span>}
         {isPicker && blitzType === 'red'   && <span className="badge badge-blitz-red">Red Blitz</span>}
         {isPartner && <span className="badge badge-partner">partner</span>}
-        {onBlitz   && (
-          <button onClick={onBlitz} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>
-            {blitzLabel}
-          </button>
-        )}
         {onCrack   && (
           <button onClick={onCrack} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>
             crack

--- a/frontend/src/components/PlayerSeat.jsx
+++ b/frontend/src/components/PlayerSeat.jsx
@@ -19,6 +19,8 @@ export default function PlayerSeat({
   noOverlap,
   onCrack,
   onRecrack,
+  onBlitz,
+  blitzLabel,
 }) {
   if (!player) {
     return (
@@ -40,6 +42,11 @@ export default function PlayerSeat({
         {isPicker && blitzType === 'black' && <span className="badge badge-blitz-black">Black Blitz</span>}
         {isPicker && blitzType === 'red'   && <span className="badge badge-blitz-red">Red Blitz</span>}
         {isPartner && <span className="badge badge-partner">partner</span>}
+        {onBlitz   && (
+          <button onClick={onBlitz} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>
+            {blitzLabel}
+          </button>
+        )}
         {onCrack   && (
           <button onClick={onCrack} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>
             crack

--- a/frontend/src/components/PlayerSeat.jsx
+++ b/frontend/src/components/PlayerSeat.jsx
@@ -9,6 +9,7 @@ export default function PlayerSeat({
   isPartner,
   isYou,
   isActiveTurn,
+  blitzType,
   dayScore,
   lifetimeScore,
   hand,
@@ -36,6 +37,8 @@ export default function PlayerSeat({
         {isYou     && <span className="badge badge-you">you</span>}
         {isDealer  && <span className="badge badge-dealer">D</span>}
         {isPicker  && <span className="badge badge-picker">picker</span>}
+        {isPicker && blitzType === 'black' && <span className="badge badge-blitz-black">Black Blitz</span>}
+        {isPicker && blitzType === 'red'   && <span className="badge badge-blitz-red">Red Blitz</span>}
         {isPartner && <span className="badge badge-partner">partner</span>}
         {onCrack   && (
           <button onClick={onCrack} style={{ fontSize: '0.6rem', padding: '1px 4px', lineHeight: 1.4, marginLeft: 2 }}>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -186,10 +186,12 @@ body {
   margin-left: 4px;
 }
 
-.badge-dealer  { background: #f59e0b; color: #000; }
-.badge-picker  { background: #3b82f6; color: #fff; }
-.badge-partner { background: #10b981; color: #fff; }
-.badge-you     { background: #8b5cf6; color: #fff; }
+.badge-dealer       { background: #f59e0b; color: #000; }
+.badge-picker       { background: #3b82f6; color: #fff; }
+.badge-partner      { background: #10b981; color: #fff; }
+.badge-you          { background: #8b5cf6; color: #fff; }
+.badge-blitz-black  { background: #1f2937; color: #fff; border: 1px solid #6b7280; }
+.badge-blitz-red    { background: #dc2626; color: #fff; }
 
 .player-scores {
   font-size: 0.7rem;

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -511,16 +511,6 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
     const blitz = (state.blitzes ?? []).find(b => b.userId === uid)
 
-    // Blitz button: test mode admin can force-pick on behalf of a blitzing bot
-    // when it's that player's turn in the pick order
-    const onBlitz = isTestMode && user.is_admin
-      && state.phase === 'picking'
-      && blitz
-      && state.pickOrder[state.pickIndex] === uid
-      && uid !== myUserId
-      ? () => handleAction('pick', {}, actAs)
-      : undefined
-
     return {
       isDealer:      uid === dealerUserId,
       isPicker:      uid === pickerUserId,
@@ -543,8 +533,6 @@ export default function GamePage({ gameId, user, onNavigate }) {
         : undefined,
       onCrack,
       onRecrack,
-      onBlitz,
-      blitzLabel:    blitz ? `${blitz.type === 'black' ? 'Black' : 'Red'} Blitz?` : undefined,
     }
   }
 

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -511,6 +511,16 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
     const blitz = (state.blitzes ?? []).find(b => b.userId === uid)
 
+    // Blitz button: test mode admin can force-pick on behalf of a blitzing bot
+    // when it's that player's turn in the pick order
+    const onBlitz = isTestMode && user.is_admin
+      && state.phase === 'picking'
+      && blitz
+      && state.pickOrder[state.pickIndex] === uid
+      && uid !== myUserId
+      ? () => handleAction('pick', {}, actAs)
+      : undefined
+
     return {
       isDealer:      uid === dealerUserId,
       isPicker:      uid === pickerUserId,
@@ -533,6 +543,8 @@ export default function GamePage({ gameId, user, onNavigate }) {
         : undefined,
       onCrack,
       onRecrack,
+      onBlitz,
+      blitzLabel:    blitz ? `${blitz.type === 'black' ? 'Black' : 'Red'} Blitz?` : undefined,
     }
   }
 

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -509,12 +509,15 @@ export default function GamePage({ gameId, user, onNavigate }) {
       ? () => handleAction('recrack', {}, actAs)
       : undefined
 
+    const blitz = (state.blitzes ?? []).find(b => b.userId === uid)
+
     return {
       isDealer:      uid === dealerUserId,
       isPicker:      uid === pickerUserId,
       isPartner:     uid === partnerUserId,
       isYou:         uid === myUserId,
       isActiveTurn:  uid === turnUserId,
+      blitzType:     uid === pickerUserId ? blitz?.type : undefined,
       cardCount:     hand.length,
       dayScore:      player.day_score      ?? 0,
       lifetimeScore: player.lifetime_score ?? 0,

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -93,11 +93,6 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     else if (hasQH && hasQD) blitzes.push({ userId: pid, type: 'red' })
   }
 
-  const log = []
-  for (const b of blitzes) {
-    log.push(`${b.userId} ${b.type === 'black' ? 'Black' : 'Red'} Blitzed!`)
-  }
-
   return {
     phase: 'picking',          // picking | discarding | calling | playing | scoring | complete
     handNumber,
@@ -127,7 +122,7 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     handCrackMultiplier: 1,    // 1 | 2 | 4 — crack/recrack multiplier for this hand only
     crackState: null,          // null | 'cracked' | 'recracked'
     blitzes,                   // [{ userId, type: 'black'|'red' }] — players who must pick
-    log,                       // string messages
+    log: [],                   // string messages
     scores: {},                // { userId: delta } — populated at scoring
   }
 }
@@ -144,7 +139,14 @@ export function pick(state, userId) {
   newState.hands[userId] = [...newState.hands[userId], ...newState.blind]
   newState.blind = []
   newState.phase = 'discarding'
-  newState.log.push(`${userId} picked.`)
+
+  const blitz = (newState.blitzes ?? []).find(b => b.userId === userId)
+  if (blitz) {
+    newState.log.push(`${userId} ${blitz.type === 'black' ? 'Black' : 'Red'} Blitzed!`)
+  } else {
+    newState.log.push(`${userId} picked.`)
+  }
+
   return newState
 }
 

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -81,6 +81,23 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     pickOrder.push(playerIds[(dealerSeat + i) % 5])
   }
 
+  // Detect blitzes: a player holding 2 queens of the same color must pick
+  const blitzes = []
+  for (const pid of playerIds) {
+    const hand = hands[pid]
+    const hasQC = hand.some(c => c.id === 'QC')
+    const hasQS = hand.some(c => c.id === 'QS')
+    const hasQH = hand.some(c => c.id === 'QH')
+    const hasQD = hand.some(c => c.id === 'QD')
+    if (hasQC && hasQS) blitzes.push({ userId: pid, type: 'black' })
+    else if (hasQH && hasQD) blitzes.push({ userId: pid, type: 'red' })
+  }
+
+  const log = []
+  for (const b of blitzes) {
+    log.push(`${b.userId} ${b.type === 'black' ? 'Black' : 'Red'} Blitzed!`)
+  }
+
   return {
     phase: 'picking',          // picking | discarding | calling | playing | scoring | complete
     handNumber,
@@ -109,7 +126,8 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     currentLeader: null,       // userId who leads next trick
     handCrackMultiplier: 1,    // 1 | 2 | 4 — crack/recrack multiplier for this hand only
     crackState: null,          // null | 'cracked' | 'recracked'
-    log: [],                   // string messages
+    blitzes,                   // [{ userId, type: 'black'|'red' }] — players who must pick
+    log,                       // string messages
     scores: {},                // { userId: delta } — populated at scoring
   }
 }
@@ -133,6 +151,11 @@ export function pick(state, userId) {
 export function pass(state, userId) {
   assertPhase(state, 'picking')
   assertTurn(state, userId, currentPicker(state))
+
+  const blitz = (state.blitzes ?? []).find(b => b.userId === userId)
+  if (blitz) {
+    throw new Error(`Cannot pass — you ${blitz.type === 'black' ? 'Black' : 'Red'} Blitzed and must pick.`)
+  }
 
   const newState = deepClone(state)
   newState.pickIndex++
@@ -675,7 +698,8 @@ function computeScores(state) {
   if (pickerTeamPoints >= 91 || (!pickerWon && pickerTeamPoints <= 29)) baseMultiplier = 2  // schneider
   if (pickerTeamTricks === 6 || pickerTeamTricks === 0) baseMultiplier = 3  // schwarz
 
-  const multiplier = baseMultiplier * doublerMultiplier * (state.handCrackMultiplier ?? 1)
+  const blitzMultiplier = (state.blitzes?.length ?? 0) > 0 ? 2 : 1
+  const multiplier = baseMultiplier * doublerMultiplier * (state.handCrackMultiplier ?? 1) * blitzMultiplier
 
   const scores = {}
   for (const uid of Object.keys(state.hands)) scores[uid] = 0


### PR DESCRIPTION
Closes #26

## Summary

- Detects Black Blitz (QC+QS) and Red Blitz (QH+QD) at deal time for each player
- Blitzing player must pick up the blind — passing is blocked with an error
- Blitz doubles the hand stakes (×2 multiplier applied in scoring)
- Pick dialog shows **Black Blitz?** / **Red Blitz?** buttons alongside Pick the Blind? and Pass when the current player is eligible
- Picker's name shows a Black Blitz / Red Blitz badge for the duration of the hand
- Log records "X Black Blitzed!" / "X Red Blitzed!" when the player picks, not at deal time

## Test plan

- [ ] Deal hands until a player has QC+QS or QH+QD
- [ ] Verify that player cannot pass — server returns an error
- [ ] Verify Black Blitz? / Red Blitz? button appears in the pick dialog for the blitzing player
- [ ] Verify the badge appears next to the picker's name after they pick
- [ ] Verify the blitz log message appears on pick, not immediately after deal
- [ ] Verify hand stakes are doubled (check score deltas at end of hand)

🤖 Generated with [Claude Code](https://claude.com/claude-code)