### PR TITLE
fix: correct schneider boundary to <=30 pts

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -89,7 +89,7 @@ The picker team needs **61 or more points** out of 120 to win.
 | Condition | Base Multiplier |
 |-----------|----------------|
 | Normal win/loss | ×1 |
-| Schneider (winner ≥91 pts, or loser ≤29 pts) | ×2 |
+| Schneider (winner ≥91 pts, or loser ≤30 pts) | ×2 |
 | Schwarz (one side takes all 6 tricks) | ×3 |
 
 The final multiplier is: `base × doubler × crack × blitz`.

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -768,7 +768,7 @@ export function computeScores(state) {
   const opponents = Object.keys(state.hands).filter(uid => !pickerTeam.includes(uid))
 
   let baseMultiplier = 1
-  if (pickerTeamPoints >= 91 || (!pickerWon && pickerTeamPoints <= 29)) baseMultiplier = 2  // schneider
+  if (pickerTeamPoints >= 91 || (!pickerWon && pickerTeamPoints <= 30)) baseMultiplier = 2  // schneider
   if (pickerTeamTricks === 6 || pickerTeamTricks === 0) baseMultiplier = 3  // schwarz
 
   const blitzMultiplier = (state.blitzes?.length ?? 0) > 0 ? 2 : 1


### PR DESCRIPTION
Closes #46.

## Summary

- The losing picker team's schneider threshold was `<= 29` instead of `<= 30`, meaning a hand where the picker team scored exactly 30 points would incorrectly be scored as a normal loss (×1) rather than schneider (×2).
- Updated `RULES.md` to match the corrected boundary.

## Multiplier logic review

As part of investigating #46, the full multiplier calculation was reviewed against the [Wikipedia scoring table](https://en.wikipedia.org/wiki/Sheepshead_(card_game)#Scoring). **The multiplier logic itself is correct** — the `baseMultiplier` tiers (1/2/3), the blitz doubling, the doubler, and the hand crack all compute accurately. The only issue was this off-by-one on the schneider boundary.

## Test plan

- [ ] Hand where picker team scores exactly 30 pts → schneider (×2 base)
- [ ] Hand where picker team scores 31 pts → normal loss (×1 base)
- [ ] Hand where picker team scores exactly 91 pts → schneider (×2 base)
- [ ] All other scoring tiers unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)