### PR TITLE
fix: identify partner fixes + reusable GameOptionsPanel (#38)

### DIFF
--- a/docs/superpowers/plans/2026-04-13-identify-partner-fixes.md
+++ b/docs/superpowers/plans/2026-04-13-identify-partner-fixes.md
@@ -1,0 +1,733 @@
+# Identify Partner Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three bugs in the "Identify partner after ace is played" feature, add it to the create game dialog, and extract a reusable `GameOptionsPanel` modal component.
+
+**Architecture:** `reveal_partner` is snapshotted from the DB into game state at each hand start (in `finishHand` and the doublers re-deal path), making it authoritative for display during a hand. A new `GameOptionsPanel` component handles both the create-game flow (mode="create", no API calls) and the in-game admin panel (mode="update", auto-saves via PATCH). `GamePage` and `LobbyPage` use this component via a modal trigger button.
+
+**Tech Stack:** React 18, Cloudflare Workers Functions, Cloudflare D1 (SQLite), Vitest
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|---|---|---|
+| `shared/gameEngine.js` | Modify | Fix `getPlayerView` to respect `reveal_partner` |
+| `shared/gameEngine.test.js` | Modify | Add `reveal_partner` tests |
+| `functions/api/_botHelpers.js` | Modify | Snapshot `reveal_partner` in `finishHand` |
+| `functions/api/games/[id]/action.js` | Modify | Snapshot `reveal_partner` in doublers re-deal |
+| `functions/api/games/index.js` | Modify | Accept `reveal_partner` + schwanzers in create; snapshot in test mode deal |
+| `frontend/src/lib/api.js` | Modify | Add `revealPartner` option to `create()` |
+| `frontend/src/components/GameOptionsPanel.jsx` | Create | Reusable modal for game options |
+| `frontend/src/pages/GamePage.jsx` | Modify | Remove `AdminSettingsPanel`, fix display bugs, use `GameOptionsPanel` |
+| `frontend/src/pages/LobbyPage.jsx` | Modify | Replace variant fieldset with options summary row + modal |
+
+---
+
+### Task 1: Tests for `reveal_partner` in `getPlayerView`
+
+**Files:**
+- Modify: `shared/gameEngine.test.js`
+
+- [ ] **Step 1: Add failing tests to the `getPlayerView` describe block**
+
+Open `shared/gameEngine.test.js`. After the existing `'partner identity is hidden from opponents when partnerRevealed is false'` test (around line 1500), add two new tests inside the `describe('getPlayerView')` block:
+
+```js
+it('partner identity is hidden from opponents when reveal_partner is false, even if partnerRevealed is true', () => {
+  const state = { ...makeViewState(), partnerRevealed: true, reveal_partner: false }
+
+  const oppView = getPlayerView(state, 'p3')
+  expect(oppView.partner).toBeNull()
+
+  const pickerView = getPlayerView(state, 'p1')
+  expect(pickerView.partner).toBe('p2')   // picker always sees partner
+
+  const partnerView = getPlayerView(state, 'p2')
+  expect(partnerView.partner).toBe('p2')  // partner sees themselves
+})
+
+it('partner identity is visible to opponents when reveal_partner is true and partnerRevealed is true', () => {
+  const state = { ...makeViewState(), partnerRevealed: true, reveal_partner: true }
+  const oppView = getPlayerView(state, 'p3')
+  expect(oppView.partner).toBe('p2')
+})
+```
+
+- [ ] **Step 2: Run the new tests and confirm they fail**
+
+```bash
+npx vitest run shared/gameEngine.test.js --reporter=verbose 2>&1 | grep -A 5 "reveal_partner"
+```
+
+Expected: both new tests FAIL — `getPlayerView` doesn't check `reveal_partner` yet.
+
+---
+
+### Task 2: Fix `getPlayerView` to respect `reveal_partner`
+
+**Files:**
+- Modify: `shared/gameEngine.js` (around line 914)
+
+- [ ] **Step 1: Update the partner-hiding condition in `getPlayerView`**
+
+Find this block in `shared/gameEngine.js` (around line 914):
+
+```js
+  // Hide partner identity until revealed (don't expose to non-partners)
+  if (!view.partnerRevealed && view.partner && view.partner !== userId && view.picker !== userId) {
+    view.partner = null
+  }
+```
+
+Replace it with:
+
+```js
+  // Hide partner identity from bystanders when:
+  // 1. The ace hasn't been played yet (partnerRevealed is false), OR
+  // 2. The "identify partner" game option is disabled (reveal_partner is false)
+  const partnerVisible = view.partnerRevealed && (view.reveal_partner ?? true)
+  if (!partnerVisible && view.partner && view.partner !== userId && view.picker !== userId) {
+    view.partner = null
+  }
+```
+
+- [ ] **Step 2: Run all tests and confirm the new tests pass and nothing regresses**
+
+```bash
+npx vitest run shared/gameEngine.test.js --reporter=verbose 2>&1 | tail -20
+```
+
+Expected: All tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add shared/gameEngine.js shared/gameEngine.test.js
+git commit -m "fix: getPlayerView respects reveal_partner setting to hide partner identity"
+```
+
+---
+
+### Task 3: Snapshot `reveal_partner` into game state at hand start
+
+**Files:**
+- Modify: `functions/api/_botHelpers.js` (line 42 area)
+- Modify: `functions/api/games/[id]/action.js` (line 67 area)
+
+- [ ] **Step 1: Update `finishHand` to snapshot `reveal_partner`**
+
+In `functions/api/_botHelpers.js`, find the `finishHand` function. After this line:
+
+```js
+  const nextState = dealHand(playerIds, nextDealer, state.handNumber + 1, 1)
+```
+
+Add:
+
+```js
+  const gameRow = await DB.prepare('SELECT reveal_partner FROM games WHERE id = ?').bind(gameId).first()
+  nextState.reveal_partner = gameRow.reveal_partner === 1
+```
+
+The full block around that area should now look like:
+
+```js
+  const nextState = dealHand(playerIds, nextDealer, state.handNumber + 1, 1)
+
+  const gameRow = await DB.prepare('SELECT reveal_partner FROM games WHERE id = ?').bind(gameId).first()
+  nextState.reveal_partner = gameRow.reveal_partner === 1
+
+  nextState.log = [...state.log, `--- Hand ${state.handNumber} complete ---`]
+  nextState.lastTrick = state.lastTrick
+```
+
+- [ ] **Step 2: Update the doublers re-deal path in `action.js` to snapshot `reveal_partner`**
+
+In `functions/api/games/[id]/action.js`, find the `pass` case around line 67. Change the existing DB query from:
+
+```js
+          const freshGame = await env.DB.prepare('SELECT no_pick_variant FROM games WHERE id = ?').bind(gameId).first()
+```
+
+To:
+
+```js
+          const freshGame = await env.DB.prepare('SELECT no_pick_variant, reveal_partner FROM games WHERE id = ?').bind(gameId).first()
+```
+
+Then, after this existing line (around line 82-84):
+
+```js
+          state = dealHand(playerIds, nextDealer, state.handNumber + 1, newMultiplier)
+          state.doublerMultiplier = newMultiplier
+          state.log.push(`Doubler! Stakes are now ×${newMultiplier}.`)
+```
+
+Add:
+
+```js
+          state.reveal_partner = freshGame.reveal_partner === 1
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add functions/api/_botHelpers.js functions/api/games/[id]/action.js
+git commit -m "feat: snapshot reveal_partner into game state at each hand start"
+```
+
+---
+
+### Task 4: Accept `reveal_partner` in the create endpoint and update `api.js`
+
+**Files:**
+- Modify: `functions/api/games/index.js`
+- Modify: `frontend/src/lib/api.js`
+
+- [ ] **Step 1: Update the create endpoint to accept `reveal_partner` and `schwanzers`**
+
+In `functions/api/games/index.js`, in the `createGame` function, find these lines (around line 72-73):
+
+```js
+  const name         = body?.name?.trim() || `${user.username}'s game`
+  const noPickVariant = body?.no_pick_variant === 'doublers' ? 'doublers' : 'leasters'
+  const testMode     = !!(body?.test_mode && user.is_admin)
+```
+
+Replace with:
+
+```js
+  const name         = body?.name?.trim() || `${user.username}'s game`
+  const VALID_VARIANTS = ['leasters', 'doublers', 'schwanzers']
+  const noPickVariant  = VALID_VARIANTS.includes(body?.no_pick_variant) ? body.no_pick_variant : 'leasters'
+  const revealPartner  = typeof body?.reveal_partner === 'boolean' ? body.reveal_partner : true
+  const testMode       = !!(body?.test_mode && user.is_admin)
+```
+
+- [ ] **Step 2: Write `reveal_partner` to the DB on game creation**
+
+Find the INSERT statement (around line 84-86):
+
+```js
+  const result = await env.DB.prepare(
+    'INSERT INTO games (name, no_pick_variant, is_test_mode, created_by) VALUES (?, ?, ?, ?)'
+  ).bind(name, noPickVariant, testMode ? 1 : 0, user.user_id).run()
+```
+
+Replace with:
+
+```js
+  const result = await env.DB.prepare(
+    'INSERT INTO games (name, no_pick_variant, reveal_partner, is_test_mode, created_by) VALUES (?, ?, ?, ?, ?)'
+  ).bind(name, noPickVariant, revealPartner ? 1 : 0, testMode ? 1 : 0, user.user_id).run()
+```
+
+- [ ] **Step 3: Snapshot `reveal_partner` in the test mode initial deal**
+
+In the test mode block (around line 111), after:
+
+```js
+    const state = dealHand(allPlayers.map(String), 0, 1, 1)
+```
+
+Add:
+
+```js
+    state.reveal_partner = revealPartner
+```
+
+- [ ] **Step 4: Update `api.games.create` to pass `reveal_partner`**
+
+In `frontend/src/lib/api.js`, change line 27:
+
+```js
+    create:         (name, noPickVariant, testMode) => request('POST',  '/games', { name, no_pick_variant: noPickVariant, test_mode: testMode }),
+```
+
+To:
+
+```js
+    create:         (name, noPickVariant, testMode, options = {}) => request('POST',  '/games', { name, no_pick_variant: noPickVariant, test_mode: testMode, ...options }),
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add functions/api/games/index.js frontend/src/lib/api.js
+git commit -m "feat: accept reveal_partner and schwanzers in game create endpoint"
+```
+
+---
+
+### Task 5: Build `GameOptionsPanel` component
+
+**Files:**
+- Create: `frontend/src/components/GameOptionsPanel.jsx`
+
+- [ ] **Step 1: Create the component**
+
+Create `frontend/src/components/GameOptionsPanel.jsx` with this content:
+
+```jsx
+import { useState, useEffect, useRef } from 'react'
+import { api } from '../lib/api.js'
+
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
+
+/**
+ * Reusable game options modal.
+ *
+ * mode="create"  — no API calls; calls onChange({ no_pick_variant, reveal_partner }) on each change.
+ * mode="update"  — auto-saves via PATCH /api/games/:gameId/settings on each change; calls onUpdated(result).
+ *
+ * The parent controls open/close via the `open` prop and `onClose` callback.
+ */
+export default function GameOptionsPanel({ mode, gameId, open, values, onChange, onUpdated, onClose }) {
+  const dialogRef  = useRef(null)
+  const [variant, setVariant] = useState(values?.no_pick_variant ?? 'leasters')
+  const [reveal,  setReveal]  = useState(values?.reveal_partner  ?? true)
+  const [saving,  setSaving]  = useState(false)
+  const [saved,   setSaved]   = useState(false)
+
+  // Re-sync form from parent values each time the panel opens
+  useEffect(() => {
+    if (open) {
+      setVariant(values?.no_pick_variant ?? 'leasters')
+      setReveal(values?.reveal_partner  ?? true)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  // Drive the native <dialog> open/close
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (open) {
+      if (!dialog.open) dialog.showModal()
+    } else {
+      if (dialog.open) dialog.close()
+    }
+  }, [open])
+
+  async function handleVariantChange(v) {
+    setVariant(v)
+    if (mode === 'create') {
+      onChange?.({ no_pick_variant: v, reveal_partner: reveal })
+    } else {
+      await save({ no_pick_variant: v })
+    }
+  }
+
+  async function handleRevealChange(v) {
+    setReveal(v)
+    if (mode === 'create') {
+      onChange?.({ no_pick_variant: variant, reveal_partner: v })
+    } else {
+      await save({ reveal_partner: v })
+    }
+  }
+
+  async function save(patch) {
+    setSaving(true)
+    setSaved(false)
+    try {
+      const result = await api.games.updateSettings(gameId, patch)
+      setSaved(true)
+      onUpdated?.(result)
+      setTimeout(() => setSaved(false), 2000)
+    } catch { /* revert handled by parent re-poll */ }
+    finally { setSaving(false) }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      style={{
+        background: '#1a1a2e',
+        border: '1px solid rgba(255,255,255,0.15)',
+        borderRadius: 10,
+        padding: '18px 22px',
+        color: '#fff',
+        minWidth: 300,
+        maxWidth: 420,
+      }}
+    >
+      <strong style={{ fontSize: '0.95rem' }}>⚙ Game options</strong>
+      {mode === 'update' && (
+        <small style={{ color: '#aaa', display: 'block', marginBottom: 12, marginTop: 2 }}>
+          Changes take effect next hand
+        </small>
+      )}
+      {mode === 'create' && (
+        <div style={{ marginBottom: 12 }} />
+      )}
+
+      {/* No-pick variant */}
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant:</div>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          {['leasters', 'doublers', 'schwanzers'].map(v => (
+            <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+              <input
+                type="radio"
+                name={`variant-${gameId ?? 'create'}`}
+                value={v}
+                checked={variant === v}
+                onChange={() => handleVariantChange(v)}
+                disabled={saving}
+              />
+              {VARIANT_LABELS[v]}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Identify partner */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>
+          Identify partner after ace is played?
+        </div>
+        <div style={{ display: 'flex', gap: 12 }}>
+          {[true, false].map(v => (
+            <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+              <input
+                type="radio"
+                name={`reveal-${gameId ?? 'create'}`}
+                value={String(v)}
+                checked={reveal === v}
+                onChange={() => handleRevealChange(v)}
+                disabled={saving}
+              />
+              {v ? 'Yes' : 'No'}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ fontSize: '0.82rem' }}>
+          {mode === 'update' && saving && <span style={{ color: '#aaa' }}>Saving…</span>}
+          {mode === 'update' && saved  && <span style={{ color: '#4ade80' }}>✓ Saved</span>}
+        </div>
+        <button
+          onClick={onClose}
+          style={{ fontSize: '0.85rem', padding: '4px 16px' }}
+        >
+          Done
+        </button>
+      </div>
+    </dialog>
+  )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add frontend/src/components/GameOptionsPanel.jsx
+git commit -m "feat: add GameOptionsPanel reusable modal component (create + update modes)"
+```
+
+---
+
+### Task 6: Update `GamePage.jsx` — replace `AdminSettingsPanel`, fix display bugs
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Add the import for `GameOptionsPanel` at the top of `GamePage.jsx`**
+
+After the existing imports (around line 8), add:
+
+```js
+import GameOptionsPanel from '../components/GameOptionsPanel.jsx'
+```
+
+- [ ] **Step 2: Add `showOptions` state**
+
+In the `GamePage` component, find the state declarations (around line 210). After:
+
+```js
+  const [revealPartner, setRevealPartner]   = useState(null)
+```
+
+Add:
+
+```js
+  const [showOptions, setShowOptions]       = useState(false)
+```
+
+- [ ] **Step 3: Delete the entire `AdminSettingsPanel` function**
+
+Remove the function from line 44 to line 121 (the entire `function AdminSettingsPanel(...)` block including its closing `}`).
+
+- [ ] **Step 4: Fix the `showPartnerName` display bug**
+
+Find this line (around line 535, now shifted after the deletion):
+
+```js
+  const showPartnerName = state.partnerRevealed && (revealPartner ?? gameData.reveal_partner ?? true)
+```
+
+Replace with:
+
+```js
+  const showPartnerName = state.partnerRevealed && (state.reveal_partner ?? true)
+```
+
+- [ ] **Step 5: Fix the partner badge display bug**
+
+Find this line (around line 531):
+
+```js
+  const partnerUserId  = state.partnerRevealed ? state.partner : null
+```
+
+Replace with:
+
+```js
+  const partnerUserId  = (state.partnerRevealed && (state.reveal_partner ?? true)) ? state.partner : null
+```
+
+- [ ] **Step 6: Replace the `AdminSettingsPanel` usage in the waiting room**
+
+Find this block in the waiting room section (around the `if (status === 'waiting')` block):
+
+```jsx
+        {isGameAdmin
+          ? (
+            <AdminSettingsPanel
+              gameId={gameId}
+              currentVariant={currentVariant ?? noPickVariant}
+              revealPartner={revealPartner ?? gameData.reveal_partner ?? true}
+              onUpdated={handleSettingsUpdate}
+            />
+          )
+          : (
+            <p style={{ color: '#aaa', fontSize: '0.85rem', marginTop: 8 }}>
+              No-pick variant: <strong>{VARIANT_LABELS[noPickVariant]}</strong>
+            </p>
+          )
+        }
+```
+
+Replace with:
+
+```jsx
+        {isGameAdmin ? (
+          <>
+            <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 10 }}>
+              <span style={{ color: '#aaa', fontSize: '0.85rem' }}>
+                {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+                Identify partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'Yes' : 'No'}
+              </span>
+              <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+                onClick={() => setShowOptions(true)}>
+                ⚙ Options
+              </button>
+            </div>
+            <GameOptionsPanel
+              mode="update"
+              gameId={gameId}
+              open={showOptions}
+              values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.reveal_partner ?? true }}
+              onUpdated={handleSettingsUpdate}
+              onClose={() => setShowOptions(false)}
+            />
+          </>
+        ) : (
+          <p style={{ color: '#aaa', fontSize: '0.85rem', marginTop: 8 }}>
+            No-pick variant: <strong>{VARIANT_LABELS[noPickVariant]}</strong>
+          </p>
+        )}
+```
+
+- [ ] **Step 7: Replace the `AdminSettingsPanel` usage in the active game area**
+
+Find this block near the bottom of the return (inside `className="score-board"`):
+
+```jsx
+      {/* ── Game admin settings (game creator only) ── */}
+      {isGameAdmin && (
+        <div className="score-board">
+          <AdminSettingsPanel
+            gameId={gameId}
+            currentVariant={currentVariant ?? noPickVariant}
+            revealPartner={revealPartner ?? gameData.reveal_partner ?? true}
+            onUpdated={handleSettingsUpdate}
+          />
+        </div>
+      )}
+```
+
+Replace with:
+
+```jsx
+      {/* ── Game admin settings (game creator only) ── */}
+      {isGameAdmin && (
+        <div className="score-board" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ color: '#aaa', fontSize: '0.78rem' }}>
+            {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+            Partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'shown' : 'hidden'}
+          </span>
+          <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+            onClick={() => setShowOptions(true)}>
+            ⚙
+          </button>
+          <GameOptionsPanel
+            mode="update"
+            gameId={gameId}
+            open={showOptions}
+            values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.reveal_partner ?? true }}
+            onUpdated={handleSettingsUpdate}
+            onClose={() => setShowOptions(false)}
+          />
+        </div>
+      )}
+```
+
+- [ ] **Step 8: Verify the app builds without errors**
+
+```bash
+npm run build 2>&1 | tail -20
+```
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/pages/GamePage.jsx
+git commit -m "fix: replace AdminSettingsPanel with GameOptionsPanel modal; fix partner display bugs"
+```
+
+---
+
+### Task 7: Update `LobbyPage.jsx` — add game options modal to create form
+
+**Files:**
+- Modify: `frontend/src/pages/LobbyPage.jsx`
+
+- [ ] **Step 1: Add import for `GameOptionsPanel`**
+
+At the top of `frontend/src/pages/LobbyPage.jsx`, after the existing imports:
+
+```js
+import GameOptionsPanel from '../components/GameOptionsPanel.jsx'
+```
+
+- [ ] **Step 2: Replace `variant` state with `gameOptions` state and add `showOptions`**
+
+Find the existing state declarations (around line 12-13):
+
+```js
+  const [variant, setVariant]   = useState('leasters')
+```
+
+Replace with:
+
+```js
+  const [gameOptions, setGameOptions] = useState({ no_pick_variant: 'leasters', reveal_partner: true })
+  const [showOptions, setShowOptions] = useState(false)
+```
+
+- [ ] **Step 3: Update `handleCreate` to use `gameOptions`**
+
+Find the `api.games.create` call inside `handleCreate` (around line 43):
+
+```js
+      const game = await api.games.create(
+        gameName.trim() || `${user.username}'s game`,
+        variant,
+        user.is_admin ? testMode : false,
+      )
+```
+
+Replace with:
+
+```js
+      const game = await api.games.create(
+        gameName.trim() || `${user.username}'s game`,
+        gameOptions.no_pick_variant,
+        user.is_admin ? testMode : false,
+        { reveal_partner: gameOptions.reveal_partner },
+      )
+```
+
+- [ ] **Step 4: Replace the variant `fieldset` with an options summary row**
+
+Find this entire `<fieldset>` block in the create form:
+
+```jsx
+            <fieldset>
+              <legend>No-pick variant</legend>
+              <label>
+                <input type="radio" name="variant" value="leasters"
+                  checked={variant === 'leasters'} onChange={() => setVariant('leasters')} />
+                Leasters — fewest points wins
+              </label>
+              <label>
+                <input type="radio" name="variant" value="doublers"
+                  checked={variant === 'doublers'} onChange={() => setVariant('doublers')} />
+                Doublers — stakes double each pass
+              </label>
+            </fieldset>
+```
+
+Replace with:
+
+```jsx
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '8px 0' }}>
+              <span style={{ fontSize: '0.85rem', color: '#aaa' }}>
+                {gameOptions.no_pick_variant.charAt(0).toUpperCase() + gameOptions.no_pick_variant.slice(1)} ·{' '}
+                Identify partner: {gameOptions.reveal_partner ? 'Yes' : 'No'}
+              </span>
+              <button
+                type="button"
+                className="outline"
+                style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+                onClick={() => setShowOptions(true)}
+              >
+                ⚙ Options
+              </button>
+            </div>
+            <GameOptionsPanel
+              mode="create"
+              open={showOptions}
+              values={gameOptions}
+              onChange={setGameOptions}
+              onClose={() => setShowOptions(false)}
+            />
+```
+
+- [ ] **Step 5: Verify the app builds without errors**
+
+```bash
+npm run build 2>&1 | tail -20
+```
+
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/LobbyPage.jsx
+git commit -m "feat: add game options modal to create game form in lobby"
+```
+
+---
+
+## Verification Checklist
+
+After all tasks are complete, manually verify in the dev environment (`npm run dev`):
+
+1. **Create game** — "⚙ Options" button appears in create form; modal opens with variant + identify partner fields; selections persist when modal is closed and form is submitted
+2. **Waiting room** — game admin sees options summary + "⚙ Options" button; modal opens, changes auto-save
+3. **Active game** — game admin sees compact options summary + ⚙ button in score board area; modal works
+4. **Partner badge** — with "Identify partner: No", the `partner` badge never appears next to any player's name after the ace is played
+5. **Info bar** — with "Identify partner: No", the called ace badge never shows the partner's name
+6. **Hand boundary** — changing identify partner mid-hand takes effect only when the next hand starts

