### PR TITLE
Add 5s delay before bot leads trick 1 to allow cracking

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -308,6 +308,9 @@ export default function GamePage({ gameId, user, onNavigate }) {
     if (botPlayRef.current.key === key) return
     if (botPlayRef.current.timer) clearTimeout(botPlayRef.current.timer)
     botPlayRef.current.key = key
+    const isLeadingTrick1 = (state.tricks?.length ?? 0) === 0
+                         && (state.currentTrick?.length ?? 0) === 0
+    const delay = isLeadingTrick1 ? 5000 : 700
     botPlayRef.current.timer = setTimeout(async () => {
       botPlayRef.current.timer = null
       try {
@@ -316,7 +319,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
       } catch {
         // State may have already advanced (e.g. another client acted); ignore.
       }
-    }, 700)
+    }, delay)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [gameData, gameId, fetchGame])
 

--- a/functions/api/_botHelpers.js
+++ b/functions/api/_botHelpers.js
@@ -120,7 +120,7 @@ async function createPlayBots(DB, count) {
 //   to trigger the next bot card — giving the appearance of sequential play.
 //
 // Saves state to the DB after each bot action and returns the final state.
-export async function processBotTurns(state, gameId, DB, game) {
+export async function processBotTurns(state, gameId, DB, game, { allowTrick1Lead = false } = {}) {
   // Fetch bot-type for every player in this game once upfront
   const { results: players } = await DB.prepare(
     'SELECT gp.user_id, u.bot_type FROM game_players gp JOIN users u ON u.id = gp.user_id WHERE gp.game_id = ?'
@@ -128,12 +128,16 @@ export async function processBotTurns(state, gameId, DB, game) {
   const botTypeMap = Object.fromEntries(players.map(p => [String(p.user_id), p.bot_type]))
 
   let current = state
+  // canLeadTrick1 starts true only for bot_play; resets to false on each hand
+  // boundary so that subsequent hands always get the full 5s crack window.
+  let canLeadTrick1 = allowTrick1Lead
   const MAX_ITERS = 60  // safety cap; one full hand is ~37 actions
 
   for (let i = 0; i < MAX_ITERS; i++) {
     // Handle scoring phase entered when a bot plays the final card of a hand
     if (current.phase === 'scoring') {
       current = await finishHand(DB, gameId, current)
+      canLeadTrick1 = false  // new hand — trick-1 delay applies again
       await persistState(DB, gameId, current)
       continue
     }
@@ -143,6 +147,14 @@ export async function processBotTurns(state, gameId, DB, game) {
     if (botTypeMap[nextActorId] !== 'play') break  // human's turn
 
     const wasPlayingPhase = current.phase === 'playing'
+
+    // Stop before leading trick 1 — frontend needs 5s for the crack window.
+    // canLeadTrick1 is only true for the current hand's initial bot_play lead.
+    if (wasPlayingPhase && !canLeadTrick1 &&
+        (current.tricks?.length ?? 0) === 0 &&
+        (current.currentTrick?.length ?? 0) === 0) {
+      break
+    }
 
     const view = getPlayerView(current, nextActorId)
     current = applyBotDecision(current, nextActorId, view)
@@ -160,6 +172,7 @@ export async function processBotTurns(state, gameId, DB, game) {
       // If the bot played the last card of the hand, score and deal the next hand.
       if (current.phase === 'scoring') {
         current = await finishHand(DB, gameId, current)
+        canLeadTrick1 = false  // new hand — trick-1 delay applies again
       }
       await persistState(DB, gameId, current)
       // If still in playing phase, stop — the frontend drives the next bot card.

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -163,7 +163,7 @@ export async function onRequestPost({ request, env, params }) {
     // the human who just played. If the hand ended (new picking phase), still run
     // processBotTurns so bot picks/passes resolve instantly as normal.
     if (type !== 'play_card' || state.phase !== 'playing') {
-      state = await processBotTurns(state, gameId, env.DB, game)
+      state = await processBotTurns(state, gameId, env.DB, game, { allowTrick1Lead: type === 'bot_play' })
     }
 
     await env.DB.prepare(


### PR DESCRIPTION
## Summary

- Adds a 5-second delay before a bot leads the first trick of each hand, giving players time to crack
- Fixes `processBotTurns` from playing trick 1 server-side before the frontend delay could fire
- Resets the delay flag at each hand boundary so it applies to every hand, not just the first

## How it works

The frontend already detects when a bot is the current player and schedules a `bot_play` after a delay — this PR extends that delay to 5s for trick 1 leads (`tricks.length === 0 && currentTrick.length === 0`).

On the server side, `processBotTurns` was immediately playing trick 1's first card whenever the game transitioned into playing phase (e.g. after `go_alone` or `call_ace`). A `canLeadTrick1` flag (true only when called via `bot_play`) now stops that, and resets to `false` at each `finishHand` call so subsequent hands also get the delay.

Closes #28

🤖 Generated with [Claude Code](https://claude.ai/claude-code)