### PR TITLE
Fix two bot bugs: called card restriction and game stuck after hand ends

### DIFF
--- a/functions/api/_botHelpers.js
+++ b/functions/api/_botHelpers.js
@@ -157,14 +157,15 @@ export async function processBotTurns(state, gameId, DB, game) {
       if (current.isLeaster && current.leasterBlind?.length > 0 && current.tricks.length === 1) {
         current = awardLeasterBlind(current)
       }
-      // If the bot played the last card of the hand, score and deal the next hand
-      // before stopping — otherwise the scoring state would be left unresolved.
+      // If the bot played the last card of the hand, score and deal the next hand.
       if (current.phase === 'scoring') {
         current = await finishHand(DB, gameId, current)
       }
       await persistState(DB, gameId, current)
-      // Stop here — the frontend will trigger the next bot play (or human acts next).
-      break
+      // If still in playing phase, stop — the frontend drives the next bot card.
+      // If a new hand was dealt (picking phase), continue so picking-phase bots run.
+      if (current.phase === 'playing') break
+      continue
     }
 
     // Award leaster blind after trick 1 (non-playing-phase path)

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -55,10 +55,19 @@ function getLegalCards(state, userId) {
     if (heldForced.length > 0) return handCards.filter(c => heldForced.includes(c.id))
   }
 
-  const hasSuit = handCards.some(c => effectiveSuit(c) === ledSuit)
-  return hasSuit
-    ? handCards.filter(c => effectiveSuit(c) === ledSuit)
+  // Called card cannot be played unless the called suit is led (mirrors gameEngine restriction)
+  const playableCards = (
+    calledCardId &&
+    ledSuit !== calledSuit &&
+    handCards.some(c => c.id !== calledCardId)
+  )
+    ? handCards.filter(c => c.id !== calledCardId)
     : handCards
+
+  const hasSuit = playableCards.some(c => effectiveSuit(c) === ledSuit)
+  return hasSuit
+    ? playableCards.filter(c => effectiveSuit(c) === ledSuit)
+    : playableCards
 }
 
 // ─── Card comparison helpers ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

**Fix 1 — Bot plays called card on wrong trick (`botStrategy.js`)**

`getLegalCards` enforced "must play called card when called suit is led" but was missing the mirror rule: the called card cannot be played when the called suit is *not* led (and the bot has other cards). This caused bots holding the called ace to attempt playing it on trump/off-suit tricks, crashing with `Cannot play AC unless the called suit is led`.

**Fix 2 — Game stuck in picking phase after bot plays last card of a hand (`_botHelpers.js`)**

When a bot played the final card of a hand, `processBotTurns` called `finishHand` (dealing the next hand) then broke out of the loop. The new hand's picking-phase bots never ran, leaving the game waiting on a bot with no trigger to advance it. Now continues the loop when the new phase is not `playing`, so picking/discarding/calling bots resolve immediately.

## Repro

- Game 50, trick 5: Oliver (partner, holds AC + AS) tried to play AC when the picker led trump (9D). Called suit was clubs.
- Game 50, hand 2: Emma (bot, first in pick order) never acted after hand 1 ended via a bot playing the last card.

## Test plan

- [ ] Dev server starts cleanly
- [ ] Bot partner does not play the called card on trump/off-suit tricks
- [ ] Bot partner does play the called card when the called suit is led
- [ ] After a hand ends with a bot playing the last card, the next hand's picking phase advances automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)