--- a/docs/superpowers/specs/2026-04-13-identify-partner-fixes-design.md
+++ b/docs/superpowers/specs/2026-04-13-identify-partner-fixes-design.md
@@ -1,0 +1,129 @@
+# Identify Partner Fixes — Design Spec
+
+**Issue:** #38  
+**Date:** 2026-04-13  
+**Status:** Approved
+
+## Problem
+
+The "Identify partner after ace is played" feature (`reveal_partner`) has three bugs and one missing integration:
+
+1. Changing the setting mid-hand immediately updates the partner name in the info bar and the partner badge — it should only take effect on the next hand.
+2. The partner badge in `PlayerSeat` is always shown when the ace has been played, regardless of the `reveal_partner` setting. It should be hidden when the setting is `false`.
+3. `reveal_partner` is not exposed in the create game dialog — only the in-game admin panel can set it.
+4. The `AdminSettingsPanel` component is one-off and can't be reused elsewhere.
+
+## Decisions
+
+- **Hand-boundary semantics:** `reveal_partner` changes take effect at the next hand start, same as `no_pick_variant`. This is implemented by snapshotting the value into game state at `startHand()`.
+- **Reusable component:** Extract a `GameOptionsPanel` modal component usable in both the lobby create flow and the in-game admin panel.
+- **Modal everywhere:** The create game form uses the same modal pattern as the in-game admin (compact summary row + "Edit" button opens modal), keeping the form compact as options grow.
+
+## Architecture
+
+### New file: `frontend/src/components/GameOptionsPanel.jsx`
+
+A self-contained modal component with two modes:
+
+**`mode="create"`**
+- Renders variant + reveal_partner fields
+- No API calls — calls `onChange({ no_pick_variant, reveal_partner })` on each field change
+- Parent (LobbyPage) collects values and passes them to `api.games.create()`
+
+**`mode="update"`**
+- Takes `gameId` prop
+- Fires `PATCH /api/games/:id/settings` directly on each field change (same optimistic pattern as current `AdminSettingsPanel`)
+- Calls `onUpdated(result)` on success
+
+Both modes use a native `<dialog>` element. The parent controls open/close state via an `open` prop and an `onClose` callback. The trigger button lives in the parent.
+
+### `functions/api/games/[id]/action.js` — hand-start snapshot
+
+When a hand ends, `action.js` already re-reads `no_pick_variant` from the DB before calling `dealHand()`. `reveal_partner` should be read in the same block and written onto the new state:
+
+```js
+// Alongside the existing no_pick_variant re-read:
+const freshGame = await env.DB.prepare(
+  'SELECT no_pick_variant, reveal_partner FROM games WHERE id = ?'
+).bind(gameId).first()
+
+state = dealHand(playerIds, nextDealer, state.handNumber + 1, newMultiplier)
+state.reveal_partner = freshGame.reveal_partner === 1
+```
+
+`state.reveal_partner` is frozen for the duration of a hand. Mid-hand DB changes have no effect until the next hand starts.
+
+### `functions/api/games/index.js` (create endpoint)
+
+Accept `reveal_partner` (boolean) in the request body. Write it to the `games` table on creation. Default to `true` if not provided.
+
+### `frontend/src/lib/api.js`
+
+Extend `api.games.create()` to accept an options object:
+
+```js
+create(name, variant, testMode, options = {})
+// options: { reveal_partner }
+```
+
+### `frontend/src/pages/GamePage.jsx`
+
+- Remove the inline `AdminSettingsPanel` component entirely
+- Add `showOptions` boolean state
+- Add "⚙ Game options" trigger button in:
+  - The waiting room (game creator only)
+  - The active game settings area (game creator only)
+- Render `<GameOptionsPanel mode="update" ... />`
+- Fix display bugs (see below)
+
+### `frontend/src/pages/LobbyPage.jsx`
+
+- Add `showOptions` boolean state + `gameOptions` state (`{ no_pick_variant, reveal_partner }`)
+- Add compact options summary row with "Edit ⚙" button in the create form
+- Render `<GameOptionsPanel mode="create" open={showOptions} onChange={setGameOptions} onClose={...} />`
+- Pass `gameOptions.reveal_partner` to `api.games.create()`
+
+## Display Bug Fixes (`GamePage.jsx`)
+
+Both fixes gate on `state.reveal_partner` (the hand-snapshotted value) instead of the live DB value.
+
+**Bug 1 — Info bar:**
+```js
+// Before
+const showPartnerName = state.partnerRevealed && (revealPartner ?? gameData.reveal_partner ?? true)
+
+// After
+const showPartnerName = state.partnerRevealed && (state.reveal_partner ?? true)
+```
+
+**Bug 2 — Partner badge:**
+```js
+// Before
+const partnerUserId = state.partnerRevealed ? state.partner : null
+
+// After
+const partnerUserId = (state.partnerRevealed && (state.reveal_partner ?? true)) ? state.partner : null
+```
+
+The `revealPartner` local state in `GamePage` is no longer used for display logic. It is retained only to seed `GameOptionsPanel` with the current value on open.
+
+## Testing
+
+In `gameEngine.test.js`:
+
+- Construct a hand state with `reveal_partner: false` set — assert display logic correctly hides partner identity
+- Construct a hand state with `reveal_partner: true` set — assert display logic correctly shows partner identity
+- Construct a hand state without `reveal_partner` — assert it defaults to `true` (existing behavior preserved)
+- Verify no existing partner-reveal tests break from the new state field
+
+## Change Summary
+
+| File | Change |
+|---|---|
+| `functions/api/games/[id]/action.js` | Snapshot `reveal_partner` into state at hand start |
+| `shared/gameEngine.test.js` | Tests for `reveal_partner` in initial state and hand start |
+| `functions/api/games/index.js` | Accept `reveal_partner` on game create |
+| `frontend/src/lib/api.js` | Pass `reveal_partner` in `create()` |
+| `frontend/src/components/GameOptionsPanel.jsx` | New reusable modal component |
+| `frontend/src/pages/GamePage.jsx` | Remove `AdminSettingsPanel`, add modal trigger, fix display bugs |
+| `frontend/src/pages/LobbyPage.jsx` | Add options modal trigger to create form |

