### PR TITLE
Implement Schwanzers no-pick variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Note: the Queen of Diamonds scores as a queen (3 points), and the Jack of Diamon
 
 The player with the **most** Schwanzer points in their hand is the Schwanzer: they lose 4 points, and all other players gain 1 point.
 
-**Tie-break:** If two or more players are tied for the most points, the player holding the most powerful trump card (Queen of Clubs > Queen of Spades > … > 7 of Diamonds) loses. If all tied players hold no trump, the first tied player in seat order loses.
+**Tie-break:** If two or more players are tied for the most points, the player holding the most powerful trump card (Queen of Clubs > Queen of Spades > … > 7 of Diamonds) loses. If all tied players hold no trump, the first tied player in pick order loses.
 
 The blind cards are not scored — only each player's 6 dealt cards count.
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,25 @@ The final multiplier is: `base × doubler × crack`.
 
 When all five players pass, a Leaster is played. There is no picker or partner — everyone plays for themselves. The blind cards are awarded to the winner of the first trick. The player who takes at least one trick and ends with the **fewest points** wins. The winner gains 4 points; all others lose 1 point.
 
+### Schwanzer
+
+When all five players pass and the no-pick variant is set to Schwanzers, hands are scored immediately — no tricks are played. Each player's dealt hand is scored using the following point scheme:
+
+| Card | Schwanzer Points |
+|------|-----------------|
+| Queen (any suit) | 3 |
+| Jack (any suit) | 2 |
+| Diamond pip (Ace, 10, King, 9, 8, 7 of Diamonds) | 1 |
+| All other cards | 0 |
+
+Note: the Queen of Diamonds scores as a queen (3 points), and the Jack of Diamonds scores as a jack (2 points) — not as diamond pips.
+
+The player with the **most** Schwanzer points in their hand is the Schwanzer: they lose 4 points, and all other players gain 1 point.
+
+**Tie-break:** If two or more players are tied for the most points, the player holding the most powerful trump card (Queen of Clubs > Queen of Spades > … > 7 of Diamonds) loses. If all tied players hold no trump, the first tied player in seat order loses.
+
+The blind cards are not scored — only each player's 6 dealt cards count.
+
 ---
 
 > **Maintainer note:** When rules change in `shared/gameEngine.js`, update the Rules section of this file to match.

