### PR TITLE
Rename bots to test bots

### DIFF
--- a/frontend/src/pages/AccountManagementPage.jsx
+++ b/frontend/src/pages/AccountManagementPage.jsx
@@ -75,7 +75,7 @@ function UserRow({ user, currentUserId, onSaved, onDeleted }) {
         <td>
           {user.username}
           {isSelf && <span className="badge badge-you" style={{ marginLeft: 6 }}>you</span>}
-          {!!user.is_bot && <span className="badge" style={{ background: '#6b7280', color: '#fff', marginLeft: 6 }}>bot</span>}
+          {!!user.is_bot && <span className="badge" style={{ background: '#6b7280', color: '#fff', marginLeft: 6 }}>test bot</span>}
         </td>
         <td>{user.is_admin ? '✓' : '—'}</td>
         <td>{user.is_bot ? '✓' : '—'}</td>
@@ -255,10 +255,10 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
           <table style={{ width: '100%', tableLayout: 'fixed', fontSize: '0.78rem' }}>
               <colgroup>
                 <col style={{ width: '4%' }} />
-                <col style={{ width: '22%' }} />
+                <col style={{ width: '20%' }} />
                 <col style={{ width: '7%' }} />
-                <col style={{ width: '6%' }} />
-                <col style={{ width: '27%' }} />
+                <col style={{ width: '9%' }} />
+                <col style={{ width: '26%' }} />
                 <col style={{ width: '34%' }} />
               </colgroup>
               <thead>
@@ -266,7 +266,7 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
                   <SortTh col="id">ID</SortTh>
                   <SortTh col="username">Username</SortTh>
                   <SortTh col="is_admin">Admin</SortTh>
-                  <SortTh col="is_bot">Bot</SortTh>
+                  <SortTh col="is_bot">Test Bot</SortTh>
                   <SortTh col="created_at">Created / New password</SortTh>
                   <th>Actions</th>
                 </tr>

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -147,7 +147,7 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
                 <span>
                   <strong>Test mode</strong>
                   <small style={{ display: 'block', color: '#888', marginTop: 2 }}>
-                    Bots auto-fill seats. You can see all hands and play for bots. Max 1 active at a time.
+                    Test bots auto-fill seats. You can see all hands and play for test bots. Max 1 active at a time.
                   </small>
                 </span>
               </label>

--- a/functions/api/auth/login.js
+++ b/functions/api/auth/login.js
@@ -13,7 +13,7 @@ export async function onRequestPost({ request, env }) {
   ).bind(username).first()
 
   if (!user) return err('Invalid username or password.', 401)
-  if (user.is_bot) return err('Bot accounts cannot log in.', 403)
+  if (user.is_bot) return err('Test bot accounts cannot log in.', 403)
 
   const hash = await hashPassword(password, user.salt)
   if (hash !== user.password_hash) return err('Invalid username or password.', 401)

--- a/functions/api/games/index.js
+++ b/functions/api/games/index.js
@@ -98,7 +98,7 @@ async function createGame({ request, env }) {
       'SELECT id FROM users WHERE is_bot = 1 ORDER BY username LIMIT 4'
     ).all()
 
-    if (bots.length < 4) return err('Not enough bot accounts found. Run migrations to seed bots.', 500)
+    if (bots.length < 4) return err('Not enough test bot accounts found. Run migrations to seed test bots.', 500)
 
     const botStmts = bots.map((bot, i) =>
       env.DB.prepare('INSERT INTO game_players (game_id, user_id, seat) VALUES (?, ?, ?)')


### PR DESCRIPTION
## Summary
- Renames all user-facing "bot"/"Bot" labels to "test bot"/"Test Bot" across the UI and API error messages
- Widens the Test Bot column in the account management table to fit the new label
- Internal code and DB schema (`is_bot`) are unchanged

## Motivation
Prepares for an upcoming Play Bots feature — keeping the two types distinguishable in the UI from day one.

## Test plan
- [ ] Account management table shows "Test Bot" column header and "test bot" badge on bot accounts
- [ ] Lobby test mode description reads "Test bots auto-fill seats..."
- [ ] Attempting to log in as a bot account returns "Test bot accounts cannot log in."

🤖 Generated with [Claude Code](https://claude.com/claude-code)