### PR TITLE
chore: add .claude/worktrees/ to .gitignore and add rewind feature plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ dist/
 .dev.vars
 *.local
 .claude/settings.local.json
+.claude/worktrees/
 .worktrees/

--- a/docs/superpowers/plans/2026-04-12-rewind.md
+++ b/docs/superpowers/plans/2026-04-12-rewind.md
@@ -1,0 +1,740 @@
+# Rewind Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add "Rewind Play" and "Rewind Trick" controls to test-mode games so an admin can step backwards through card plays within the current hand.
+
+**Architecture:** Game state embeds a `rewindHistory` array (stack of pre-play snapshots, each with `rewindHistory: []` to prevent exponential nesting). Two new pure engine functions pop snapshots and restore prior state. Two new API action types expose them behind an admin + test-mode guard. Two buttons in `GamePage.jsx` call those actions.
+
+**Tech Stack:** Vitest (tests), shared/gameEngine.js (pure functions), Cloudflare Pages Functions (API), React 18 (frontend)
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `shared/gameEngine.js` | Modify `dealHand` + `playCard`; add `rewindPlay`, `rewindTrick` |
+| `shared/gameEngine.test.js` | Add tests for the above |
+| `functions/api/games/[id]/action.js` | Add `rewind_play` and `rewind_trick` cases |
+| `frontend/src/pages/GamePage.jsx` | Add rewind buttons (test mode admin only) |
+
+---
+
+## Task 1: Initialize `rewindHistory` in `dealHand`
+
+**Files:**
+- Modify: `shared/gameEngine.js` (the `dealHand` return object, around line 105)
+- Test: `shared/gameEngine.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Add inside the existing `describe('dealHand', ...)` block in `gameEngine.test.js`:
+
+```js
+it('initializes rewindHistory as an empty array', () => {
+  const state = dealHand(['p1','p2','p3','p4','p5'], 0, 1, 1)
+  expect(state.rewindHistory).toEqual([])
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewindHistory"
+```
+Expected: FAIL — `rewindHistory` is `undefined`.
+
+- [ ] **Step 3: Add `rewindHistory: []` to the `dealHand` return object**
+
+In `shared/gameEngine.js`, find the return statement in `dealHand` (around line 105). Add the field:
+
+```js
+  return {
+    phase: 'picking',
+    handNumber,
+    dealerSeat,
+    doublerMultiplier,
+    pickOrder,
+    pickIndex: 0,
+    picker: null,
+    partner: null,
+    calledAce: null,
+    calledTen: null,
+    calledKing: null,
+    calledSuit: null,
+    callMode: null,
+    underCard: null,
+    pickerMustHold: [],
+    pickerForcedPlays: [],
+    partnerRevealed: false,
+    goingAlone: false,
+    blind,
+    discard: [],
+    hands,
+    tricks: [],
+    currentTrick: [],
+    lastTrick: [],
+    currentLeader: null,
+    handCrackMultiplier: 1,
+    crackState: null,
+    potentialBlitzes,
+    blitzes: [],
+    log: [],
+    scores: {},
+    rewindHistory: [],   // ← add this line
+  }
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewindHistory"
+```
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/gameEngine.js shared/gameEngine.test.js
+git commit -m "feat: initialize rewindHistory in dealHand"
+```
+
+---
+
+## Task 2: `playCard` pushes a history snapshot
+
+**Files:**
+- Modify: `shared/gameEngine.js` (`playCard`, around line 459)
+- Test: `shared/gameEngine.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block in `gameEngine.test.js`, after the existing `playCard` describe block:
+
+```js
+describe('rewind history (playCard)', () => {
+  function makeLeadingState() {
+    return {
+      phase: 'playing',
+      picker: 'p1',
+      partner: 'p3',
+      goingAlone: false,
+      calledAce: { suit: 'S', aceId: 'AS' },
+      calledSuit: 'S',
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: true,
+      pickerForcedPlays: [],
+      underCard: null,
+      pickOrder: ['p1','p2','p3','p4','p5'],
+      doublerMultiplier: 1,
+      handCrackMultiplier: 1,
+      crackState: null,
+      blitzes: [],
+      discard: [],
+      tricks: [],
+      currentTrick: [],
+      currentLeader: 'p1',
+      lastTrick: [],
+      log: [],
+      scores: {},
+      rewindHistory: [],
+      hands: {
+        p1: [c('K','H')],
+        p2: [c('7','H')],
+        p3: [c('8','H')],
+        p4: [c('9','H')],
+        p5: [c('10','H')],
+      },
+    }
+  }
+
+  it('adds one entry to rewindHistory per card play', () => {
+    const state = makeLeadingState()
+    const next = playCard(state, 'p1', 'KH')
+    expect(next.rewindHistory).toHaveLength(1)
+  })
+
+  it('snapshot does not contain nested rewindHistory entries (no exponential growth)', () => {
+    const state = makeLeadingState()
+    const next = playCard(state, 'p1', 'KH')
+    expect(next.rewindHistory[0].rewindHistory).toEqual([])
+  })
+
+  it('snapshot captures pre-play state (card still in hand, trick still empty)', () => {
+    const state = makeLeadingState()
+    const next = playCard(state, 'p1', 'KH')
+    const snapshot = next.rewindHistory[0]
+    expect(snapshot.currentTrick).toHaveLength(0)
+    expect(snapshot.hands.p1.some(cd => cd.id === 'KH')).toBe(true)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewind history"
+```
+Expected: FAIL — `rewindHistory` is `[]` after playCard.
+
+- [ ] **Step 3: Modify `playCard` to push a stripped snapshot**
+
+In `shared/gameEngine.js`, find `export function playCard` (around line 459). Add the snapshot push immediately after the two `assert` calls and before `const newState = deepClone(state)`:
+
+```js
+export function playCard(state, userId, cardId) {
+  assertPhase(state, 'playing')
+  assertTurn(state, userId, currentPlayer(state))
+
+  // Capture pre-play snapshot. Strip rewindHistory to prevent exponential nesting.
+  const snapshot = deepClone(state)
+  snapshot.rewindHistory = []
+
+  const newState = deepClone(state)
+  newState.rewindHistory = [...(state.rewindHistory ?? []), snapshot]
+
+  // ... rest of existing function body unchanged ...
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewind history"
+```
+Expected: all 3 PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+npm test 2>&1 | tail -10
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/gameEngine.js shared/gameEngine.test.js
+git commit -m "feat: push pre-play snapshot onto rewindHistory in playCard"
+```
+
+---
+
+## Task 3: `rewindPlay` function
+
+**Files:**
+- Modify: `shared/gameEngine.js` (add after `playCard`)
+- Test: `shared/gameEngine.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block in `gameEngine.test.js`:
+
+```js
+describe('rewindPlay', () => {
+  // Snapshot representing start of hand (before any card played)
+  function makeHandStartSnapshot(overrides = {}) {
+    return {
+      phase: 'playing',
+      picker: 'p1',
+      partner: 'p3',
+      goingAlone: false,
+      calledAce: { suit: 'S', aceId: 'AS' },
+      calledSuit: 'S',
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: true,
+      pickerForcedPlays: [],
+      underCard: null,
+      pickOrder: ['p1','p2','p3','p4','p5'],
+      doublerMultiplier: 1,
+      handCrackMultiplier: 1,
+      crackState: null,
+      blitzes: [],
+      discard: [],
+      tricks: [],
+      currentTrick: [],
+      currentLeader: 'p1',
+      lastTrick: [],
+      log: [],
+      scores: {},
+      rewindHistory: [],
+      hands: {
+        p1: [c('K','H')],
+        p2: [c('7','H')],
+        p3: [c('8','H')],
+        p4: [c('9','H')],
+        p5: [c('10','H')],
+      },
+      ...overrides,
+    }
+  }
+
+  // Current state: p1 has played KH (p2 is next); snapshot in history
+  function makeStateAfterOnePlay() {
+    const snapshot = makeHandStartSnapshot()
+    return {
+      ...makeHandStartSnapshot(),
+      hands: { ...makeHandStartSnapshot().hands, p1: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }],
+      rewindHistory: [snapshot],
+    }
+  }
+
+  it('restores currentTrick to pre-play length', () => {
+    const state = makeStateAfterOnePlay()
+    const rewound = rewindPlay(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+  })
+
+  it('restores the played card to the player hand', () => {
+    const state = makeStateAfterOnePlay()
+    const rewound = rewindPlay(state)
+    expect(rewound.hands.p1.some(cd => cd.id === 'KH')).toBe(true)
+  })
+
+  it('removes the entry from rewindHistory', () => {
+    const state = makeStateAfterOnePlay()
+    const rewound = rewindPlay(state)
+    expect(rewound.rewindHistory).toHaveLength(0)
+  })
+
+  it('throws when rewindHistory is empty', () => {
+    const state = makeHandStartSnapshot()
+    expect(() => rewindPlay(state)).toThrow('Nothing to rewind')
+  })
+
+  it('throws when phase is not playing', () => {
+    const state = makeStateAfterOnePlay()
+    state.phase = 'picking'
+    expect(() => rewindPlay(state)).toThrow()
+  })
+
+  it('resets crackState and handCrackMultiplier when restored state is at hand start', () => {
+    // Crack happened before first play — snapshot reflects the crack
+    const crackedSnapshot = makeHandStartSnapshot({ crackState: 'cracked', handCrackMultiplier: 2 })
+    const state = {
+      ...makeHandStartSnapshot({ crackState: 'cracked', handCrackMultiplier: 2 }),
+      hands: { ...makeHandStartSnapshot().hands, p1: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }],
+      rewindHistory: [crackedSnapshot],
+    }
+    const rewound = rewindPlay(state)
+    // Rewind lands at tricks=[], currentTrick=[] — must reset crack regardless of snapshot value
+    expect(rewound.crackState).toBeNull()
+    expect(rewound.handCrackMultiplier).toBe(1)
+  })
+
+  it('does NOT reset crackState when restored state is mid-trick (not hand start)', () => {
+    // Two plays in; rewinding one lands mid-trick, not at hand start
+    const s0 = makeHandStartSnapshot({ hands: { p1: [c('K','H')], p2: [c('7','H')], p3: [c('8','H')], p4: [c('9','H')], p5: [c('10','H')] } })
+    const s1 = {
+      ...s0,
+      hands: { ...s0.hands, p1: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }],
+      rewindHistory: [],
+    }
+    const state = {
+      ...s1,
+      crackState: 'cracked',
+      handCrackMultiplier: 2,
+      hands: { ...s1.hands, p2: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s0, s1],
+    }
+    const rewound = rewindPlay(state)
+    // Restores s1: currentTrick has 1 entry (not empty), so no crack reset
+    expect(rewound.currentTrick).toHaveLength(1)
+    expect(rewound.crackState).toBe('cracked')  // preserved from s1
+  })
+})
+```
+
+- [ ] **Step 2: Update the import in `gameEngine.test.js`**
+
+Add `rewindPlay` and `rewindTrick` to the import at the top of the test file:
+
+```js
+import {
+  isTrump, trumpRank, suitRank, effectiveSuit, cardPoints,
+  schwanzerCardPoints, resolveSchwanzer,
+  dealHand, pick, pass, blitz,
+  discard, callAce, goAlone, callTen, callKing,
+  callAceUnknown, crack, recrack,
+  playCard, computeScores, resolveLeaster,
+  setupLeaster, awardLeasterBlind, getPlayerView,
+  rewindPlay, rewindTrick,
+} from './gameEngine.js'
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewindPlay"
+```
+Expected: FAIL — `rewindPlay` is not a function.
+
+- [ ] **Step 4: Implement `rewindPlay` in `shared/gameEngine.js`**
+
+Add after the `playCard` function (after its closing brace), before `currentPlayer`:
+
+```js
+// ─── Rewind ──────────────────────────────────────────────────────────────────
+export function rewindPlay(state) {
+  assertPhase(state, 'playing')
+  const history = state.rewindHistory ?? []
+  if (history.length === 0) throw new Error('Nothing to rewind.')
+
+  const remaining = history.slice(0, -1)
+  const restored = history[history.length - 1]
+  restored.rewindHistory = remaining
+
+  // Rewinding to the start of the hand resets crack/recrack state
+  if (restored.tricks.length === 0 && restored.currentTrick.length === 0) {
+    restored.crackState = null
+    restored.handCrackMultiplier = 1
+  }
+
+  return restored
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewindPlay"
+```
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/gameEngine.js shared/gameEngine.test.js
+git commit -m "feat: add rewindPlay to game engine"
+```
+
+---
+
+## Task 4: `rewindTrick` function
+
+**Files:**
+- Modify: `shared/gameEngine.js` (add after `rewindPlay`)
+- Test: `shared/gameEngine.test.js`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add a new `describe` block in `gameEngine.test.js` (reuse the `makeHandStartSnapshot` helper from Task 3 — define it at the outer describe scope or duplicate it here):
+
+```js
+describe('rewindTrick', () => {
+  function makeHandStartSnapshot(overrides = {}) {
+    return {
+      phase: 'playing',
+      picker: 'p1', partner: 'p3', goingAlone: false,
+      calledAce: { suit: 'S', aceId: 'AS' }, calledSuit: 'S',
+      calledTen: null, calledKing: null,
+      partnerRevealed: true, pickerForcedPlays: [], underCard: null,
+      pickOrder: ['p1','p2','p3','p4','p5'],
+      doublerMultiplier: 1, handCrackMultiplier: 1, crackState: null,
+      blitzes: [], discard: [],
+      tricks: [], currentTrick: [], currentLeader: 'p1',
+      lastTrick: [], log: [], scores: {},
+      rewindHistory: [],
+      hands: {
+        p1: [c('K','H')], p2: [c('7','H')], p3: [c('8','H')],
+        p4: [c('9','H')], p5: [c('10','H')],
+      },
+      ...overrides,
+    }
+  }
+
+  it('is a no-op when rewindHistory is empty', () => {
+    const state = makeHandStartSnapshot()
+    const result = rewindTrick(state)
+    expect(result).toBe(state)
+  })
+
+  it('rewinds mid-trick to the start of the current trick', () => {
+    // s0: start of hand (currentTrick=[])
+    const s0 = makeHandStartSnapshot()
+    // s1: after p1 played (currentTrick=[p1])
+    const s1 = { ...makeHandStartSnapshot(), hands: { ...makeHandStartSnapshot().hands, p1: [] }, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    // current: after p2 played (currentTrick=[p1,p2])
+    const state = {
+      ...s1,
+      hands: { ...s1.hands, p2: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s0, s1],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+    expect(rewound.tricks).toHaveLength(0)
+  })
+
+  it('rewinds to the previous trick when currentTrick is already empty', () => {
+    // s0: start of hand
+    const s0 = makeHandStartSnapshot()
+    // Simulate: trick 1 played (4 snapshots for plays 1-4, since play 5 completes the trick)
+    const s1 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    const s2 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }], rewindHistory: [] }
+    const s3 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }, { userId: 'p3', card: c('8','H') }], rewindHistory: [] }
+    const s4 = { ...s0, currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }, { userId: 'p3', card: c('8','H') }, { userId: 'p4', card: c('9','H') }], rewindHistory: [] }
+    // State: start of trick 2 (currentTrick=[], tricks=[{t1}])
+    const state = {
+      ...makeHandStartSnapshot(),
+      tricks: [{ leader: 'p1', plays: [], winner: 'p1' }],  // trick 1 completed
+      currentTrick: [],
+      currentLeader: 'p1',
+      rewindHistory: [s0, s1, s2, s3, s4],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+    expect(rewound.tricks).toHaveLength(0)  // back to before trick 1
+  })
+
+  it('resets crackState and handCrackMultiplier when rewinding to hand start', () => {
+    const s0 = makeHandStartSnapshot({ crackState: 'cracked', handCrackMultiplier: 2 })
+    const s1 = { ...s0, hands: { ...s0.hands, p1: [] }, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    const state = {
+      ...s1,
+      hands: { ...s1.hands, p2: [] },
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s0, s1],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.tricks).toHaveLength(0)
+    expect(rewound.crackState).toBeNull()
+    expect(rewound.handCrackMultiplier).toBe(1)
+  })
+
+  it('does NOT reset crackState when rewinding to a mid-hand trick boundary', () => {
+    // Trick 2, 2 plays in; rewindTrick → start of trick 2 (tricks=[{t1}])
+    const s5 = makeHandStartSnapshot({
+      tricks: [{ leader: 'p1', plays: [], winner: 'p1' }],
+      currentTrick: [],
+      crackState: 'cracked',
+      handCrackMultiplier: 2,
+    })
+    const s6 = { ...s5, currentTrick: [{ userId: 'p1', card: c('K','H') }], rewindHistory: [] }
+    const state = {
+      ...s5,
+      currentTrick: [{ userId: 'p1', card: c('K','H') }, { userId: 'p2', card: c('7','H') }],
+      rewindHistory: [s5, s6],
+    }
+    const rewound = rewindTrick(state)
+    expect(rewound.currentTrick).toHaveLength(0)
+    expect(rewound.tricks).toHaveLength(1)  // trick 1 still there
+    expect(rewound.crackState).toBe('cracked')  // preserved — not at hand start
+  })
+
+  it('throws when phase is not playing', () => {
+    const state = makeHandStartSnapshot({ phase: 'picking' })
+    expect(() => rewindTrick(state)).toThrow()
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewindTrick"
+```
+Expected: FAIL — `rewindTrick` is not a function.
+
+- [ ] **Step 3: Implement `rewindTrick` in `shared/gameEngine.js`**
+
+Add immediately after `rewindPlay`:
+
+```js
+export function rewindTrick(state) {
+  assertPhase(state, 'playing')
+  const history = state.rewindHistory ?? []
+  if (history.length === 0) return state  // no-op at start of hand
+
+  let entries = [...history]
+  let restored
+
+  // Pop snapshots until we land at the start of a trick (currentTrick empty).
+  // Works for both mid-trick and start-of-trick cases: if we're already at
+  // currentTrick=[], the first pop goes back into the previous trick's plays,
+  // then we keep popping until we hit the previous trick's start.
+  do {
+    restored = entries[entries.length - 1]
+    entries = entries.slice(0, -1)
+  } while (entries.length > 0 && restored.currentTrick.length > 0)
+
+  restored.rewindHistory = entries
+
+  // Rewinding to the start of the hand resets crack/recrack state
+  if (restored.tricks.length === 0) {
+    restored.crackState = null
+    restored.handCrackMultiplier = 1
+  }
+
+  return restored
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "rewindTrick"
+```
+Expected: all PASS
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+```bash
+npm test 2>&1 | tail -10
+```
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/gameEngine.js shared/gameEngine.test.js
+git commit -m "feat: add rewindTrick to game engine"
+```
+
+---
+
+## Task 5: API layer — `rewind_play` and `rewind_trick` actions
+
+**Files:**
+- Modify: `functions/api/games/[id]/action.js`
+
+- [ ] **Step 1: Update the import at the top of `action.js`**
+
+Add `rewindPlay` and `rewindTrick` to the existing import from `gameEngine.js`:
+
+```js
+import {
+  pick, blitz, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
+  crack, recrack,
+  setupLeaster, awardLeasterBlind, resolveLeaster,
+  resolveSchwanzer,
+  dealHand, currentPlayer,
+  rewindPlay, rewindTrick,
+} from '../../../../shared/gameEngine.js'
+```
+
+- [ ] **Step 2: Add the two new `case` blocks to the `switch` statement**
+
+In the `switch (type)` block, add before the `default` case:
+
+```js
+      case 'rewind_play': {
+        if (!game.is_test_mode) return err('rewind_play is only allowed in test mode games.', 403)
+        if (!user.is_admin)     return err('Only admins can use rewind_play.', 403)
+        state = rewindPlay(state)
+        break
+      }
+
+      case 'rewind_trick': {
+        if (!game.is_test_mode) return err('rewind_trick is only allowed in test mode games.', 403)
+        if (!user.is_admin)     return err('Only admins can use rewind_trick.', 403)
+        state = rewindTrick(state)
+        break
+      }
+```
+
+- [ ] **Step 3: Skip `processBotTurns` for rewind actions**
+
+Find the existing condition that guards `processBotTurns` (around line 165):
+
+```js
+    if (type !== 'play_card' || state.phase !== 'playing') {
+      state = await processBotTurns(...)
+    }
+```
+
+Extend it to also skip for rewind actions:
+
+```js
+    if ((type !== 'play_card' && type !== 'rewind_play' && type !== 'rewind_trick') || state.phase !== 'playing') {
+      state = await processBotTurns(state, gameId, env.DB, game, { allowTrick1Lead: type === 'bot_play' })
+    }
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/api/games/[id]/action.js
+git commit -m "feat: add rewind_play and rewind_trick API actions"
+```
+
+---
+
+## Task 6: Frontend — Rewind buttons in `GamePage.jsx`
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Add the computed disable conditions**
+
+In `GamePage.jsx`, near the `crackWindowOpen` constant (around line 537), add:
+
+```js
+  const rewindHistory = state.rewindHistory ?? []
+  const canRewindPlay  = isTestMode && user.is_admin && state.phase === 'playing' && rewindHistory.length > 0
+  const canRewindTrick = isTestMode && user.is_admin && state.phase === 'playing'
+    && !(rewindHistory.length === 0 && (state.tricks ?? []).length === 0 && (state.currentTrick ?? []).length === 0)
+```
+
+- [ ] **Step 2: Add the rewind buttons to the JSX**
+
+In the JSX return, add a "Test Controls" section. Place it after the closing `)}` of the action panel block (around line 693) and before the `{/* ── Game log ── */}` comment:
+
+```jsx
+      {/* ── Test controls (admin rewind) ── */}
+      {isTestMode && user.is_admin && state.phase === 'playing' && (
+        <div style={{
+          gridColumn: '1 / -1',
+          display: 'flex',
+          gap: 8,
+          justifyContent: 'center',
+          padding: '4px 0',
+        }}>
+          <button
+            className="secondary"
+            onClick={() => handleAction('rewind_play', {})}
+            disabled={!canRewindPlay || actionLoading}
+            style={{ fontSize: '0.8rem' }}
+          >
+            Rewind Play
+          </button>
+          <button
+            className="secondary"
+            onClick={() => handleAction('rewind_trick', {})}
+            disabled={!canRewindTrick || actionLoading}
+            style={{ fontSize: '0.8rem' }}
+          >
+            Rewind Trick
+          </button>
+        </div>
+      )}
+```
+
+- [ ] **Step 3: Start the dev server and manually verify**
+
+```bash
+npm run dev
+```
+
+Open a test-mode game as an admin. Verify:
+1. Rewind buttons are not visible in non-test-mode games
+2. Rewind buttons appear during the playing phase
+3. Both buttons are disabled before the first card is played
+4. After playing a card, "Rewind Play" is enabled; clicking it returns the card to the player's hand
+5. After playing cards, "Rewind Trick" rewinds all cards in the current trick
+6. "Rewind Trick" at the start of a trick rewinds to the previous trick
+7. At the very start of the hand, both buttons are disabled
+8. After rewinding to the start of the hand, crack/recrack controls become available again (if applicable)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/GamePage.jsx
+git commit -m "feat: add Rewind Play and Rewind Trick buttons for test mode admins"
+```


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore`
- Adds `docs/superpowers/plans/2026-04-12-rewind.md` — implementation plan for the Rewind Play/Trick feature

## Test plan
- [x] Verify `.claude/worktrees/` is ignored by git after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)