--- a/docs/superpowers/plans/2026-04-12-schwanzers.md
+++ b/docs/superpowers/plans/2026-04-12-schwanzers.md
@@ -1,0 +1,573 @@
+# Schwanzers Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Schwanzers as a third no-pick variant — when all five players pass, each player's hand is scored using a trump-based point scheme (Q=3, J=2, diamond pip=1), the player with the most points loses 4, all others gain 1, and the next hand is dealt immediately.
+
+**Architecture:** Immediate resolution within the `pass` action handler — no new game phase, no trick-playing, no UI overlay. `resolveSchwanzer` in the game engine computes scores from dealt hands, `finishHand` (unchanged) writes score events and deals the next hand. The frontend exposes the variant in the admin settings radio group; the game log communicates the result.
+
+**Tech Stack:** Vanilla JS ES modules (game engine), Cloudflare Pages Functions (API), React 18 / Vite (frontend), Vitest (test runner)
+
+---
+
+## File Map
+
+| Action | File |
+|--------|------|
+| Create | `shared/gameEngine.test.js` |
+| Modify | `shared/gameEngine.js` |
+| Modify | `functions/api/games/[id]/settings.js` |
+| Modify | `functions/api/games/[id]/action.js` |
+| Modify | `frontend/src/pages/GamePage.jsx` |
+| Modify | `README.md` |
+| Modify | `package.json` (root) |
+
+---
+
+## Task 1: Set up Vitest
+
+The project has no test runner. Vitest integrates naturally with the ES module codebase.
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install vitest at the root workspace**
+
+```bash
+npm install --save-dev vitest
+```
+
+- [ ] **Step 2: Add test script to root `package.json`**
+
+Open `package.json`. Add `"test": "vitest run"` to the `scripts` block:
+
+```json
+"scripts": {
+  "dev": "concurrently -n frontend,wrangler -c cyan,yellow \"npm run dev:frontend\" \"npm run dev:wrangler\"",
+  "dev:frontend": "npm run dev -w frontend",
+  "dev:wrangler": "wrangler pages dev --port 8788",
+  "build": "npm run build -w frontend",
+  "deploy": "npm run build && wrangler pages deploy frontend/dist",
+  "db:migrate:local": "wrangler d1 migrations apply sheepshead-db --local",
+  "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote",
+  "test": "vitest run",
+  "postinstall": "git config core.hooksPath .githooks"
+},
+```
+
+- [ ] **Step 3: Verify vitest runs (no tests yet)**
+
+```bash
+npm test
+```
+
+Expected output: `No test files found` or similar — exit 0 is fine. If it errors, check that `vitest` appears in `node_modules/.bin/`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git checkout -b feature/schwanzers
+git add package.json package-lock.json
+git commit -m "chore: add vitest test runner"
+```
+
+---
+
+## Task 2: Test and implement `schwanzerCardPoints`
+
+A pure helper with no dependencies on state.
+
+**Files:**
+- Create: `shared/gameEngine.test.js`
+- Modify: `shared/gameEngine.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `shared/gameEngine.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { schwanzerCardPoints } from './gameEngine.js'
+
+const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
+
+describe('schwanzerCardPoints', () => {
+  it('returns 3 for any queen', () => {
+    expect(schwanzerCardPoints(c('Q', 'C'))).toBe(3)
+    expect(schwanzerCardPoints(c('Q', 'S'))).toBe(3)
+    expect(schwanzerCardPoints(c('Q', 'H'))).toBe(3)
+    expect(schwanzerCardPoints(c('Q', 'D'))).toBe(3)  // QD is a queen, not a diamond pip
+  })
+
+  it('returns 2 for any jack', () => {
+    expect(schwanzerCardPoints(c('J', 'C'))).toBe(2)
+    expect(schwanzerCardPoints(c('J', 'S'))).toBe(2)
+    expect(schwanzerCardPoints(c('J', 'H'))).toBe(2)
+    expect(schwanzerCardPoints(c('J', 'D'))).toBe(2)  // JD is a jack, not a diamond pip
+  })
+
+  it('returns 1 for diamond pip cards (non-Q, non-J diamonds)', () => {
+    expect(schwanzerCardPoints(c('A',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('10', 'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('K',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('9',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('8',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('7',  'D'))).toBe(1)
+  })
+
+  it('returns 0 for non-trump fail cards', () => {
+    expect(schwanzerCardPoints(c('A',  'C'))).toBe(0)
+    expect(schwanzerCardPoints(c('10', 'H'))).toBe(0)
+    expect(schwanzerCardPoints(c('K',  'S'))).toBe(0)
+    expect(schwanzerCardPoints(c('9',  'C'))).toBe(0)
+    expect(schwanzerCardPoints(c('8',  'H'))).toBe(0)
+    expect(schwanzerCardPoints(c('7',  'S'))).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+npm test
+```
+
+Expected: `schwanzerCardPoints is not a function` or similar import error.
+
+- [ ] **Step 3: Add `schwanzerCardPoints` to `shared/gameEngine.js`**
+
+Open `shared/gameEngine.js`. Find the existing `cardPoints` function (around line 43):
+
+```js
+// Point value of a card
+const POINT_VALUES = { A: 11, '10': 10, K: 4, Q: 3, J: 2 }
+export function cardPoints(card) {
+  return POINT_VALUES[card.rank] ?? 0
+}
+```
+
+Add immediately after it:
+
+```js
+// Schwanzer point value — used only when scoring a Schwanzer no-pick hand
+// Queens=3, Jacks=2, diamond pips (non-Q, non-J, suit=D)=1, all else=0
+export function schwanzerCardPoints(card) {
+  if (card.rank === 'Q') return 3
+  if (card.rank === 'J') return 2
+  if (card.suit === 'D') return 1
+  return 0
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+npm test
+```
+
+Expected: all `schwanzerCardPoints` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/gameEngine.js shared/gameEngine.test.js
+git commit -m "feat: add schwanzerCardPoints"
+```
+
+---
+
+## Task 3: Test and implement `resolveSchwanzer`
+
+**Files:**
+- Modify: `shared/gameEngine.test.js`
+- Modify: `shared/gameEngine.js`
+
+- [ ] **Step 1: Add the failing tests to `shared/gameEngine.test.js`**
+
+Append after the existing `schwanzerCardPoints` describe block:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { schwanzerCardPoints, resolveSchwanzer } from './gameEngine.js'
+```
+
+Update the import at the top of the file to include `resolveSchwanzer`:
+
+```js
+import { schwanzerCardPoints, resolveSchwanzer } from './gameEngine.js'
+```
+
+Then append this describe block at the end of the file:
+
+```js
+// ─── helpers for resolveSchwanzer tests ──────────────────────────────────────
+// Build a minimal state object — only the fields resolveSchwanzer reads
+function makeState(hands, pickOrder) {
+  return { hands, pickOrder, log: [] }
+}
+
+describe('resolveSchwanzer', () => {
+  it('identifies the player with the most schwanzer points as the loser', () => {
+    const hands = {
+      p1: [c('Q','C'), c('7','C'), c('8','C'), c('9','C'), c('A','C'), c('10','C')],  // 3 pts
+      p2: [c('Q','S'), c('Q','H'), c('7','S'), c('8','S'), c('9','S'), c('A','S')],   // 6 pts → loses
+      p3: [c('J','C'), c('7','H'), c('8','H'), c('9','H'), c('A','H'), c('10','H')],  // 2 pts
+      p4: [c('7','C'), c('8','C'), c('9','S'), c('A','S'), c('10','S'), c('K','S')],  // 0 pts
+      p5: [c('K','C'), c('A','H'), c('10','C'), c('K','H'), c('A','C'), c('K','S')],  // 0 pts
+    }
+    const { loser, scores } = resolveSchwanzer(makeState(hands, ['p1','p2','p3','p4','p5']))
+    expect(loser).toBe('p2')
+    expect(scores.p2).toBe(-4)
+    expect(scores.p1).toBe(1)
+    expect(scores.p3).toBe(1)
+    expect(scores.p4).toBe(1)
+    expect(scores.p5).toBe(1)
+  })
+
+  it('tie-break: tied player with the most powerful trump loses', () => {
+    // p1 has QC (TRUMP_ORDER index 0) — most powerful trump → loses
+    // p2 has QS (TRUMP_ORDER index 1) — less powerful
+    // both have 3 schwanzer points
+    const hands = {
+      p1: [c('Q','C'), c('7','S'), c('8','S'), c('9','S'), c('A','S'), c('10','S')],  // 3 pts, trump=QC(idx 0)
+      p2: [c('Q','S'), c('7','H'), c('8','H'), c('9','H'), c('A','H'), c('10','H')],  // 3 pts, trump=QS(idx 1)
+      p3: [c('K','C'), c('A','C'), c('10','C'), c('K','H'), c('A','H'), c('K','S')],  // 0 pts
+      p4: [c('7','C'), c('8','C'), c('9','C'), c('K','H'), c('A','S'), c('10','S')],  // 0 pts (duplicate ok in test)
+      p5: [c('8','H'), c('9','H'), c('10','H'), c('7','S'), c('9','S'), c('K','S')],  // 0 pts
+    }
+    const { loser } = resolveSchwanzer(makeState(hands, ['p1','p2','p3','p4','p5']))
+    expect(loser).toBe('p1')  // QC is more powerful than QS
+  })
+
+  it('fallback tie-break: when tied players hold no trump, first in pickOrder loses', () => {
+    // All players have 0 schwanzer points — no Q, J, or D cards in any hand
+    const noTrumpHand = [c('A','C'), c('10','C'), c('K','C'), c('A','H'), c('10','H'), c('K','H')]
+    const hands = {
+      p1: noTrumpHand,
+      p2: noTrumpHand,
+      p3: noTrumpHand,
+      p4: noTrumpHand,
+      p5: noTrumpHand,
+    }
+    // p2 is first in pickOrder → p2 loses
+    const { loser } = resolveSchwanzer(makeState(hands, ['p2','p1','p3','p4','p5']))
+    expect(loser).toBe('p2')
+  })
+
+  it('pushes a log entry naming the loser and listing point totals', () => {
+    const hands = {
+      p1: [c('Q','C'), c('7','C'), c('8','C'), c('9','C'), c('A','C'), c('10','C')],  // 3 pts
+      p2: [c('7','S'), c('8','S'), c('9','S'), c('A','S'), c('10','S'), c('K','S')],  // 0 pts
+      p3: [c('7','H'), c('8','H'), c('9','H'), c('A','H'), c('10','H'), c('K','H')],  // 0 pts
+      p4: [c('K','C'), c('A','H'), c('10','C'), c('K','H'), c('9','C'), c('8','H')],  // 0 pts
+      p5: [c('8','C'), c('9','S'), c('K','S'), c('A','C'), c('10','H'), c('K','C')],  // 0 pts
+    }
+    const state = makeState(hands, ['p1','p2','p3','p4','p5'])
+    resolveSchwanzer(state)
+    expect(state.log.length).toBe(1)
+    expect(state.log[0]).toContain('p1')
+    expect(state.log[0]).toContain('loses')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests — verify the new tests fail**
+
+```bash
+npm test
+```
+
+Expected: `resolveSchwanzer is not a function` or similar.
+
+- [ ] **Step 3: Add `resolveSchwanzer` to `shared/gameEngine.js`**
+
+Open `shared/gameEngine.js`. Find the `resolveLeaster` function (around line 762). Add the following block immediately after `resolveLeaster`:
+
+```js
+// ─── Schwanzer ────────────────────────────────────────────────────────────────
+// No tricks are played. Each player's dealt hand is scored using Schwanzer point
+// values. The player with the most points is the loser (-4); all others gain +1.
+// Tie-break: most powerful trump (lowest TRUMP_ORDER index) loses.
+// Fallback: if all tied players hold no trump, first tied player in pickOrder loses.
+export function resolveSchwanzer(state) {
+  const pointsByPlayer = {}
+  for (const [uid, hand] of Object.entries(state.hands)) {
+    pointsByPlayer[uid] = hand.reduce((sum, card) => sum + schwanzerCardPoints(card), 0)
+  }
+
+  const maxPoints = Math.max(...Object.values(pointsByPlayer))
+  // Preserve pickOrder sequence so fallback tie-break is deterministic
+  const tied = state.pickOrder.filter(uid => pointsByPlayer[uid] === maxPoints)
+
+  function bestTrumpIndex(uid) {
+    const trumps = state.hands[uid].filter(c => isTrump(c))
+    if (trumps.length === 0) return TRUMP_ORDER.length  // no trump → least powerful
+    return Math.min(...trumps.map(c => trumpRank(c)))
+  }
+
+  // Among tied players: lowest trump index (most powerful) loses.
+  // pickOrder preserves insertion order, so the first element wins the fallback.
+  const loser = tied.reduce((worst, uid) =>
+    bestTrumpIndex(uid) < bestTrumpIndex(worst) ? uid : worst
+  )
+
+  const scores = {}
+  for (const uid of Object.keys(state.hands)) {
+    scores[uid] = uid === loser ? -4 : 1
+  }
+
+  const breakdown = state.pickOrder
+    .map(uid => `${uid}: ${pointsByPlayer[uid]}pts`)
+    .join(', ')
+  state.log.push(`Schwanzer! Points — ${breakdown}. ${loser} had the most and loses.`)
+
+  return { loser, scores }
+}
+```
+
+- [ ] **Step 4: Run all tests — verify they pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass, including `schwanzerCardPoints` tests from Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/gameEngine.js shared/gameEngine.test.js
+git commit -m "feat: add resolveSchwanzer to game engine"
+```
+
+---
+
+## Task 4: Allow `'schwanzers'` in the settings API
+
+**Files:**
+- Modify: `functions/api/games/[id]/settings.js`
+
+- [ ] **Step 1: Open `functions/api/games/[id]/settings.js` and find the validation check on line 21**
+
+Current code:
+```js
+if (no_pick_variant !== undefined && !['leasters', 'doublers'].includes(no_pick_variant)) {
+  return err('no_pick_variant must be "leasters" or "doublers".')
+}
+```
+
+- [ ] **Step 2: Add `'schwanzers'` to the allowed values**
+
+```js
+if (no_pick_variant !== undefined && !['leasters', 'doublers', 'schwanzers'].includes(no_pick_variant)) {
+  return err('no_pick_variant must be "leasters", "doublers", or "schwanzers".')
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add functions/api/games/[id]/settings.js
+git commit -m "feat: allow schwanzers as a valid no-pick variant in settings API"
+```
+
+---
+
+## Task 5: Resolve Schwanzers in the action handler
+
+**Files:**
+- Modify: `functions/api/games/[id]/action.js`
+
+- [ ] **Step 1: Open `functions/api/games/[id]/action.js` and update the import**
+
+Current import (line 1–7):
+```js
+import {
+  pick, blitz, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
+  crack, recrack,
+  setupLeaster, awardLeasterBlind, resolveLeaster,
+  dealHand,
+} from '../../../../shared/gameEngine.js'
+```
+
+Add `resolveSchwanzer`:
+```js
+import {
+  pick, blitz, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
+  crack, recrack,
+  setupLeaster, awardLeasterBlind, resolveLeaster,
+  resolveSchwanzer,
+  dealHand,
+} from '../../../../shared/gameEngine.js'
+```
+
+- [ ] **Step 2: Add the Schwanzers branch in the `pass` case**
+
+Find the `pass` case (around line 62). The current structure is:
+
+```js
+case 'pass':
+  state = pass(state, userId)
+  if (state.phase === 'no_pick') {
+    const freshGame = await env.DB.prepare('SELECT no_pick_variant FROM games WHERE id = ?').bind(gameId).first()
+    if (freshGame.no_pick_variant === 'leasters') {
+      state = setupLeaster(state)
+    } else {
+      const newMultiplier = state.doublerMultiplier * 2
+      // ... doublers logic ...
+    }
+  }
+  break
+```
+
+Add the `schwanzers` branch between `leasters` and the `else` (doublers):
+
+```js
+case 'pass':
+  state = pass(state, userId)
+  if (state.phase === 'no_pick') {
+    const freshGame = await env.DB.prepare('SELECT no_pick_variant FROM games WHERE id = ?').bind(gameId).first()
+    if (freshGame.no_pick_variant === 'leasters') {
+      state = setupLeaster(state)
+    } else if (freshGame.no_pick_variant === 'schwanzers') {
+      const { scores } = resolveSchwanzer(state)
+      state.scores = scores
+      state.phase = 'scoring'
+      state = await finishHand(env.DB, gameId, state)
+    } else {
+      const newMultiplier = state.doublerMultiplier * 2
+      const { results: players } = await env.DB.prepare(
+        'SELECT user_id FROM game_players WHERE game_id = ? ORDER BY seat'
+      ).bind(gameId).all()
+      const playerIds = players.map(p => String(p.user_id))
+      const nextDealer = (state.dealerSeat + 1) % 5
+      state = dealHand(playerIds, nextDealer, state.handNumber + 1, newMultiplier)
+      state.doublerMultiplier = newMultiplier
+      state.log.push(`Doubler! Stakes are now ×${newMultiplier}.`)
+
+      await env.DB.prepare(
+        "UPDATE games SET doubler_multiplier = ?, updated_at = datetime('now') WHERE id = ?"
+      ).bind(newMultiplier, gameId).run()
+    }
+  }
+  break
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "functions/api/games/[id]/action.js"
+git commit -m "feat: resolve schwanzers immediately when all players pass"
+```
+
+---
+
+## Task 6: Add Schwanzers to the frontend admin settings
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Update `VARIANT_LABELS` on line 11**
+
+Current:
+```js
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers' }
+```
+
+Replace with:
+```js
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
+```
+
+- [ ] **Step 2: Update the radio group array in `AdminSettingsPanel` (around line 93)**
+
+Current:
+```js
+{['leasters', 'doublers'].map(v => (
+```
+
+Replace with:
+```js
+{['leasters', 'doublers', 'schwanzers'].map(v => (
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add frontend/src/pages/GamePage.jsx
+git commit -m "feat: add schwanzers option to admin settings panel"
+```
+
+---
+
+## Task 7: Document Schwanzer rules in README
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Open `README.md` and find the Leaster section (around line 116)**
+
+Current ending of the Leaster section:
+```markdown
+### Leaster
+
+When all five players pass, a Leaster is played. There is no picker or partner — everyone plays for themselves. The blind cards are awarded to the winner of the first trick. The player who takes at least one trick and ends with the **fewest points** wins. The winner gains 4 points; all others lose 1 point.
+
+---
+```
+
+- [ ] **Step 2: Add the Schwanzer section after the Leaster section, before the `---`**
+
+```markdown
+### Schwanzer
+
+When all five players pass and the no-pick variant is set to Schwanzers, hands are scored immediately — no tricks are played. Each player's dealt hand is scored using the following point scheme:
+
+| Card | Schwanzer Points |
+|------|-----------------|
+| Queen (any suit) | 3 |
+| Jack (any suit) | 2 |
+| Diamond pip (Ace, 10, King, 9, 8, 7 of Diamonds) | 1 |
+| All other cards | 0 |
+
+Note: the Queen of Diamonds scores as a queen (3 points), and the Jack of Diamonds scores as a jack (2 points) — not as diamond pips.
+
+The player with the **most** Schwanzer points in their hand is the Schwanzer: they lose 4 points, and all other players gain 1 point.
+
+**Tie-break:** If two or more players are tied for the most points, the player holding the most powerful trump card (Queen of Clubs > Queen of Spades > … > 7 of Diamonds) loses. If all tied players hold no trump, the first tied player in seat order loses.
+
+The blind cards are not scored — only each player's 6 dealt cards count.
+```
+
+- [ ] **Step 3: Run a quick sanity check**
+
+```bash
+grep -n "Schwanzer" README.md
+```
+
+Expected: several lines matching, including the section heading, table, and tie-break rule.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add Schwanzer rules to README"
+```
+
+---
+
+## Manual Verification Checklist
+
+After all tasks are complete, verify end-to-end in the dev environment:
+
+```bash
+npm run dev
+```
+
+- [ ] In the admin settings panel (waiting lobby or active game), "Schwanzers" appears as a third radio option
+- [ ] Selecting Schwanzers saves correctly (check network tab → PATCH `/api/games/:id/settings` returns `no_pick_variant: "schwanzers"`)
+- [ ] Start a test game, set variant to Schwanzers, have all 5 players pass
+- [ ] The game immediately advances to the next hand (no trick-playing)
+- [ ] The game log contains a "Schwanzer!" entry naming the loser and showing per-player point totals
+- [ ] The scoreboard shows -4 for the loser and +1 for all others
+- [ ] The `doubler_multiplier` resets to 1 for the next hand

--- a/docs/superpowers/specs/2026-04-12-schwanzers-design.md
+++ b/docs/superpowers/specs/2026-04-12-schwanzers-design.md
@@ -1,0 +1,129 @@
+# Schwanzers Design
+
+**Date:** 2026-04-12
+**Issue:** #50
+**Status:** Approved
+
+---
+
+## Overview
+
+Implement Schwanzers as a third no-pick variant alongside Leasters and Doublers. When all five players pass and the game's `no_pick_variant` is set to `schwanzers`, hands are scored immediately using a trump-based point scheme — no tricks are played. The player with the most Schwanzer points loses; all others gain.
+
+---
+
+## Point Scheme
+
+| Card | Schwanzer Points |
+|------|-----------------|
+| Queen (any suit) | 3 |
+| Jack (any suit) | 2 |
+| Diamond pip (non-Q, non-J, suit=D) | 1 |
+| All other cards | 0 |
+
+Total Schwanzer points in the 32-card deck: 26 (4Q×3 + 4J×2 + 6 pip diamonds×1).
+
+Note: QD and JD score as queen (3) and jack (2) respectively — not as diamond pips.
+
+---
+
+## Resolution Rules
+
+1. Sum each player's Schwanzer points from their 6 dealt cards.
+2. The player with the **most** points is the Schwanzer (loser).
+3. **Tie-break:** Among tied players, the one holding the most powerful trump (lowest index in `TRUMP_ORDER`) loses.
+4. **Fallback tie-break:** If all tied players hold no trump, the first tied player in `pickOrder` loses.
+5. **The blind is excluded** — it is not in anyone's hand and is not scored.
+6. **No multiplier** — scoring is flat: loser gets −4, all others get +1. The doubler multiplier does not apply (same as Leasters).
+
+---
+
+## Architecture
+
+### `shared/gameEngine.js`
+
+Add two exported functions:
+
+**`schwanzerCardPoints(card)`**
+```
+if rank === 'Q' → 3
+if rank === 'J' → 2
+if suit === 'D' → 1   (catches AD, 10D, KD, 9D, 8D, 7D — Qs and Js already handled)
+else → 0
+```
+
+**`resolveSchwanzer(state)`**
+- Compute points per player from `state.hands`
+- Identify loser (max points, tie-break by best trump in TRUMP_ORDER, fallback to pickOrder)
+- Build `scores` object: loser → −4, all others → +1
+- Push a log line listing each player's totals and naming the loser
+- Return `{ loser, scores }`
+
+### `functions/api/games/[id]/action.js`
+
+In the `pass` case, add a Schwanzers branch after the Leasters branch:
+
+```js
+const freshGame = await env.DB.prepare('SELECT no_pick_variant FROM games WHERE id = ?').bind(gameId).first()
+if (freshGame.no_pick_variant === 'leasters') {
+  state = setupLeaster(state)
+} else if (freshGame.no_pick_variant === 'schwanzers') {
+  const { scores } = resolveSchwanzer(state)
+  state.scores = scores
+  state.phase = 'scoring'
+  state = await finishHand(env.DB, gameId, state)
+} else {
+  // doublers: double multiplier and re-deal
+  ...
+}
+```
+
+`finishHand` requires no changes. When `state.isLeaster` is false and `state.scores` is already set, it uses those scores directly, writes `score_events` to the DB, resets `doubler_multiplier` to 1, and deals the next hand.
+
+Import `resolveSchwanzer` alongside the existing engine imports.
+
+### `functions/api/games/[id]/settings.js`
+
+Extend the valid values check:
+```js
+// Before:
+!['leasters', 'doublers'].includes(no_pick_variant)
+// After:
+!['leasters', 'doublers', 'schwanzers'].includes(no_pick_variant)
+```
+
+### `frontend/src/pages/GamePage.jsx`
+
+Two small changes:
+
+1. Add to `VARIANT_LABELS`:
+   ```js
+   const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
+   ```
+
+2. Add `'schwanzers'` to the radio group array in `AdminSettingsPanel`:
+   ```js
+   {['leasters', 'doublers', 'schwanzers'].map(v => ( ... ))}
+   ```
+
+No changes to `ActionPanel` — Schwanzers resolves entirely within the `pass` action; the game never enters a phase requiring player input during a Schwanzer hand. The game log is the player-facing result.
+
+### `README.md`
+
+Add a Schwanzer section after the Leaster section describing the rules, point scheme, and scoring.
+
+---
+
+## What Is Not Changing
+
+- No new game phase — Schwanzers resolves immediately in the `pass` handler.
+- No scoring overlay or badge — the game log communicates the result.
+- No DB migration required — `no_pick_variant` is a TEXT column with no constraint.
+- No changes to trick-playing, cracking, or any other game phase.
+
+---
+
+## Out of Scope
+
+- Multiplier interaction with accumulated doublers (Schwanzers resets to ×1, same as Leasters).
+- Blind card inclusion in scoring (blind is excluded; only dealt hands count).

--- a/docs/superpowers/specs/2026-04-12-schwanzers-plan.md
+++ b/docs/superpowers/specs/2026-04-12-schwanzers-plan.md
@@ -1,0 +1,150 @@
+# Schwanzers Implementation Plan
+
+**Spec:** `2026-04-12-schwanzers-design.md`
+**Issue:** #50
+
+---
+
+## Step 1 — Game engine: add `schwanzerCardPoints` and `resolveSchwanzer`
+
+**File:** `shared/gameEngine.js`
+
+Add after the existing `cardPoints` function:
+
+```js
+// Schwanzer point value of a card (used only in Schwanzer no-pick hands)
+// Queens=3, Jacks=2, diamond pips (non-Q, non-J diamonds)=1, all else=0
+export function schwanzerCardPoints(card) {
+  if (card.rank === 'Q') return 3
+  if (card.rank === 'J') return 2
+  if (card.suit === 'D') return 1
+  return 0
+}
+```
+
+Add after the `resolveLeaster` function:
+
+```js
+// ─── Schwanzer ────────────────────────────────────────────────────────────────
+// No tricks are played. Each player's 6 dealt cards are scored using Schwanzer
+// point values. The player with the most points loses 4; all others gain 1.
+// Tie-break: most powerful trump (lowest TRUMP_ORDER index) loses.
+// Fallback: first tied player in pickOrder loses.
+export function resolveSchwanzer(state) {
+  const pointsByPlayer = {}
+  for (const [uid, hand] of Object.entries(state.hands)) {
+    pointsByPlayer[uid] = hand.reduce((sum, card) => sum + schwanzerCardPoints(card), 0)
+  }
+
+  const maxPoints = Math.max(...Object.values(pointsByPlayer))
+  const tied = state.pickOrder.filter(uid => pointsByPlayer[uid] === maxPoints)
+
+  // Tie-break by most powerful trump held (lowest TRUMP_ORDER index = most powerful)
+  function bestTrumpIndex(uid) {
+    const trumps = state.hands[uid].filter(c => isTrump(c))
+    if (trumps.length === 0) return TRUMP_ORDER.length  // no trump → least powerful
+    return Math.min(...trumps.map(c => trumpRank(c)))
+  }
+
+  const loser = tied.reduce((worst, uid) =>
+    bestTrumpIndex(uid) < bestTrumpIndex(worst) ? uid : worst
+  )
+
+  const scores = {}
+  for (const uid of Object.keys(state.hands)) {
+    scores[uid] = uid === loser ? -4 : 1
+  }
+
+  const breakdown = state.pickOrder
+    .map(uid => `${uid}: ${pointsByPlayer[uid]}pts`)
+    .join(', ')
+  state.log.push(`Schwanzer! Points — ${breakdown}. ${loser} had the most and loses.`)
+
+  return { loser, scores }
+}
+```
+
+---
+
+## Step 2 — Settings API: allow `'schwanzers'` as a valid variant
+
+**File:** `functions/api/games/[id]/settings.js`
+
+Change:
+```js
+if (no_pick_variant !== undefined && !['leasters', 'doublers'].includes(no_pick_variant)) {
+```
+To:
+```js
+if (no_pick_variant !== undefined && !['leasters', 'doublers', 'schwanzers'].includes(no_pick_variant)) {
+```
+
+---
+
+## Step 3 — Action handler: resolve Schwanzers on all-pass
+
+**File:** `functions/api/games/[id]/action.js`
+
+1. Add `resolveSchwanzer` to the import from `gameEngine.js`.
+
+2. In the `pass` case, add the Schwanzers branch:
+
+```js
+if (freshGame.no_pick_variant === 'leasters') {
+  state = setupLeaster(state)
+} else if (freshGame.no_pick_variant === 'schwanzers') {
+  const { scores } = resolveSchwanzer(state)
+  state.scores = scores
+  state.phase = 'scoring'
+  state = await finishHand(env.DB, gameId, state)
+} else {
+  // doublers (existing code)
+  ...
+}
+```
+
+---
+
+## Step 4 — Frontend: add Schwanzers to variant labels and admin radio
+
+**File:** `frontend/src/pages/GamePage.jsx`
+
+1. Update `VARIANT_LABELS`:
+```js
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
+```
+
+2. Update the radio group in `AdminSettingsPanel`:
+```js
+{['leasters', 'doublers', 'schwanzers'].map(v => ( ... ))}
+```
+
+---
+
+## Step 5 — README: document Schwanzer rules
+
+**File:** `README.md`
+
+Add a `### Schwanzer` section after the Leaster section:
+
+- Triggered when all five players pass and the no-pick variant is set to Schwanzers
+- No tricks are played — each player's dealt hand is scored immediately
+- Point scheme: Q=3, J=2, diamond pip=1
+- The player with the most Schwanzer points loses 4; all others gain 1
+- Tie-break: most powerful trump (QC > QS > … > 7D) loses; if none, first in seat order
+
+---
+
+## Verification Checklist
+
+- [ ] `schwanzerCardPoints` returns 3/2/1/0 for Q/J/pip-D/other; QD=3, JD=2
+- [ ] `resolveSchwanzer` correctly identifies max-points player
+- [ ] Tie-break: player with more powerful trump loses
+- [ ] Fallback tie-break: first in pickOrder wins when no trump held by any tied player
+- [ ] Blind cards are excluded from scoring (only `state.hands` used)
+- [ ] Scores written to `score_events` table (handled by `finishHand`)
+- [ ] Next hand dealt immediately after Schwanzer resolves
+- [ ] `doubler_multiplier` resets to 1 after Schwanzer (handled by `finishHand`)
+- [ ] Settings API accepts `'schwanzers'` and rejects anything else
+- [ ] Admin radio shows all three variants; non-admin label shows correct name
+- [ ] Game log clearly names the loser and their point total

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -8,7 +8,7 @@ import GameLog from '../components/GameLog.jsx'
 import ScoreBoard from '../components/ScoreBoard.jsx'
 
 const SUIT_SYMBOLS   = { C: '♣', D: '♦', H: '♥', S: '♠' }
-const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers' }
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
 
 // ── Seat layout (you at bottom, 4 opponents around the arc) ──────────────────
 // 5-seat positions: bottom, left, top-left, top-right, right
@@ -90,7 +90,7 @@ function AdminSettingsPanel({ gameId, currentVariant, revealPartner, onUpdated }
       <div style={{ marginBottom: 8 }}>
         <div style={{ color: '#ccc', marginBottom: 4 }}>No-pick variant:</div>
         <div style={{ display: 'flex', gap: 8 }}>
-          {['leasters', 'doublers'].map(v => (
+          {['leasters', 'doublers', 'schwanzers'].map(v => (
             <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
               <input type="radio" name={`variant-${gameId}`} value={v}
                 checked={variant === v} onChange={() => handleVariantChange(v)} disabled={saving} />

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -3,6 +3,7 @@ import {
   pick, blitz, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
   crack, recrack,
   setupLeaster, awardLeasterBlind, resolveLeaster,
+  resolveSchwanzer,
   dealHand,
 } from '../../../../shared/gameEngine.js'
 
@@ -64,6 +65,11 @@ export async function onRequestPost({ request, env, params }) {
           const freshGame = await env.DB.prepare('SELECT no_pick_variant FROM games WHERE id = ?').bind(gameId).first()
           if (freshGame.no_pick_variant === 'leasters') {
             state = setupLeaster(state)
+          } else if (freshGame.no_pick_variant === 'schwanzers') {
+            const { scores } = resolveSchwanzer(state)
+            state.scores = scores
+            state.phase = 'scoring'
+            state = await finishHand(env.DB, gameId, state)
           } else {
             const newMultiplier = state.doublerMultiplier * 2
             const { results: players } = await env.DB.prepare(

--- a/functions/api/games/[id]/settings.js
+++ b/functions/api/games/[id]/settings.js
@@ -18,8 +18,8 @@ export async function onRequestPatch({ request, env, params }) {
 
     const { no_pick_variant, reveal_partner } = body ?? {}
 
-    if (no_pick_variant !== undefined && !['leasters', 'doublers'].includes(no_pick_variant)) {
-      return err('no_pick_variant must be "leasters" or "doublers".')
+    if (no_pick_variant !== undefined && !['leasters', 'doublers', 'schwanzers'].includes(no_pick_variant)) {
+      return err('no_pick_variant must be "leasters", "doublers", or "schwanzers".')
     }
     if (reveal_partner !== undefined && typeof reveal_partner !== 'boolean') {
       return err('reveal_partner must be a boolean.')

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,11 +7,13 @@
     "": {
       "name": "sheepshead",
       "version": "0.0.1",
+      "hasInstallScript": true,
       "workspaces": [
         "frontend"
       ],
       "devDependencies": {
         "concurrently": "^8.2.2",
+        "vitest": "^4.1.4",
         "wrangler": "^3.0.0"
       }
     },
@@ -447,11 +449,34 @@
         "node": ">=12"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "dev": true,
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1282,10 +1307,314 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
+      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@picocss/pico": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@picocss/pico/-/pico-2.1.1.tgz",
       "integrity": "sha512-kIDugA7Ps4U+2BHxiNHmvgPIQDWPDU4IeU6TNRdvXQM1uZX+FibqDQT2xUOnnO2yq/LUHcwnGlu1hvf4KfXnMg=="
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -1618,6 +1947,24 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1659,6 +2006,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1683,6 +2048,102 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/acorn": {
@@ -1737,6 +2198,16 @@
       "dev": true,
       "dependencies": {
         "printable-characters": "^1.0.42"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1809,6 +2280,16 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -1987,7 +2468,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2003,6 +2483,13 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.17.19",
@@ -2080,11 +2567,39 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/exsolve": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
       "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
       "dev": true
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -2186,6 +2701,279 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/lodash": {
@@ -2299,6 +3087,17 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ohash": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
@@ -2322,6 +3121,19 @@
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.8",
@@ -2397,6 +3209,47 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.60.1",
@@ -2558,6 +3411,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
@@ -2599,6 +3459,13 @@
       "integrity": "sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==",
       "dev": true
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktracey": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
@@ -2608,6 +3475,13 @@
         "as-table": "^1.0.36",
         "get-source": "^2.0.12"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
@@ -2658,6 +3532,50 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tree-kill": {
@@ -3183,6 +4101,238 @@
         "@esbuild/win32-arm64": "0.21.5",
         "@esbuild/win32-ia32": "0.21.5",
         "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/workerd": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "sheepshead",
   "version": "0.0.1",
   "private": true,
-  "workspaces": ["frontend"],
+  "workspaces": [
+    "frontend"
+  ],
   "scripts": {
     "dev": "concurrently -n frontend,wrangler -c cyan,yellow \"npm run dev:frontend\" \"npm run dev:wrangler\"",
     "dev:frontend": "npm run dev -w frontend",
@@ -11,10 +13,12 @@
     "deploy": "npm run build && wrangler pages deploy frontend/dist",
     "db:migrate:local": "wrangler d1 migrations apply sheepshead-db --local",
     "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote",
+    "test": "vitest run --passWithNoTests",
     "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",
+    "vitest": "^4.1.4",
     "wrangler": "^3.0.0"
   }
 }

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -809,6 +809,46 @@ export function resolveLeaster(state) {
   return { winner, scores }
 }
 
+// ─── Schwanzer ────────────────────────────────────────────────────────────────
+// No tricks are played. Each player's dealt hand is scored using Schwanzer point
+// values. The player with the most points is the loser (-4); all others gain +1.
+// Tie-break: most powerful trump (lowest TRUMP_ORDER index) loses.
+// Fallback: if all tied players hold no trump, first tied player in pickOrder loses.
+export function resolveSchwanzer(state) {
+  const pointsByPlayer = {}
+  for (const [uid, hand] of Object.entries(state.hands)) {
+    pointsByPlayer[uid] = hand.reduce((sum, card) => sum + schwanzerCardPoints(card), 0)
+  }
+
+  const maxPoints = Math.max(...Object.values(pointsByPlayer))
+  // Preserve pickOrder sequence so fallback tie-break is deterministic
+  const tied = state.pickOrder.filter(uid => pointsByPlayer[uid] === maxPoints)
+
+  function bestTrumpIndex(uid) {
+    const trumps = state.hands[uid].filter(c => isTrump(c))
+    if (trumps.length === 0) return TRUMP_ORDER.length  // no trump → least powerful
+    return Math.min(...trumps.map(c => trumpRank(c)))
+  }
+
+  // Among tied players: lowest trump index (most powerful) loses.
+  // pickOrder preserves insertion order, so the first element wins the fallback.
+  const loser = tied.reduce((worst, uid) =>
+    bestTrumpIndex(uid) < bestTrumpIndex(worst) ? uid : worst
+  )
+
+  const scores = {}
+  for (const uid of Object.keys(state.hands)) {
+    scores[uid] = uid === loser ? -4 : 1
+  }
+
+  const breakdown = state.pickOrder
+    .map(uid => `${uid}: ${pointsByPlayer[uid]}pts`)
+    .join(', ')
+  state.log.push(`Schwanzer! Points — ${breakdown}. ${loser} had the most and loses.`)
+
+  return { loser, scores }
+}
+
 // ─── Player view (redact other hands) ────────────────────────────────────────
 export function getPlayerView(state, userId) {
   const view = deepClone(state)

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -45,6 +45,15 @@ export function cardPoints(card) {
   return POINT_VALUES[card.rank] ?? 0
 }
 
+// Schwanzer point value — used only when scoring a Schwanzer no-pick hand
+// Queens=3, Jacks=2, diamond pips (non-Q, non-J, suit=D)=1, all else=0
+export function schwanzerCardPoints(card) {
+  if (card.rank === 'Q') return 3
+  if (card.rank === 'J') return 2
+  if (card.suit === 'D') return 1
+  return 0
+}
+
 // Effective suit for following-suit purposes (trump = 'T')
 export function effectiveSuit(card) {
   return isTrump(card) ? 'T' : card.suit

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { schwanzerCardPoints } from './gameEngine.js'
+import { schwanzerCardPoints, resolveSchwanzer } from './gameEngine.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
 
@@ -34,5 +34,74 @@ describe('schwanzerCardPoints', () => {
     expect(schwanzerCardPoints(c('9',  'C'))).toBe(0)
     expect(schwanzerCardPoints(c('8',  'H'))).toBe(0)
     expect(schwanzerCardPoints(c('7',  'S'))).toBe(0)
+  })
+})
+
+// ─── helpers for resolveSchwanzer tests ──────────────────────────────────────
+function makeState(hands, pickOrder) {
+  return { hands, pickOrder, log: [] }
+}
+
+describe('resolveSchwanzer', () => {
+  it('identifies the player with the most schwanzer points as the loser', () => {
+    const hands = {
+      p1: [c('Q','C'), c('7','C'), c('8','C'), c('9','C'), c('A','C'), c('10','C')],  // 3 pts
+      p2: [c('Q','S'), c('Q','H'), c('7','S'), c('8','S'), c('9','S'), c('A','S')],   // 6 pts → loses
+      p3: [c('J','C'), c('7','H'), c('8','H'), c('9','H'), c('A','H'), c('10','H')],  // 2 pts
+      p4: [c('7','C'), c('8','C'), c('9','S'), c('A','S'), c('10','S'), c('K','S')],  // 0 pts
+      p5: [c('K','C'), c('A','H'), c('10','C'), c('K','H'), c('A','C'), c('K','S')],  // 0 pts
+    }
+    const { loser, scores } = resolveSchwanzer(makeState(hands, ['p1','p2','p3','p4','p5']))
+    expect(loser).toBe('p2')
+    expect(scores.p2).toBe(-4)
+    expect(scores.p1).toBe(1)
+    expect(scores.p3).toBe(1)
+    expect(scores.p4).toBe(1)
+    expect(scores.p5).toBe(1)
+  })
+
+  it('tie-break: tied player with the most powerful trump loses', () => {
+    // p1 has QC (TRUMP_ORDER index 0) — most powerful trump → loses
+    // p2 has QS (TRUMP_ORDER index 1) — less powerful
+    // both have 3 schwanzer points
+    const hands = {
+      p1: [c('Q','C'), c('7','S'), c('8','S'), c('9','S'), c('A','S'), c('10','S')],  // 3 pts, trump=QC(idx 0)
+      p2: [c('Q','S'), c('7','H'), c('8','H'), c('9','H'), c('A','H'), c('10','H')],  // 3 pts, trump=QS(idx 1)
+      p3: [c('K','C'), c('A','C'), c('10','C'), c('K','H'), c('A','H'), c('K','S')],  // 0 pts
+      p4: [c('7','C'), c('8','C'), c('9','C'), c('K','H'), c('A','S'), c('10','S')],  // 0 pts
+      p5: [c('8','H'), c('9','H'), c('10','H'), c('7','S'), c('9','S'), c('K','S')],  // 0 pts
+    }
+    const { loser } = resolveSchwanzer(makeState(hands, ['p1','p2','p3','p4','p5']))
+    expect(loser).toBe('p1')  // QC is more powerful than QS
+  })
+
+  it('fallback tie-break: when tied players hold no trump, first in pickOrder loses', () => {
+    // All players have 0 schwanzer points — no Q, J, or D cards in any hand
+    const noTrumpHand = [c('A','C'), c('10','C'), c('K','C'), c('A','H'), c('10','H'), c('K','H')]
+    const hands = {
+      p1: noTrumpHand,
+      p2: noTrumpHand,
+      p3: noTrumpHand,
+      p4: noTrumpHand,
+      p5: noTrumpHand,
+    }
+    // p2 is first in pickOrder → p2 loses
+    const { loser } = resolveSchwanzer(makeState(hands, ['p2','p1','p3','p4','p5']))
+    expect(loser).toBe('p2')
+  })
+
+  it('pushes a log entry naming the loser and listing point totals', () => {
+    const hands = {
+      p1: [c('Q','C'), c('7','C'), c('8','C'), c('9','C'), c('A','C'), c('10','C')],  // 3 pts
+      p2: [c('7','S'), c('8','S'), c('9','S'), c('A','S'), c('10','S'), c('K','S')],  // 0 pts
+      p3: [c('7','H'), c('8','H'), c('9','H'), c('A','H'), c('10','H'), c('K','H')],  // 0 pts
+      p4: [c('K','C'), c('A','H'), c('10','C'), c('K','H'), c('9','C'), c('8','H')],  // 0 pts
+      p5: [c('8','C'), c('9','S'), c('K','S'), c('A','C'), c('10','H'), c('K','C')],  // 0 pts
+    }
+    const state = makeState(hands, ['p1','p2','p3','p4','p5'])
+    resolveSchwanzer(state)
+    expect(state.log.length).toBe(1)
+    expect(state.log[0]).toContain('p1')
+    expect(state.log[0]).toContain('loses')
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { schwanzerCardPoints } from './gameEngine.js'
+
+const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
+
+describe('schwanzerCardPoints', () => {
+  it('returns 3 for any queen', () => {
+    expect(schwanzerCardPoints(c('Q', 'C'))).toBe(3)
+    expect(schwanzerCardPoints(c('Q', 'S'))).toBe(3)
+    expect(schwanzerCardPoints(c('Q', 'H'))).toBe(3)
+    expect(schwanzerCardPoints(c('Q', 'D'))).toBe(3)  // QD is a queen, not a diamond pip
+  })
+
+  it('returns 2 for any jack', () => {
+    expect(schwanzerCardPoints(c('J', 'C'))).toBe(2)
+    expect(schwanzerCardPoints(c('J', 'S'))).toBe(2)
+    expect(schwanzerCardPoints(c('J', 'H'))).toBe(2)
+    expect(schwanzerCardPoints(c('J', 'D'))).toBe(2)  // JD is a jack, not a diamond pip
+  })
+
+  it('returns 1 for diamond pip cards (non-Q, non-J diamonds)', () => {
+    expect(schwanzerCardPoints(c('A',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('10', 'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('K',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('9',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('8',  'D'))).toBe(1)
+    expect(schwanzerCardPoints(c('7',  'D'))).toBe(1)
+  })
+
+  it('returns 0 for non-trump fail cards', () => {
+    expect(schwanzerCardPoints(c('A',  'C'))).toBe(0)
+    expect(schwanzerCardPoints(c('10', 'H'))).toBe(0)
+    expect(schwanzerCardPoints(c('K',  'S'))).toBe(0)
+    expect(schwanzerCardPoints(c('9',  'C'))).toBe(0)
+    expect(schwanzerCardPoints(c('8',  'H'))).toBe(0)
+    expect(schwanzerCardPoints(c('7',  'S'))).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds Schwanzers as a third no-pick variant alongside Leasters and Doublers
- When all 5 players pass with Schwanzers selected, hands are scored immediately using a trump-based point scheme (Q=3, J=2, diamond pip=1) — no tricks are played
- The player with the most Schwanzer points loses 4; all others gain 1
- Tie-break: most powerful trump (QC > QS > … > 7D) loses; if no tied player holds trump, first in pick order loses

Closes #50

## Changes

- `shared/gameEngine.js` — `schwanzerCardPoints()` and `resolveSchwanzer()` functions
- `shared/gameEngine.test.js` — 8 TDD tests (new test suite, vitest)
- `functions/api/games/[id]/action.js` — schwanzers branch in the `pass` handler
- `functions/api/games/[id]/settings.js` — `'schwanzers'` added to valid `no_pick_variant` values
- `frontend/src/pages/GamePage.jsx` — Schwanzers radio button and label in admin settings
- `README.md` — Schwanzer rules documented
- `package.json` — vitest test runner added

## Test plan

- [ ] Run `npm test` — 8 tests pass
- [ ] In a test game, set no-pick variant to Schwanzers in admin settings panel
- [ ] Have all 5 players pass
- [ ] Verify game immediately advances to next hand (no trick-playing)
- [ ] Verify game log shows per-player Schwanzer point totals and names the loser
- [ ] Verify scoreboard shows −4 for the loser and +1 for all others

🤖 Generated with [Claude Code](https://claude.com/claude-code)