--- a/frontend/src/components/GameOptionsPanel.jsx
+++ b/frontend/src/components/GameOptionsPanel.jsx
@@ -1,0 +1,151 @@
+import { useState, useEffect, useRef } from 'react'
+import { api } from '../lib/api.js'
+
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
+
+/**
+ * Reusable game options modal.
+ *
+ * mode="create"  — no API calls; calls onChange({ no_pick_variant, reveal_partner }) on each change.
+ * mode="update"  — auto-saves via PATCH /api/games/:gameId/settings on each change; calls onUpdated(result).
+ *
+ * The parent controls open/close via the `open` prop and `onClose` callback.
+ */
+export default function GameOptionsPanel({ mode, gameId, open, values, onChange, onUpdated, onClose }) {
+  const dialogRef  = useRef(null)
+  const [variant, setVariant] = useState(values?.no_pick_variant ?? 'leasters')
+  const [reveal,  setReveal]  = useState(values?.reveal_partner  ?? true)
+  const [saving,  setSaving]  = useState(false)
+  const [saved,   setSaved]   = useState(false)
+
+  // Re-sync form from parent values each time the panel opens
+  useEffect(() => {
+    if (open) {
+      setVariant(values?.no_pick_variant ?? 'leasters')
+      setReveal(values?.reveal_partner  ?? true)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  // Drive the native <dialog> open/close
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (open) {
+      if (!dialog.open) dialog.showModal()
+    } else {
+      if (dialog.open) dialog.close()
+    }
+  }, [open])
+
+  async function handleVariantChange(v) {
+    setVariant(v)
+    if (mode === 'create') {
+      onChange?.({ no_pick_variant: v, reveal_partner: reveal })
+    } else {
+      await save({ no_pick_variant: v })
+    }
+  }
+
+  async function handleRevealChange(v) {
+    setReveal(v)
+    if (mode === 'create') {
+      onChange?.({ no_pick_variant: variant, reveal_partner: v })
+    } else {
+      await save({ reveal_partner: v })
+    }
+  }
+
+  async function save(patch) {
+    setSaving(true)
+    setSaved(false)
+    try {
+      const result = await api.games.updateSettings(gameId, patch)
+      setSaved(true)
+      onUpdated?.(result)
+      setTimeout(() => setSaved(false), 2000)
+    } catch { /* revert handled by parent re-poll */ }
+    finally { setSaving(false) }
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      onClose={onClose}
+      style={{
+        background: '#1a1a2e',
+        border: '1px solid rgba(255,255,255,0.15)',
+        borderRadius: 10,
+        padding: '18px 22px',
+        color: '#fff',
+        minWidth: 300,
+        maxWidth: 420,
+      }}
+    >
+      <strong style={{ fontSize: '0.95rem' }}>⚙ Game options</strong>
+      {mode === 'update' && (
+        <small style={{ color: '#aaa', display: 'block', marginBottom: 12, marginTop: 2 }}>
+          Changes take effect next hand
+        </small>
+      )}
+      {mode === 'create' && (
+        <div style={{ marginBottom: 12 }} />
+      )}
+
+      {/* No-pick variant */}
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant:</div>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          {['leasters', 'doublers', 'schwanzers'].map(v => (
+            <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+              <input
+                type="radio"
+                name={`variant-${gameId ?? 'create'}`}
+                value={v}
+                checked={variant === v}
+                onChange={() => handleVariantChange(v)}
+                disabled={saving}
+              />
+              {VARIANT_LABELS[v]}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Identify partner */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>
+          Identify partner after ace is played?
+        </div>
+        <div style={{ display: 'flex', gap: 12 }}>
+          {[true, false].map(v => (
+            <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+              <input
+                type="radio"
+                name={`reveal-${gameId ?? 'create'}`}
+                value={String(v)}
+                checked={reveal === v}
+                onChange={() => handleRevealChange(v)}
+                disabled={saving}
+              />
+              {v ? 'Yes' : 'No'}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ fontSize: '0.82rem' }}>
+          {mode === 'update' && saving && <span style={{ color: '#aaa' }}>Saving…</span>}
+          {mode === 'update' && saved  && <span style={{ color: '#4ade80' }}>✓ Saved</span>}
+        </div>
+        <button
+          onClick={onClose}
+          style={{ fontSize: '0.85rem', padding: '4px 16px' }}
+        >
+          Done
+        </button>
+      </div>
+    </dialog>
+  )
+}

--- a/frontend/src/components/GameOptionsPanel.jsx
+++ b/frontend/src/components/GameOptionsPanel.jsx
@@ -13,8 +13,8 @@ const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers:
  */
 export default function GameOptionsPanel({ mode, gameId, open, values, onChange, onUpdated, onClose }) {
   const dialogRef  = useRef(null)
-  const [variant, setVariant] = useState(values?.no_pick_variant ?? 'leasters')
-  const [reveal,  setReveal]  = useState(values?.reveal_partner  ?? true)
+  const [variant, setVariant] = useState(values?.no_pick_variant ?? 'doublers')
+  const [reveal,  setReveal]  = useState(values?.reveal_partner  ?? false)
   const [saving,  setSaving]  = useState(false)
   const [saved,   setSaved]   = useState(false)
 
@@ -71,16 +71,8 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
   return (
     <dialog
       ref={dialogRef}
+      className="game-options-dialog"
       onClose={onClose}
-      style={{
-        background: '#1a1a2e',
-        border: '1px solid rgba(255,255,255,0.15)',
-        borderRadius: 10,
-        padding: '18px 22px',
-        color: '#fff',
-        minWidth: 300,
-        maxWidth: 420,
-      }}
     >
       <strong style={{ fontSize: '0.95rem' }}>⚙ Game options</strong>
       {mode === 'update' && (
@@ -94,9 +86,9 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
 
       {/* No-pick variant */}
       <div style={{ marginBottom: 12 }}>
-        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant:</div>
+        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant</div>
         <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-          {['leasters', 'doublers', 'schwanzers'].map(v => (
+          {['doublers', 'leasters', 'schwanzers'].map(v => (
             <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
               <input
                 type="radio"
@@ -115,10 +107,10 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
       {/* Identify partner */}
       <div style={{ marginBottom: 16 }}>
         <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>
-          Identify partner after ace is played?
+          Partner Visibility
         </div>
         <div style={{ display: 'flex', gap: 12 }}>
-          {[true, false].map(v => (
+          {[false, true].map(v => (
             <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
               <input
                 type="radio"
@@ -128,7 +120,7 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
                 onChange={() => handleRevealChange(v)}
                 disabled={saving}
               />
-              {v ? 'Yes' : 'No'}
+              {v ? 'Shown' : 'Hidden'}
             </label>
           ))}
         </div>
@@ -140,6 +132,7 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
           {mode === 'update' && saved  && <span style={{ color: '#4ade80' }}>✓ Saved</span>}
         </div>
         <button
+          type="button"
           onClick={onClose}
           style={{ fontSize: '0.85rem', padding: '4px 16px' }}
         >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -418,3 +418,35 @@ body {
   font-size: 0.8rem;
   margin-top: 4px;
 }
+
+/* ── Game options dialog ─────────────────────────────────── */
+/* Pico CSS turns <dialog> into a full-screen transparent flex overlay
+   (display: flex, min-height: 100%, min-width: 100%). Scope all overrides
+   to [open] so the dialog stays hidden when closed (browser default). */
+dialog.game-options-dialog:not([open]) {
+  display: none;
+}
+
+dialog.game-options-dialog[open] {
+  display: block;
+  position: fixed;
+  inset: 0;
+  margin: auto;
+  width: fit-content;
+  min-width: 300px;
+  max-width: 420px;
+  height: fit-content;
+  min-height: unset;
+  max-height: 90vh;
+  overflow-y: auto;
+  padding: 18px 22px;
+  background: #1a1a2e;
+  background-color: #1a1a2e;
+  border: 1px solid rgba(255,255,255,0.15);
+  border-radius: 10px;
+  color: #fff;
+}
+
+dialog.game-options-dialog::backdrop {
+  background: rgba(0, 0, 0, 0.6);
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -24,7 +24,7 @@ export const api = {
   },
   games: {
     list:           ()                              => request('GET',   '/games'),
-    create:         (name, noPickVariant, testMode) => request('POST',  '/games', { name, no_pick_variant: noPickVariant, test_mode: testMode }),
+    create:         (name, noPickVariant, testMode, options = {}) => request('POST',  '/games', { name, no_pick_variant: noPickVariant, test_mode: testMode, ...options }),
     get:            (id)                            => request('GET',   `/games/${id}`),
     join:           (id)                            => request('POST',  `/games/${id}/join`),
     fillWithBots:   (id)                            => request('POST',  `/games/${id}/fill-with-bots`),

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -394,15 +394,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
         {/* Game creator controls settings */}
         {isGameAdmin ? (
           <>
-            <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 10 }}>
-              <span style={{ color: '#aaa', fontSize: '0.85rem' }}>
-                {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
-                Identify partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'Yes' : 'No'}
-              </span>
-              <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
-                onClick={() => setShowOptions(true)}>
-                ⚙ Options
-              </button>
+            <div style={{ marginTop: 8 }}>
+              <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+                <span style={{ color: '#ccc', fontSize: '0.85rem' }}>
+                  {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+                  Partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'shown' : 'hidden'}
+                </span>
+                <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+                  onClick={() => setShowOptions(true)}>
+                  ⚙ Edit
+                </button>
+              </div>
             </div>
             <GameOptionsPanel
               mode="update"
@@ -666,15 +669,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
       {/* ── Game admin settings (game creator only) ── */}
       {isGameAdmin && (
-        <div className="score-board" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <span style={{ color: '#aaa', fontSize: '0.78rem' }}>
-            {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
-            Partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'shown' : 'hidden'}
-          </span>
-          <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
-            onClick={() => setShowOptions(true)}>
-            ⚙
-          </button>
+        <div className="score-board">
+          <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+            <span style={{ color: '#aaa', fontSize: '0.78rem' }}>
+              {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+              Partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'shown' : 'hidden'}
+            </span>
+            <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+              onClick={() => setShowOptions(true)}>
+              ⚙ Edit
+            </button>
+          </div>
           <GameOptionsPanel
             mode="update"
             gameId={gameId}

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -6,6 +6,7 @@ import TrickArea, { LastTrickArea } from '../components/TrickArea.jsx'
 import ActionPanel from '../components/ActionPanel.jsx'
 import GameLog from '../components/GameLog.jsx'
 import ScoreBoard from '../components/ScoreBoard.jsx'
+import GameOptionsPanel from '../components/GameOptionsPanel.jsx'
 
 const SUIT_SYMBOLS   = { C: '♣', D: '♦', H: '♥', S: '♠' }
 const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
@@ -38,86 +39,6 @@ function resolveLogNames(entries, players) {
     }
     return s
   })
-}
-
-// ── Game admin settings panel (game creator only) ────────────────────────────
-function AdminSettingsPanel({ gameId, currentVariant, revealPartner, onUpdated }) {
-  const [variant, setVariant]             = useState(currentVariant)
-  const [reveal, setReveal]               = useState(revealPartner)
-  const [saving, setSaving]               = useState(false)
-  const [saved, setSaved]                 = useState(false)
-
-  useEffect(() => { setVariant(currentVariant) },  [currentVariant])
-  useEffect(() => { setReveal(revealPartner) },     [revealPartner])
-
-  async function save(patch) {
-    setSaving(true)
-    setSaved(false)
-    try {
-      const result = await api.games.updateSettings(gameId, patch)
-      setSaved(true)
-      onUpdated?.(result)
-      setTimeout(() => setSaved(false), 2000)
-    } catch { /* revert handled by parent re-poll */ }
-    finally { setSaving(false) }
-  }
-
-  async function handleVariantChange(v) {
-    setVariant(v)
-    await save({ no_pick_variant: v })
-  }
-
-  async function handleRevealChange(v) {
-    setReveal(v)
-    await save({ reveal_partner: v })
-  }
-
-  return (
-    <div style={{
-      background: 'rgba(0,0,0,0.5)',
-      border: '1px solid rgba(255,255,255,0.15)',
-      borderRadius: 8,
-      padding: '10px 14px',
-      color: '#fff',
-      fontSize: '0.82rem',
-    }}>
-      <strong>⚙ Game settings</strong>
-      <small style={{ color: '#aaa', display: 'block', marginBottom: 8 }}>
-        Changes take effect next hand
-      </small>
-
-      {/* No-pick variant */}
-      <div style={{ marginBottom: 8 }}>
-        <div style={{ color: '#ccc', marginBottom: 4 }}>No-pick variant:</div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          {['leasters', 'doublers', 'schwanzers'].map(v => (
-            <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
-              <input type="radio" name={`variant-${gameId}`} value={v}
-                checked={variant === v} onChange={() => handleVariantChange(v)} disabled={saving} />
-              {VARIANT_LABELS[v]}
-            </label>
-          ))}
-        </div>
-      </div>
-
-      {/* Reveal partner */}
-      <div>
-        <div style={{ color: '#ccc', marginBottom: 4 }}>Identify partner after ace is played?</div>
-        <div style={{ display: 'flex', gap: 8 }}>
-          {[true, false].map(v => (
-            <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer' }}>
-              <input type="radio" name={`reveal-${gameId}`} value={String(v)}
-                checked={reveal === v} onChange={() => handleRevealChange(v)} disabled={saving} />
-              {v ? 'Yes' : 'No'}
-            </label>
-          ))}
-        </div>
-      </div>
-
-      {saving && <span style={{ color: '#aaa', marginTop: 6, display: 'block' }}>Saving…</span>}
-      {saved  && <span style={{ color: '#4ade80', marginTop: 6, display: 'block' }}>✓ Saved</span>}
-    </div>
-  )
 }
 
 // ── Current turn helper ───────────────────────────────────────────────────────
@@ -208,6 +129,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const [leaving, setLeaving]               = useState(false)
   const [currentVariant, setCurrentVariant] = useState(null)
   const [revealPartner, setRevealPartner]   = useState(null)
+  const [showOptions, setShowOptions]       = useState(false)
   const pollingRef = useRef(null)
   // Tracks the auto-play timer for the last trick. We key by
   // `${turnUserId}:${trickLen}` so each "pending play" only schedules once,
@@ -470,21 +392,32 @@ export default function GamePage({ gameId, user, onNavigate }) {
         </div>
 
         {/* Game creator controls settings */}
-        {isGameAdmin
-          ? (
-            <AdminSettingsPanel
+        {isGameAdmin ? (
+          <>
+            <div style={{ marginTop: 8, display: 'flex', alignItems: 'center', gap: 10 }}>
+              <span style={{ color: '#aaa', fontSize: '0.85rem' }}>
+                {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+                Identify partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'Yes' : 'No'}
+              </span>
+              <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+                onClick={() => setShowOptions(true)}>
+                ⚙ Options
+              </button>
+            </div>
+            <GameOptionsPanel
+              mode="update"
               gameId={gameId}
-              currentVariant={currentVariant ?? noPickVariant}
-              revealPartner={revealPartner ?? gameData.reveal_partner ?? true}
+              open={showOptions}
+              values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.reveal_partner ?? true }}
               onUpdated={handleSettingsUpdate}
+              onClose={() => setShowOptions(false)}
             />
-          )
-          : (
-            <p style={{ color: '#aaa', fontSize: '0.85rem', marginTop: 8 }}>
-              No-pick variant: <strong>{VARIANT_LABELS[noPickVariant]}</strong>
-            </p>
-          )
-        }
+          </>
+        ) : (
+          <p style={{ color: '#aaa', fontSize: '0.85rem', marginTop: 8 }}>
+            No-pick variant: <strong>{VARIANT_LABELS[noPickVariant]}</strong>
+          </p>
+        )}
 
         <p style={{ marginTop: 16 }}>Waiting for players… ({players.length}/5)</p>
         <ul>{players.map(p => <li key={p.user_id}>{p.username}</li>)}</ul>
@@ -528,11 +461,11 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
   const dealerUserId  = state.pickOrder ? state.pickOrder[4] : null
   const pickerUserId  = state.picker
-  const partnerUserId = state.partnerRevealed ? state.partner : null
+  const partnerUserId  = (state.partnerRevealed && (state.reveal_partner ?? true)) ? state.partner : null
 
   // Called ace display
   const calledAce       = state.calledAce
-  const showPartnerName = state.partnerRevealed && (revealPartner ?? gameData.reveal_partner ?? true)
+  const showPartnerName = state.partnerRevealed && (state.reveal_partner ?? true)
   const partnerPlayer   = showPartnerName && state.partner
     ? players.find(p => String(p.user_id) === String(state.partner))
     : null
@@ -733,12 +666,22 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
       {/* ── Game admin settings (game creator only) ── */}
       {isGameAdmin && (
-        <div className="score-board">
-          <AdminSettingsPanel
+        <div className="score-board" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ color: '#aaa', fontSize: '0.78rem' }}>
+            {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+            Partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'shown' : 'hidden'}
+          </span>
+          <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+            onClick={() => setShowOptions(true)}>
+            ⚙
+          </button>
+          <GameOptionsPanel
+            mode="update"
             gameId={gameId}
-            currentVariant={currentVariant ?? noPickVariant}
-            revealPartner={revealPartner ?? gameData.reveal_partner ?? true}
+            open={showOptions}
+            values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.reveal_partner ?? true }}
             onUpdated={handleSettingsUpdate}
+            onClose={() => setShowOptions(false)}
           />
         </div>
       )}

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { api } from '../lib/api.js'
+import GameOptionsPanel from '../components/GameOptionsPanel.jsx'
 
 const STATUS_LABELS  = { waiting: 'Open', active: 'In progress' }
 const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers' }
@@ -9,7 +10,8 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
   const [loading, setLoading]   = useState(true)
   const [showCreate, setShowCreate] = useState(false)
   const [gameName, setGameName] = useState(`${user.username}'s game`)
-  const [variant, setVariant]   = useState('leasters')
+  const [gameOptions, setGameOptions] = useState({ no_pick_variant: 'leasters', reveal_partner: true })
+  const [showOptions, setShowOptions] = useState(false)
   const [testMode, setTestMode] = useState(false)
   const [creating, setCreating] = useState(false)
   const [error, setError]       = useState(null)
@@ -41,8 +43,9 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
     try {
       const game = await api.games.create(
         gameName.trim() || `${user.username}'s game`,
-        variant,
+        gameOptions.no_pick_variant,
         user.is_admin ? testMode : false,
+        { reveal_partner: gameOptions.reveal_partner },
       )
       onNavigate(`/game/${game.id}`)
     } catch (e) {
@@ -133,19 +136,27 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
                 maxLength={60}
               />
             </label>
-            <fieldset>
-              <legend>No-pick variant</legend>
-              <label>
-                <input type="radio" name="variant" value="leasters"
-                  checked={variant === 'leasters'} onChange={() => setVariant('leasters')} />
-                Leasters — fewest points wins
-              </label>
-              <label>
-                <input type="radio" name="variant" value="doublers"
-                  checked={variant === 'doublers'} onChange={() => setVariant('doublers')} />
-                Doublers — stakes double each pass
-              </label>
-            </fieldset>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '8px 0' }}>
+              <span style={{ fontSize: '0.85rem', color: '#aaa' }}>
+                {gameOptions.no_pick_variant.charAt(0).toUpperCase() + gameOptions.no_pick_variant.slice(1)} ·{' '}
+                Identify partner: {gameOptions.reveal_partner ? 'Yes' : 'No'}
+              </span>
+              <button
+                type="button"
+                className="outline"
+                style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+                onClick={() => setShowOptions(true)}
+              >
+                ⚙ Options
+              </button>
+            </div>
+            <GameOptionsPanel
+              mode="create"
+              open={showOptions}
+              values={gameOptions}
+              onChange={setGameOptions}
+              onClose={() => setShowOptions(false)}
+            />
 
             {user.is_admin && (
               <label className="test-mode-label">

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -3,7 +3,7 @@ import { api } from '../lib/api.js'
 import GameOptionsPanel from '../components/GameOptionsPanel.jsx'
 
 const STATUS_LABELS  = { waiting: 'Open', active: 'In progress' }
-const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers' }
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
 
 export default function LobbyPage({ user, onNavigate, onLogout }) {
   const [games, setGames]       = useState([])

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -10,7 +10,7 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
   const [loading, setLoading]   = useState(true)
   const [showCreate, setShowCreate] = useState(false)
   const [gameName, setGameName] = useState(`${user.username}'s game`)
-  const [gameOptions, setGameOptions] = useState({ no_pick_variant: 'leasters', reveal_partner: true })
+  const [gameOptions, setGameOptions] = useState({ no_pick_variant: 'doublers', reveal_partner: false })
   const [showOptions, setShowOptions] = useState(false)
   const [testMode, setTestMode] = useState(false)
   const [creating, setCreating] = useState(false)
@@ -136,19 +136,22 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
                 maxLength={60}
               />
             </label>
-            <div style={{ display: 'flex', alignItems: 'center', gap: 10, margin: '8px 0' }}>
-              <span style={{ fontSize: '0.85rem', color: '#aaa' }}>
-                {gameOptions.no_pick_variant.charAt(0).toUpperCase() + gameOptions.no_pick_variant.slice(1)} ·{' '}
-                Identify partner: {gameOptions.reveal_partner ? 'Yes' : 'No'}
-              </span>
-              <button
-                type="button"
-                className="outline"
-                style={{ fontSize: '0.8rem', padding: '2px 10px' }}
-                onClick={() => setShowOptions(true)}
-              >
-                ⚙ Options
-              </button>
+            <div style={{ margin: '8px 0' }}>
+              <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+                <span style={{ fontSize: '0.85rem', color: '#ccc' }}>
+                  {gameOptions.no_pick_variant.charAt(0).toUpperCase() + gameOptions.no_pick_variant.slice(1)} ·{' '}
+                  Partner: {gameOptions.reveal_partner ? 'shown' : 'hidden'}
+                </span>
+                <button
+                  type="button"
+                  className="outline"
+                  style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+                  onClick={() => setShowOptions(true)}
+                >
+                  ⚙ Edit
+                </button>
+              </div>
             </div>
             <GameOptionsPanel
               mode="create"

--- a/functions/api/_botHelpers.js
+++ b/functions/api/_botHelpers.js
@@ -41,6 +41,9 @@ export async function finishHand(DB, gameId, state) {
   const nextDealer = (state.dealerSeat + 1) % 5
   const nextState = dealHand(playerIds, nextDealer, state.handNumber + 1, 1)
 
+  const gameRow = await DB.prepare('SELECT reveal_partner FROM games WHERE id = ?').bind(gameId).first()
+  nextState.reveal_partner = gameRow.reveal_partner === 1
+
   nextState.log = [...state.log, `--- Hand ${state.handNumber} complete ---`]
   nextState.lastTrick = state.lastTrick
 

--- a/functions/api/_botHelpers.js
+++ b/functions/api/_botHelpers.js
@@ -265,6 +265,8 @@ async function resolveNoPick(state, game, DB, gameId) {
   const nextDealer = (state.dealerSeat + 1) % 5
   const newState = dealHand(playerIds, nextDealer, state.handNumber + 1, newMultiplier)
   newState.doublerMultiplier = newMultiplier
+  const gameRow = await DB.prepare('SELECT reveal_partner FROM games WHERE id = ?').bind(gameId).first()
+  newState.reveal_partner = gameRow.reveal_partner === 1
   newState.log = [...state.log, ...newState.log, `Doubler! Stakes are now ×${newMultiplier}.`]
 
   await DB.prepare(

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -64,7 +64,7 @@ export async function onRequestPost({ request, env, params }) {
         state = pass(state, userId)
         if (state.phase === 'no_pick') {
           // Re-read no_pick_variant from DB in case admin changed it mid-session
-          const freshGame = await env.DB.prepare('SELECT no_pick_variant FROM games WHERE id = ?').bind(gameId).first()
+          const freshGame = await env.DB.prepare('SELECT no_pick_variant, reveal_partner FROM games WHERE id = ?').bind(gameId).first()
           if (freshGame.no_pick_variant === 'leasters') {
             state = setupLeaster(state)
           } else if (freshGame.no_pick_variant === 'schwanzers') {
@@ -81,6 +81,7 @@ export async function onRequestPost({ request, env, params }) {
             const nextDealer = (state.dealerSeat + 1) % 5
             state = dealHand(playerIds, nextDealer, state.handNumber + 1, newMultiplier)
             state.doublerMultiplier = newMultiplier
+            state.reveal_partner = freshGame.reveal_partner === 1
             state.log.push(`Doubler! Stakes are now ×${newMultiplier}.`)
 
             await env.DB.prepare(

--- a/functions/api/games/[id]/fill-with-bots.js
+++ b/functions/api/games/[id]/fill-with-bots.js
@@ -48,6 +48,7 @@ export async function onRequestPost({ request, env, params }) {
     const playerIds = allPlayers.map(p => String(p.user_id))
 
     let state = dealHand(playerIds, 0, 1, 1)
+    state.reveal_partner = game.reveal_partner === 1
 
     await env.DB.prepare(
       "INSERT INTO game_state (game_id, state_json, updated_at) VALUES (?, ?, datetime('now'))"

--- a/functions/api/games/[id]/join.js
+++ b/functions/api/games/[id]/join.js
@@ -47,6 +47,7 @@ export async function onRequestPost({ request, env, params }) {
 
       const dealerSeat = 0
       const state = dealHand(allPlayers, dealerSeat, 1, 1)
+      state.reveal_partner = game.reveal_partner === 1
 
       await env.DB.prepare(
         'INSERT INTO game_state (game_id, state_json, updated_at) VALUES (?, ?, datetime(\'now\'))'

--- a/functions/api/games/index.js
+++ b/functions/api/games/index.js
@@ -70,8 +70,10 @@ async function createGame({ request, env }) {
   }
 
   const name         = body?.name?.trim() || `${user.username}'s game`
-  const noPickVariant = body?.no_pick_variant === 'doublers' ? 'doublers' : 'leasters'
-  const testMode     = !!(body?.test_mode && user.is_admin)
+  const VALID_VARIANTS = ['leasters', 'doublers', 'schwanzers']
+  const noPickVariant  = VALID_VARIANTS.includes(body?.no_pick_variant) ? body.no_pick_variant : 'leasters'
+  const revealPartner  = typeof body?.reveal_partner === 'boolean' ? body.reveal_partner : true
+  const testMode       = !!(body?.test_mode && user.is_admin)
 
   if (testMode) {
     // Only admins can create test games, and only one at a time
@@ -82,8 +84,8 @@ async function createGame({ request, env }) {
   }
 
   const result = await env.DB.prepare(
-    'INSERT INTO games (name, no_pick_variant, is_test_mode, created_by) VALUES (?, ?, ?, ?)'
-  ).bind(name, noPickVariant, testMode ? 1 : 0, user.user_id).run()
+    'INSERT INTO games (name, no_pick_variant, reveal_partner, is_test_mode, created_by) VALUES (?, ?, ?, ?, ?)'
+  ).bind(name, noPickVariant, revealPartner ? 1 : 0, testMode ? 1 : 0, user.user_id).run()
 
   const gameId = result.meta.last_row_id
 
@@ -109,6 +111,7 @@ async function createGame({ request, env }) {
     // All 5 seats filled — start the game immediately
     const allPlayers = [user.user_id, ...bots.map(b => b.id)]
     const state = dealHand(allPlayers.map(String), 0, 1, 1)
+    state.reveal_partner = revealPartner
 
     await env.DB.prepare(
       "INSERT INTO game_state (game_id, state_json, updated_at) VALUES (?, ?, datetime('now'))"

--- a/functions/api/games/index.js
+++ b/functions/api/games/index.js
@@ -71,8 +71,8 @@ async function createGame({ request, env }) {
 
   const name         = body?.name?.trim() || `${user.username}'s game`
   const VALID_VARIANTS = ['leasters', 'doublers', 'schwanzers']
-  const noPickVariant  = VALID_VARIANTS.includes(body?.no_pick_variant) ? body.no_pick_variant : 'leasters'
-  const revealPartner  = typeof body?.reveal_partner === 'boolean' ? body.reveal_partner : true
+  const noPickVariant  = VALID_VARIANTS.includes(body?.no_pick_variant) ? body.no_pick_variant : 'doublers'
+  const revealPartner  = typeof body?.reveal_partner === 'boolean' ? body.reveal_partner : false
   const testMode       = !!(body?.test_mode && user.is_admin)
 
   if (testMode) {

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -911,8 +911,11 @@ export function getPlayerView(state, userId) {
     }
   }
 
-  // Hide partner identity until revealed (don't expose to non-partners)
-  if (!view.partnerRevealed && view.partner && view.partner !== userId && view.picker !== userId) {
+  // Hide partner identity from bystanders when:
+  // 1. The ace hasn't been played yet (partnerRevealed is false), OR
+  // 2. The "identify partner" game option is disabled (reveal_partner is false)
+  const partnerVisible = view.partnerRevealed && (view.reveal_partner ?? true)
+  if (!partnerVisible && view.partner && view.partner !== userId && view.picker !== userId) {
     view.partner = null
   }
 

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1499,6 +1499,25 @@ describe('getPlayerView', () => {
     expect(oppView.partner).toBeNull()      // opponent sees null until revealed
   })
 
+  it('partner identity is hidden from opponents when reveal_partner is false, even if partnerRevealed is true', () => {
+    const state = { ...makeViewState(), partnerRevealed: true, reveal_partner: false }
+
+    const oppView = getPlayerView(state, 'p3')
+    expect(oppView.partner).toBeNull()
+
+    const pickerView = getPlayerView(state, 'p1')
+    expect(pickerView.partner).toBe('p2')   // picker always sees partner
+
+    const partnerView = getPlayerView(state, 'p2')
+    expect(partnerView.partner).toBe('p2')  // partner sees themselves
+  })
+
+  it('partner identity is visible to opponents when reveal_partner is true and partnerRevealed is true', () => {
+    const state = { ...makeViewState(), partnerRevealed: true, reveal_partner: true }
+    const oppView = getPlayerView(state, 'p3')
+    expect(oppView.partner).toBe('p2')
+  })
+
   it('strips rewindHistory from the player view', () => {
     // Build a minimal state with a non-empty rewindHistory
     const snapshot = { phase: 'playing', tricks: [], currentTrick: [], rewindHistory: [] }


### PR DESCRIPTION
## Summary

- **Bug fix:** `reveal_partner` changes now take effect at the next hand start, not immediately — value is snapshotted into game state at `dealHand()` time across all code paths (`action.js`, `_botHelpers.js`, `join.js`, `fill-with-bots.js`)
- **Bug fix:** Partner badge is now hidden when `reveal_partner` is false, even after the ace is played
- **New:** `reveal_partner` is now configurable in the create game dialog (previously only available in-game)
- **New:** Replaced one-off `AdminSettingsPanel` with a reusable `GameOptionsPanel` modal component (`mode="create"` for lobby, `mode="update"` for in-game admin)
- **UI polish:** "Game options" heading with right-justified Edit button, Shown/Hidden labels, Doublers as default no-pick variant, partner visibility hidden by default

## Test Plan
- [ ] Create a game — verify "Game options" row shows with Edit button, dialog opens and closes without submitting the form
- [ ] Set partner visibility to Shown before creating — verify partner is revealed after ace is played
- [ ] Set partner visibility to Hidden — verify partner badge is not shown after ace, even mid-hand
- [ ] Change `reveal_partner` mid-hand in-game admin panel — verify it does NOT take effect until the next hand
- [ ] Verify no-pick variant change also takes effect next hand only
- [ ] Non-admin players should not see the Game options row

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)