### PR TITLE
Fix duplicate imports in action.js from bad merge resolution

### DIFF
--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -5,8 +5,6 @@ import {
   setupLeaster, awardLeasterBlind, resolveLeaster,
   resolveSchwanzer,
   dealHand, currentPlayer,
-  resolveSchwanzer,
-  dealHand,
 } from '../../../../shared/gameEngine.js'
 import { finishHand, processBotTurns } from '../../_botHelpers.js'
 


### PR DESCRIPTION
## Summary

- The merge of #28 (play bots) and #58 (Schwanzers no-pick variant) left `resolveSchwanzer` and `dealHand` duplicated in the named import list of `action.js`
- Duplicate named imports in ESM are a `SyntaxError` that crashes the Cloudflare Worker, preventing the app from running
- Removes the two duplicate lines; all required imports remain

## Test plan

- [ ] `npm run build` passes
- [ ] Dev server starts without Worker errors (`npm run dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)