### PR TITLE
Fix called ace showing playable animation when it cannot be played

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -171,11 +171,6 @@ function getLegalCardIds(state, userId, hand) {
     return ['UNDER_CARD']
   }
 
-  const hasSuit = handCards.some(c => effectiveSuit(c) === ledSuit)
-  const mustFollow = hasSuit
-    ? handCards.filter(c => effectiveSuit(c) === ledSuit).map(c => c.id)
-    : handCards.map(c => c.id)
-
   // Partner must play the called card when called suit is led
   const calledCardId = calledAce?.aceId || calledTen?.tenId || calledKing?.kingId
   if (calledCardId && userId === partner && !partnerRevealed && ledSuit === calledSuit) {
@@ -189,7 +184,20 @@ function getLegalCardIds(state, userId, hand) {
     if (heldForced.length > 0) return heldForced
   }
 
-  return mustFollow
+  // Called card cannot be played unless the called suit is led
+  // (except when it's the player's only remaining card)
+  const playableCards = (
+    calledCardId &&
+    ledSuit !== calledSuit &&
+    handCards.some(c => c.id !== calledCardId)
+  )
+    ? handCards.filter(c => c.id !== calledCardId)
+    : handCards
+
+  const hasSuit = playableCards.some(c => effectiveSuit(c) === ledSuit)
+  return hasSuit
+    ? playableCards.filter(c => effectiveSuit(c) === ledSuit).map(c => c.id)
+    : playableCards.map(c => c.id)
 }
 
 // ── Main GamePage ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `getLegalCardIds` in `GamePage.jsx` was missing the restriction (already present in `botStrategy.js`) that the called card cannot be played when a different suit is led, unless it is the player's only remaining card
- This caused the bump/hover animation to appear on the called ace even though the server would reject the play
- Fix mirrors the existing bot strategy logic exactly

Closes #43

## Test plan
- [ ] Start a game where you are the partner holding the called ace
- [ ] When a non-called suit is led and you have cards of that suit, verify the called ace does NOT show the bump animation
- [ ] When a non-called suit is led and you are void (must discard), verify the called ace does NOT show the bump animation (only other cards do)
- [ ] When the called suit is led, verify the called ace is still correctly highlighted as the only legal play
- [ ] When the called ace is your only remaining card, verify it shows as playable regardless of led suit

🤖 Generated with [Claude Code](https://claude.com/claude-code)