### PR TITLE
feat: rewind play and rewind trick for test mode (#37)

### DIFF
--- a/docs/superpowers/specs/2026-04-12-rewind-design.md
+++ b/docs/superpowers/specs/2026-04-12-rewind-design.md
@@ -1,0 +1,74 @@
+# Rewind Feature Design
+
+**Issue:** #37  
+**Date:** 2026-04-12  
+**Status:** Approved
+
+## Overview
+
+Add "Rewind Play" and "Rewind Trick" controls to test-mode games, allowing an admin to step backwards through card plays within the current hand. Rewind never crosses hand boundaries or returns to the pick/bury/calling phase.
+
+## Section 1: State History
+
+A `rewindHistory: []` array is added to the game state JSON. It holds complete state snapshots (oldest-first), one per card play.
+
+- `dealHand` initializes `rewindHistory: []`, clearing history at the start of each hand
+- `playCard` pushes a deep clone of the pre-play state onto `rewindHistory` before applying the play. **The snapshot must have `rewindHistory` stripped (set to `[]`) before pushing**, otherwise each snapshot would nest all prior snapshots inside it, causing exponential JSON growth.
+- Existing in-flight games that lack the field are handled via a `?? []` fallback
+
+History is bounded naturally to the current hand (max 30 card plays = 6 tricks × 5 players). Storage is O(N × base state size) because snapshots do not carry nested history.
+
+## Section 2: Game Engine Functions
+
+### `rewindPlay(state)`
+
+- Asserts phase is `playing` and `rewindHistory` is non-empty (throws otherwise)
+- Pops the last snapshot off `rewindHistory`
+- Sets the popped snapshot's `rewindHistory` to the remaining entries (the array minus the popped entry)
+- Returns the restored state
+
+### `rewindTrick(state)`
+
+- Asserts phase is `playing`
+- If `rewindHistory` is empty, returns state unchanged (no-op)
+- Pops snapshots until `currentTrick.length === 0` in the restored state
+- If `currentTrick` was already empty when called, pops one full additional trick's worth (rewinding to the previous trick)
+- After each pop: sets the popped snapshot's `rewindHistory` to the remaining entries before continuing
+- After settling, if `tricks.length === 0` (start of hand): resets `crackState = null` and `handCrackMultiplier = 1`
+- Returns the restored state
+
+### `playCard` change
+
+Before applying each card play, push `deepClone(state)` onto `state.rewindHistory`, **with `rewindHistory` stripped to `[]` in the snapshot** to avoid exponential nesting.
+
+## Section 3: API Layer
+
+Two new action types in `functions/api/games/[id]/action.js`:
+
+| Action type    | Engine function  | Guard                              |
+|----------------|------------------|------------------------------------|
+| `rewind_play`  | `rewindPlay()`   | `is_test_mode && user.is_admin`    |
+| `rewind_trick` | `rewindTrick()`  | `is_test_mode && user.is_admin`    |
+
+- Both return 403 if not test mode or not admin
+- No `act_as` needed — rewind operates on the global game state
+- `processBotTurns` is skipped after either rewind action (same treatment as `play_card` during the playing phase)
+
+## Section 4: Frontend
+
+Two buttons shown in `GamePage.jsx` when `isTestMode && user.is_admin && state.phase === 'playing'`:
+
+- **"Rewind Play"** — disabled when `rewindHistory` is empty
+- **"Rewind Trick"** — disabled when `rewindHistory` is empty, or when `currentTrick.length === 0 && tricks.length === 0` (already at start of hand with no previous trick)
+
+Both buttons call `onAction({ type: 'rewind_play' })` and `onAction({ type: 'rewind_trick' })` using the existing action dispatch mechanism. No new API client code required.
+
+Placement: a dedicated "Test Controls" section, visually separate from the normal action panel, to make it clear these are administrative tools.
+
+## Out of Scope
+
+- Rewind during picking, discarding, or calling phases
+- Rewind across hand boundaries
+- Rewind in leaster or schwanzer variants (no explicit requirement; can be revisited). Note: leasters use the same `playing` phase, so rewind would technically function — but rewinding past trick 1 in a leaster hand could create inconsistency with the `awardLeasterBlind` side effect that fires after trick 1 completes.
+- Non-admin players triggering rewind
+- Option C (action log replay) — tracked separately in #70

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -542,6 +542,11 @@ export default function GamePage({ gameId, user, onNavigate }) {
     && (state.tricks ?? []).length === 0
     && (state.currentTrick ?? []).length === 0
 
+  const rewindHistory = state.rewindHistory ?? []
+  const canRewindPlay  = isTestMode && user.is_admin && state.phase === 'playing' && rewindHistory.length > 0
+  const canRewindTrick = isTestMode && user.is_admin && state.phase === 'playing'
+    && !(rewindHistory.length === 0 && (state.tricks ?? []).length === 0 && (state.currentTrick ?? []).length === 0)
+
   function seatProps(player) {
     if (!player) return {}
     const uid  = String(player.user_id)
@@ -689,6 +694,34 @@ export default function GamePage({ gameId, user, onNavigate }) {
             loading={actionLoading}
             actingForName={isActingForBot ? (actingForPlayer?.username ?? turnUserId) : null}
           />
+        </div>
+      )}
+
+      {/* ── Test controls (admin rewind) ── */}
+      {isTestMode && user.is_admin && state.phase === 'playing' && (
+        <div style={{
+          gridColumn: '1 / -1',
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'center',
+          padding: '4px 0',
+        }}>
+          <button
+            className="secondary"
+            onClick={() => handleAction('rewind_play', {})}
+            disabled={!canRewindPlay || actionLoading}
+            style={{ fontSize: '0.8rem' }}
+          >
+            Rewind Play
+          </button>
+          <button
+            className="secondary"
+            onClick={() => handleAction('rewind_trick', {})}
+            disabled={!canRewindTrick || actionLoading}
+            style={{ fontSize: '0.8rem' }}
+          >
+            Rewind Trick
+          </button>
         </div>
       )}
 

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -348,10 +348,13 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
     if (trick.length > 0) {
       // Cards are being played — update immediately and cancel any pending clear.
+      // Also sync the ref so a rewind-reduced trickCount is tracked; otherwise
+      // re-completing the same trick won't trigger the completion branch below.
       if (trickClearTimerRef.current) {
         clearTimeout(trickClearTimerRef.current)
         trickClearTimerRef.current = null
       }
+      lastProcessedTrickCountRef.current = trickCount
       setDisplayedTrick(trick)
     } else if (trickCount !== lastProcessedTrickCountRef.current) {
       // A new trick just completed — guard by trickCount so repeated polls of

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -5,6 +5,7 @@ import {
   setupLeaster, awardLeasterBlind, resolveLeaster,
   resolveSchwanzer,
   dealHand, currentPlayer,
+  rewindPlay, rewindTrick,
 } from '../../../../shared/gameEngine.js'
 import { finishHand, processBotTurns } from '../../_botHelpers.js'
 
@@ -154,6 +155,20 @@ export async function onRequestPost({ request, env, params }) {
         // No-op — hands now auto-advance; kept for backward compatibility
         break
 
+      case 'rewind_play': {
+        if (!game.is_test_mode) return err('rewind_play is only allowed in test mode games.', 403)
+        if (!user.is_admin)     return err('Only admins can use rewind_play.', 403)
+        state = rewindPlay(state)
+        break
+      }
+
+      case 'rewind_trick': {
+        if (!game.is_test_mode) return err('rewind_trick is only allowed in test mode games.', 403)
+        if (!user.is_admin)     return err('Only admins can use rewind_trick.', 403)
+        state = rewindTrick(state)
+        break
+      }
+
       default:
         return err(`Unknown action type: ${type}`)
     }
@@ -162,7 +177,7 @@ export async function onRequestPost({ request, env, params }) {
     // the frontend's bot_play trigger applies the same 700 ms delay for bots as for
     // the human who just played. If the hand ended (new picking phase), still run
     // processBotTurns so bot picks/passes resolve instantly as normal.
-    if (type !== 'play_card' || state.phase !== 'playing') {
+    if ((type !== 'play_card' && type !== 'rewind_play' && type !== 'rewind_trick') || state.phase !== 'playing') {
       state = await processBotTurns(state, gameId, env.DB, game, { allowTrick1Lead: type === 'bot_play' })
     }
 

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -556,6 +556,33 @@ export function rewindPlay(state) {
   return restored
 }
 
+export function rewindTrick(state) {
+  assertPhase(state, 'playing')
+  const history = state.rewindHistory ?? []
+  if (history.length === 0) return state  // no-op at start of hand
+
+  let entries = [...history]
+  let poppedSnapshot
+
+  // Pop snapshots until we land at the start of a trick (currentTrick empty).
+  // Works for both mid-trick and start-of-trick cases: if we're already at
+  // currentTrick=[], the first pop goes back into the previous trick's plays,
+  // then we keep popping until we hit the previous trick's start.
+  do {
+    poppedSnapshot = entries[entries.length - 1]
+    entries = entries.slice(0, -1)
+  } while (entries.length > 0 && poppedSnapshot.currentTrick.length > 0)
+
+  const restored = { ...poppedSnapshot, rewindHistory: entries }
+
+  // Rewinding to the start of the hand resets crack/recrack state
+  if (restored.tricks.length === 0) {
+    return { ...restored, crackState: null, handCrackMultiplier: 1 }
+  }
+
+  return restored
+}
+
 // Who plays next in the current trick?
 export function currentPlayer(state) {
   const played = state.currentTrick.map(p => p.userId)

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -539,6 +539,23 @@ export function playCard(state, userId, cardId) {
   return newState
 }
 
+// ─── Rewind ──────────────────────────────────────────────────────────────────
+export function rewindPlay(state) {
+  assertPhase(state, 'playing')
+  const history = state.rewindHistory ?? []
+  if (history.length === 0) throw new Error('Nothing to rewind.')
+
+  const remaining = history.slice(0, -1)
+  let restored = { ...history[history.length - 1], rewindHistory: remaining }
+
+  // Rewinding to the start of the hand resets crack/recrack state
+  if (restored.tricks.length === 0 && restored.currentTrick.length === 0) {
+    restored = { ...restored, crackState: null, handCrackMultiplier: 1 }
+  }
+
+  return restored
+}
+
 // Who plays next in the current trick?
 export function currentPlayer(state) {
   const played = state.currentTrick.map(p => p.userId)

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -902,6 +902,7 @@ export function resolveSchwanzer(state) {
 // ─── Player view (redact other hands) ────────────────────────────────────────
 export function getPlayerView(state, userId) {
   const view = deepClone(state)
+  view.rewindHistory = []   // strip snapshots — each contains all players' unredacted hands
 
   for (const uid of Object.keys(view.hands)) {
     if (uid !== userId) {

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -134,6 +134,7 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     blitzes: [],               // [{ userId, type: 'black'|'red' }] — players who declared a blitz
     log: [],                   // string messages
     scores: {},                // { userId: delta } — populated at scoring
+    rewindHistory: [],         // card play snapshots for rewinding
   }
 }
 

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -461,7 +461,12 @@ export function playCard(state, userId, cardId) {
   assertPhase(state, 'playing')
   assertTurn(state, userId, currentPlayer(state))
 
+  // Capture pre-play snapshot. Strip rewindHistory to prevent exponential nesting.
+  const snapshot = deepClone(state)
+  snapshot.rewindHistory = []
+
   const newState = deepClone(state)
+  newState.rewindHistory = [...(state.rewindHistory ?? []), snapshot]
 
   const isUnderCardPlay =
     newState.underCard &&

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -7,6 +7,7 @@ import {
   callAceUnknown, crack, recrack,
   playCard, computeScores, resolveLeaster,
   setupLeaster, awardLeasterBlind, getPlayerView,
+  rewindPlay, rewindTrick,
 } from './gameEngine.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -846,6 +847,120 @@ describe('rewind history (playCard)', () => {
     const snapshot = next.rewindHistory[0]
     expect(snapshot.currentTrick).toHaveLength(0)
     expect(snapshot.hands.p1.some(cd => cd.id === 'KH')).toBe(true)
+  })
+})
+
+describe('rewindPlay', () => {
+  function makeHandStartSnapshot(overrides = {}) {
+    return {
+      phase: 'playing',
+      picker: 'p1',
+      partner: 'p3',
+      goingAlone: false,
+      calledAce: { suit: 'S', aceId: 'AS' },
+      calledSuit: 'S',
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: true,
+      pickerForcedPlays: [],
+      underCard: null,
+      pickOrder: ['p1','p2','p3','p4','p5'],
+      doublerMultiplier: 1,
+      handCrackMultiplier: 1,
+      crackState: null,
+      blitzes: [],
+      discard: [],
+      tricks: [],
+      currentTrick: [],
+      currentLeader: 'p1',
+      lastTrick: [],
+      log: [],
+      scores: {},
+      rewindHistory: [],
+      hands: {
+        p1: [c('K','H')],
+        p2: [c('7','H')],
+        p3: [c('8','H')],
+        p4: [c('9','H')],
+        p5: [c('10','H')],
+      },
+      ...overrides,
+    }
+  }
+
+  function makeStateAfterOnePlay() {
+    const snapshot = makeHandStartSnapshot()
+    return {
+      ...makeHandStartSnapshot(),
+      hands: { ...makeHandStartSnapshot().hands, p1: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }],
+      rewindHistory: [snapshot],
+    }
+  }
+
+  it('restores currentTrick to pre-play length', () => {
+    const state = makeStateAfterOnePlay()
+    const rewound = rewindPlay(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+  })
+
+  it('restores the played card to the player hand', () => {
+    const state = makeStateAfterOnePlay()
+    const rewound = rewindPlay(state)
+    expect(rewound.hands.p1.some(cd => cd.id === 'KH')).toBe(true)
+  })
+
+  it('removes the entry from rewindHistory', () => {
+    const state = makeStateAfterOnePlay()
+    const rewound = rewindPlay(state)
+    expect(rewound.rewindHistory).toHaveLength(0)
+  })
+
+  it('throws when rewindHistory is empty', () => {
+    const state = makeHandStartSnapshot()
+    expect(() => rewindPlay(state)).toThrow('Nothing to rewind')
+  })
+
+  it('throws when phase is not playing', () => {
+    const state = makeStateAfterOnePlay()
+    state.phase = 'picking'
+    expect(() => rewindPlay(state)).toThrow()
+  })
+
+  it('resets crackState and handCrackMultiplier when restored state is at hand start', () => {
+    const crackedSnapshot = makeHandStartSnapshot({ crackState: 'cracked', handCrackMultiplier: 2 })
+    const state = {
+      ...makeHandStartSnapshot({ crackState: 'cracked', handCrackMultiplier: 2 }),
+      hands: { ...makeHandStartSnapshot().hands, p1: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }],
+      rewindHistory: [crackedSnapshot],
+    }
+    const rewound = rewindPlay(state)
+    expect(rewound.crackState).toBeNull()
+    expect(rewound.handCrackMultiplier).toBe(1)
+  })
+
+  it('does NOT reset crackState when restored state is mid-trick (not hand start)', () => {
+    const s0 = makeHandStartSnapshot()
+    const s1 = {
+      ...s0,
+      crackState: 'cracked',
+      handCrackMultiplier: 2,
+      hands: { ...s0.hands, p1: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }],
+      rewindHistory: [],
+    }
+    const state = {
+      ...s1,
+      crackState: 'cracked',
+      handCrackMultiplier: 2,
+      hands: { ...s1.hands, p2: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s0, s1],
+    }
+    const rewound = rewindPlay(state)
+    expect(rewound.currentTrick).toHaveLength(1)
+    expect(rewound.crackState).toBe('cracked')
   })
 })
 

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -250,6 +250,11 @@ describe('dealHand', () => {
     expect(state.phase).toBe('picking')
     expect(state.pickIndex).toBe(0)
   })
+
+  it('initializes rewindHistory as an empty array', () => {
+    const state = dealHand(['p1','p2','p3','p4','p5'], 0, 1, 1)
+    expect(state.rewindHistory).toEqual([])
+  })
 })
 
 describe('pick / pass / blitz', () => {

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -964,6 +964,106 @@ describe('rewindPlay', () => {
   })
 })
 
+describe('rewindTrick', () => {
+  function makeHandStartSnapshot(overrides = {}) {
+    return {
+      phase: 'playing',
+      picker: 'p1', partner: 'p3', goingAlone: false,
+      calledAce: { suit: 'S', aceId: 'AS' }, calledSuit: 'S',
+      calledTen: null, calledKing: null,
+      partnerRevealed: true, pickerForcedPlays: [], underCard: null,
+      pickOrder: ['p1','p2','p3','p4','p5'],
+      doublerMultiplier: 1, handCrackMultiplier: 1, crackState: null,
+      blitzes: [], discard: [],
+      tricks: [], currentTrick: [], currentLeader: 'p1',
+      lastTrick: [], log: [], scores: {},
+      rewindHistory: [],
+      hands: {
+        p1: [c('K','H')], p2: [c('7','H')], p3: [c('8','H')],
+        p4: [c('9','H')], p5: [c('10','H')],
+      },
+      ...overrides,
+    }
+  }
+
+  it('is a no-op when rewindHistory is empty', () => {
+    const state = makeHandStartSnapshot()
+    const result = rewindTrick(state)
+    expect(result).toBe(state)
+  })
+
+  it('rewinds mid-trick to the start of the current trick', () => {
+    const s0 = makeHandStartSnapshot()
+    const s1 = { ...makeHandStartSnapshot(), hands: { ...makeHandStartSnapshot().hands, p1: [] }, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    const state = {
+      ...s1,
+      hands: { ...s1.hands, p2: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s0, s1],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+    expect(rewound.tricks).toHaveLength(0)
+  })
+
+  it('rewinds to the previous trick when currentTrick is already empty', () => {
+    const s0 = makeHandStartSnapshot()
+    const s1 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    const s2 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }], rewindHistory: [] }
+    const s3 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }, { userId: 'p3', card: c('8','H') }], rewindHistory: [] }
+    const s4 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }, { userId: 'p3', card: c('8','H') }, { userId: 'p4', card: c('9','H') }], rewindHistory: [] }
+    const state = {
+      ...makeHandStartSnapshot(),
+      tricks: [{ leader: 'p1', plays: [], winner: 'p1' }],
+      currentTrick: [],
+      currentLeader: 'p1',
+      rewindHistory: [s0, s1, s2, s3, s4],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+    expect(rewound.tricks).toHaveLength(0)
+  })
+
+  it('resets crackState and handCrackMultiplier when rewinding to hand start', () => {
+    const s0 = makeHandStartSnapshot({ crackState: 'cracked', handCrackMultiplier: 2 })
+    const s1 = { ...s0, hands: { ...s0.hands, p1: [] }, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    const state = {
+      ...s1,
+      hands: { ...s1.hands, p2: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s0, s1],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.tricks).toHaveLength(0)
+    expect(rewound.crackState).toBeNull()
+    expect(rewound.handCrackMultiplier).toBe(1)
+  })
+
+  it('does NOT reset crackState when rewinding to a mid-hand trick boundary', () => {
+    const s5 = makeHandStartSnapshot({
+      tricks: [{ leader: 'p1', plays: [], winner: 'p1' }],
+      currentTrick: [],
+      crackState: 'cracked',
+      handCrackMultiplier: 2,
+    })
+    const s6 = { ...s5, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    const state = {
+      ...s5,
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s5, s6],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+    expect(rewound.tricks).toHaveLength(1)
+    expect(rewound.crackState).toBe('cracked')
+  })
+
+  it('throws when phase is not playing', () => {
+    const state = makeHandStartSnapshot({ phase: 'picking' })
+    expect(() => rewindTrick(state)).toThrow()
+  })
+})
+
 describe('computeScores', () => {
   // Create a fake card with a specific point rank (suit doesn't affect scoring)
   let fakeId = 0

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -791,6 +791,64 @@ describe('playCard', () => {
   })
 })
 
