### PR TITLE
Make blitzing optional (fixes #51)

### DIFF
--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -77,17 +77,17 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
         </div>
       )
     }
-    const playerBlitz = (state.blitzes ?? []).find(b => b.userId === myUserId)
+    const playerBlitz = (state.potentialBlitzes ?? []).find(b => b.userId === myUserId)
     return (
       <div className="action-panel" style={botStyle}>
         <h4>{turnLabel} — pick or pass?</h4>
         {doublerMultiplier > 1 && <p style={{ color: '#f59e0b' }}>⚠ Stakes are ×{doublerMultiplier}</p>}
         <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginTop: 8 }}>
           {playerBlitz?.type === 'black' && (
-            <button onClick={() => act('pick')} disabled={loading}>Black Blitz?</button>
+            <button onClick={() => act('blitz')} disabled={loading}>Black Blitz?</button>
           )}
           {playerBlitz?.type === 'red' && (
-            <button onClick={() => act('pick')} disabled={loading}>Red Blitz?</button>
+            <button onClick={() => act('blitz')} disabled={loading}>Red Blitz?</button>
           )}
           <button onClick={() => act('pick')} disabled={loading}>Pick the Blind?</button>
           <button className="secondary" onClick={() => act('pass')} disabled={loading}>Pass</button>

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -1,6 +1,6 @@
 import { json, err, requireUser, AuthError } from '../../_helpers.js'
 import {
-  pick, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
+  pick, blitz, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
   crack, recrack,
   setupLeaster, awardLeasterBlind, resolveLeaster,
   dealHand,
@@ -51,6 +51,10 @@ export async function onRequestPost({ request, env, params }) {
     switch (type) {
       case 'pick':
         state = pick(state, userId)
+        break
+
+      case 'blitz':
+        state = blitz(state, userId)
         break
 
       case 'pass':

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -81,16 +81,16 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     pickOrder.push(playerIds[(dealerSeat + i) % 5])
   }
 
-  // Detect blitzes: a player holding 2 queens of the same color must pick
-  const blitzes = []
+  // Detect potential blitzes: a player holding 2 queens of the same color may blitz
+  const potentialBlitzes = []
   for (const pid of playerIds) {
     const hand = hands[pid]
     const hasQC = hand.some(c => c.id === 'QC')
     const hasQS = hand.some(c => c.id === 'QS')
     const hasQH = hand.some(c => c.id === 'QH')
     const hasQD = hand.some(c => c.id === 'QD')
-    if (hasQC && hasQS) blitzes.push({ userId: pid, type: 'black' })
-    else if (hasQH && hasQD) blitzes.push({ userId: pid, type: 'red' })
+    if (hasQC && hasQS) potentialBlitzes.push({ userId: pid, type: 'black' })
+    else if (hasQH && hasQD) potentialBlitzes.push({ userId: pid, type: 'red' })
   }
 
   return {
@@ -121,7 +121,8 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     currentLeader: null,       // userId who leads next trick
     handCrackMultiplier: 1,    // 1 | 2 | 4 — crack/recrack multiplier for this hand only
     crackState: null,          // null | 'cracked' | 'recracked'
-    blitzes,                   // [{ userId, type: 'black'|'red' }] — players who must pick
+    potentialBlitzes,          // [{ userId, type: 'black'|'red' }] — players who may blitz
+    blitzes: [],               // [{ userId, type: 'black'|'red' }] — players who declared a blitz
     log: [],                   // string messages
     scores: {},                // { userId: delta } — populated at scoring
   }
@@ -139,13 +140,29 @@ export function pick(state, userId) {
   newState.hands[userId] = [...newState.hands[userId], ...newState.blind]
   newState.blind = []
   newState.phase = 'discarding'
+  newState.log.push(`${userId} picked.`)
 
-  const blitz = (newState.blitzes ?? []).find(b => b.userId === userId)
-  if (blitz) {
-    newState.log.push(`${userId} ${blitz.type === 'black' ? 'Black' : 'Red'} Blitzed!`)
-  } else {
-    newState.log.push(`${userId} picked.`)
+  return newState
+}
+
+export function blitz(state, userId) {
+  assertPhase(state, 'picking')
+  assertTurn(state, userId, currentPicker(state))
+
+  const potentialBlitz = (state.potentialBlitzes ?? []).find(b => b.userId === userId)
+  if (!potentialBlitz) {
+    throw new Error('Cannot blitz — you do not hold 2 queens of the same color.')
   }
+
+  const newState = deepClone(state)
+  newState.picker = userId
+  newState.blitzes = [...(newState.blitzes ?? []), { userId, type: potentialBlitz.type }]
+
+  // Give picker the blind
+  newState.hands[userId] = [...newState.hands[userId], ...newState.blind]
+  newState.blind = []
+  newState.phase = 'discarding'
+  newState.log.push(`${userId} ${potentialBlitz.type === 'black' ? 'Black' : 'Red'} Blitzed!`)
 
   return newState
 }
@@ -153,11 +170,6 @@ export function pick(state, userId) {
 export function pass(state, userId) {
   assertPhase(state, 'picking')
   assertTurn(state, userId, currentPicker(state))
-
-  const blitz = (state.blitzes ?? []).find(b => b.userId === userId)
-  if (blitz) {
-    throw new Error(`Cannot pass — you ${blitz.type === 'black' ? 'Black' : 'Red'} Blitzed and must pick.`)
-  }
 
   const newState = deepClone(state)
   newState.pickIndex++


### PR DESCRIPTION
## Summary

- Splits blitz detection into `potentialBlitzes` (set at deal time for any player holding 2 queens of the same color) and `blitzes` (populated only when a player actively declares a blitz)
- Removes the `pass()` enforcement that blocked blitz-eligible players from passing
- Adds a new `blitz` game action — distinct from `pick` — that picks the blind and declares the blitz
- The 2x scoring multiplier now only applies when the picker explicitly blitzed; picking normally while holding qualifying queens gets no multiplier
- Frontend "Black Blitz?" / "Red Blitz?" buttons now send `blitz` action; "Pick the Blind?" always sends `pick`

## Test plan

- [ ] Player holding QC+QS or QH+QD sees both blitz button and "Pick the Blind?" button
- [ ] Clicking "Black/Red Blitz?" picks the blind, logs "X Black/Red Blitzed!", and applies 2x multiplier at scoring
- [ ] Clicking "Pick the Blind?" picks normally with no blitz multiplier
- [ ] Player holding qualifying queens can pass — no error
- [ ] Player without qualifying queens cannot send `blitz` action (backend throws)
- [ ] Blitz badge shows on picker's seat only when they declared a blitz

🤖 Generated with [Claude Code](https://claude.com/claude-code)