### PR TITLE
feat: display build hash in lobby footer

### DIFF
--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -242,6 +242,9 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
           </article>
         )
       })}
+      <p style={{ textAlign: 'right', fontFamily: 'monospace', fontSize: '0.65rem', color: 'rgba(255,255,255,0.25)', marginTop: 24 }}>
+        Build {__GIT_HASH__}
+      </p>
     </div>
   )
 }

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,8 +1,14 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+import { execFileSync } from 'child_process'
+
+const gitHash = execFileSync('git', ['rev-parse', 'HEAD']).toString().trim().slice(0, 7)
 
 export default defineConfig({
+  define: {
+    __GIT_HASH__: JSON.stringify(gitHash),
+  },
   plugins: [react()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Injects the current git commit hash at Vite build time via `execFileSync` + `define`
- Renders the first 7 characters as `Build <hash>` in a muted right-aligned footer at the bottom of the lobby

## Test plan
- [x] Start dev server and verify hash appears in lobby footer
- [x] Confirm hash matches `git rev-parse HEAD | cut -c1-7`
- [x] Verify no visual interference with game page

🤖 Generated with [Claude Code](https://claude.com/claude-code)