+describe('rewind history (playCard)', () => {
+  function makeLeadingState() {
+    return {
+      phase: 'playing',
+      picker: 'p1',
+      partner: 'p3',
+      goingAlone: false,
+      calledAce: { suit: 'S', aceId: 'AS' },
+      calledSuit: 'S',
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: true,
+      pickerForcedPlays: [],
+      underCard: null,
+      pickOrder: ['p1','p2','p3','p4','p5'],
+      doublerMultiplier: 1,
+      handCrackMultiplier: 1,
+      crackState: null,
+      blitzes: [],
+      discard: [],
+      tricks: [],
+      currentTrick: [],
+      currentLeader: 'p1',
+      lastTrick: [],
+      log: [],
+      scores: {},
+      rewindHistory: [],
+      hands: {
+        p1: [c('K','H')],
+        p2: [c('7','H')],
+        p3: [c('8','H')],
+        p4: [c('9','H')],
+        p5: [c('10','H')],
+      },
+    }
+  }
+
+  it('adds one entry to rewindHistory per card play', () => {
+    const state = makeLeadingState()
+    const next = playCard(state, 'p1', 'KH')
+    expect(next.rewindHistory).toHaveLength(1)
+  })
+
+  it('snapshot does not contain nested rewindHistory entries (no exponential growth)', () => {
+    const state = makeLeadingState()
+    const next = playCard(state, 'p1', 'KH')
+    expect(next.rewindHistory[0].rewindHistory).toEqual([])
+  })
+
+  it('snapshot captures pre-play state (card still in hand, trick still empty)', () => {
+    const state = makeLeadingState()
+    const next = playCard(state, 'p1', 'KH')
+    const snapshot = next.rewindHistory[0]
+    expect(snapshot.currentTrick).toHaveLength(0)
+    expect(snapshot.hands.p1.some(cd => cd.id === 'KH')).toBe(true)
+  })
+})
+
 describe('computeScores', () => {
   // Create a fake card with a specific point rank (suit doesn't affect scoring)
   let fakeId = 0

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1498,4 +1498,23 @@ describe('getPlayerView', () => {
     const oppView = getPlayerView(makeViewState(), 'p3')
     expect(oppView.partner).toBeNull()      // opponent sees null until revealed
   })
+
+  it('strips rewindHistory from the player view', () => {
+    // Build a minimal state with a non-empty rewindHistory
+    const snapshot = { phase: 'playing', tricks: [], currentTrick: [], rewindHistory: [] }
+    const state = {
+      phase: 'playing',
+      picker: 'p1', partner: 'p3', goingAlone: false,
+      calledAce: null, calledSuit: null, calledTen: null, calledKing: null,
+      partnerRevealed: false, pickerForcedPlays: [], underCard: null,
+      pickOrder: ['p1','p2','p3','p4','p5'],
+      doublerMultiplier: 1, handCrackMultiplier: 1, crackState: null,
+      blitzes: [], discard: [], tricks: [], currentTrick: [], currentLeader: 'p1',
+      lastTrick: [], log: [], scores: {},
+      rewindHistory: [snapshot],
+      hands: { p1: [], p2: [], p3: [], p4: [], p5: [] },
+    }
+    const view = getPlayerView(state, 'p1')
+    expect(view.rewindHistory).toEqual([])
+  })
 })


