### PR TITLE
docs: document missing game rules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Total points in the deck: 120.
 
 #### 1. Picking
 
-Two blind cards are dealt face-down. Starting left of the dealer, each player may **pick** (take the blind and become the picker) or **pass**. If all five players pass, the hand is played as a **Leaster**.
+Two blind cards are dealt face-down. Starting left of the dealer, each player may **pick** (take the blind and become the picker) or **pass**. If all five players pass, what happens depends on the game's no-pick variant: the hand is played as a **Leaster**, the stakes double (**Doublers**), or the hand is scored immediately as a **Schwanzer**.
 
 **Blitzing**
 
@@ -120,6 +120,10 @@ The final multiplier is: `base × doubler × crack × blitz`.
 ### Leaster
 
 When all five players pass, a Leaster is played. There is no picker or partner — everyone plays for themselves. The blind cards are awarded to the winner of the first trick. The player who takes at least one trick and ends with the **fewest points** wins. The winner gains 4 points; all others lose 1 point.
+
+### Doublers
+
+When all five players pass and the no-pick variant is Doublers, no hand is played. Instead, the session-wide stakes multiplier doubles (×2, stacking on each successive no-pick), a new hand is dealt, and play continues until someone picks. The accumulated doubler multiplier applies to the final payout of the next played hand, then resets to ×1.
 
 ### Schwanzer
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Queen of Clubs, Queen of Spades, Queen of Hearts, Queen of Diamonds,
 Jack of Clubs, Jack of Spades, Jack of Hearts, Jack of Diamonds,
 Ace of Diamonds, 10 of Diamonds, King of Diamonds, 9 of Diamonds, 8 of Diamonds, 7 of Diamonds
 
+### Non-Trump Suit Rank (highest → lowest)
+
+Ace, 10, King, 9, 8, 7. Note that the 10 outranks the King.
+
 ### Card Point Values
 
 | Card | Points |
@@ -119,7 +123,7 @@ The final multiplier is: `base × doubler × crack × blitz`.
 
 ### Leaster
 
-When all five players pass and the no-pick variant is Leasters, a Leaster is played. There is no picker or partner — everyone plays for themselves. The blind cards are awarded to the winner of the first trick. The player who takes at least one trick and ends with the **fewest points** wins. The winner gains 4 points; all others lose 1 point.
+When all five players pass and the no-pick variant is Leasters, a Leaster is played. There is no picker or partner — everyone plays for themselves. The blind cards are awarded to the winner of the first trick. The player who takes at least one trick and ends with the **fewest points** wins. **Tie-break:** if two or more eligible players are tied on points, the one who took the fewest tricks wins. The winner gains 4 points; all others lose 1 point.
 
 ### Doubler
 

--- a/README.md
+++ b/README.md
@@ -119,9 +119,9 @@ The final multiplier is: `base × doubler × crack × blitz`.
 
 ### Leaster
 
-When all five players pass, a Leaster is played. There is no picker or partner — everyone plays for themselves. The blind cards are awarded to the winner of the first trick. The player who takes at least one trick and ends with the **fewest points** wins. The winner gains 4 points; all others lose 1 point.
+When all five players pass and the no-pick variant is Leasters, a Leaster is played. There is no picker or partner — everyone plays for themselves. The blind cards are awarded to the winner of the first trick. The player who takes at least one trick and ends with the **fewest points** wins. The winner gains 4 points; all others lose 1 point.
 
-### Doublers
+### Doubler
 
 When all five players pass and the no-pick variant is Doublers, no hand is played. Instead, the session-wide stakes multiplier doubles (×2, stacking on each successive no-pick), a new hand is dealt, and play continues until someone picks. The accumulated doubler multiplier applies to the final payout of the next played hand, then resets to ×1.
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Total points in the deck: 120.
 
 Two blind cards are dealt face-down. Starting left of the dealer, each player may **pick** (take the blind and become the picker) or **pass**. If all five players pass, the hand is played as a **Leaster**.
 
+**Blitzing**
+
+A player holding both black queens (Queen of Clubs + Queen of Spades) or both red queens (Queen of Hearts + Queen of Diamonds) may **blitz** when it is their turn to pick. Blitzing forces the player to pick (they take the blind and proceed to discarding), and doubles the hand's final payout (×2 on top of all other multipliers).
+
 #### 2. Discarding
 
 The picker adds the 2 blind cards to their hand (8 total) and buries 2 cards face-down. The buried cards count toward the picker's point pile at scoring. The picker may not bury cards required for the partner call (see below).
@@ -103,7 +107,7 @@ The picker team needs **61 or more points** out of 120 to win.
 | Schneider (winner ≥91 pts, or loser ≤29 pts) | ×2 |
 | Schwarz (one side takes all 6 tricks) | ×3 |
 
-The final multiplier is: `base × doubler × crack`.
+The final multiplier is: `base × doubler × crack × blitz`.
 
 **Picker wins:**
 - With partner: picker earns 2 points, partner earns 1 point; each opponent loses 1 point (all × multiplier).


### PR DESCRIPTION
Closes #53

## Summary
- Documents blitzing rules (eligibility, forced-pick mechanic, ×2 payout multiplier)
- Fixes picking phase description to reflect all three no-pick variants (Leasters, Doublers, Schwanzers)
- Adds Doubler section explaining the stacking stakes multiplier
- Adds Non-Trump Suit Rank section (A > 10 > K > 9 > 8 > 7)
- Adds Leaster tie-break rule (fewest tricks breaks a points tie)
- Updates scoring formula to include blitz multiplier

## Test plan
- [ ] Read through the Rules section of README.md end-to-end and verify accuracy against `shared/gameEngine.js`