### PR TITLE
fix: hide partner reveal log entry when reveal_partner is off

### DIFF
--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -513,7 +513,9 @@ export function playCard(state, userId, cardId) {
       newState.calledKing?.kingId
     if (calledCardId && card.id === calledCardId && userId === newState.partner) {
       newState.partnerRevealed = true
-      newState.log.push(`${userId} revealed as partner by playing the ${card.id}.`)
+      if (newState.reveal_partner) {
+        newState.log.push(`${userId} revealed as partner by playing the ${card.id}.`)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Gates the "revealed as partner" game log message on `reveal_partner` being enabled
- When partner visibility is set to hidden, opponents won't see the partner identity in the log when the called card is played

## Test plan
- [ ] Play a hand with `reveal_partner = false` — confirm no "revealed as partner" log entry appears when the called card is played
- [ ] Play a hand with `reveal_partner = true` — confirm the log entry still appears as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)