### PR DESCRIPTION
## Summary

- Adds **Rewind Play** and **Rewind Trick** buttons to test-mode games, visible only to admins during the playing phase
- Game state embeds a `rewindHistory` stack of pre-play snapshots (with history stripped from each snapshot to prevent exponential growth); `dealHand` initializes it to `[]`
- Two new pure engine functions (`rewindPlay`, `rewindTrick`) pop snapshots to restore prior state; crack/recrack state is reset only when rewinding to the very start of the hand
- Two new API action types (`rewind_play`, `rewind_trick`) guarded by `is_test_mode` and `is_admin`; `processBotTurns` is skipped after rewind actions
- `getPlayerView` strips `rewindHistory` before sending state to clients (each snapshot contains all players' unredacted hands)
- Fixed a frontend bug where re-completing a trick after a rewind didn't trigger the trick-clear animation, caused by `lastProcessedTrickCountRef` not being synced when `trickCount` decreased

## Test Plan

- [ ] In a test-mode game, verify Rewind Play / Rewind Trick buttons are absent in non-test-mode games and absent outside the playing phase
- [ ] Both buttons disabled before the first card is played
- [ ] Rewind Play restores the last card to the player's hand and the trick area reflects the prior state
- [ ] Rewind Trick at mid-trick clears the current trick
- [ ] Rewind Trick at the start of a trick goes back to the previous trick
- [ ] Rewind Trick at the very start of the hand has no effect
- [ ] After rewinding to hand start, crack/recrack controls are re-enabled
- [ ] After rewinding and re-completing a trick, the 5-card display and 1-second clear animation fire correctly
- [ ] Non-admin players in a test-mode game cannot trigger rewind (403)
- [ ] All 107 tests pass

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)