### PR TITLE
feat: bot strategy improvements (schmearing, void discard, trump counting, go-alone, pick decision)

### DIFF
--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -37,6 +37,7 @@ export function trumpRemainingElsewhere(view, userId) {
 // Returns 0 if fewer than 2 non-trump cards exist.
 export function buriablePoints(hand) {
   const nonTrump = hand.filter(c => !c.hidden && !isTrump(c))
+  if (nonTrump.length < 2) return 0
   const sorted = [...nonTrump].sort((a, b) => cardPoints(b) - cardPoints(a))
   return sorted.slice(0, 2).reduce((sum, c) => sum + cardPoints(c), 0)
 }

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -2,7 +2,7 @@
 // Pure functions that derive facts from a player's view (own hand + played cards).
 // No decisions, no side effects. All functions receive a getPlayerView-redacted view.
 
-import { isTrump } from './gameEngine.js'
+import { isTrump, cardPoints, schwanzerCardPoints } from './gameEngine.js'
 
 // ─── Trump tracking ───────────────────────────────────────────────────────────
 
@@ -29,4 +29,21 @@ export function trumpRemainingElsewhere(view, userId) {
   const myTrump = (view.hands[userId] ?? []).filter(c => !c.hidden && isTrump(c)).length
   const discardTrump = (view.discard ?? []).filter(c => !c.hidden && isTrump(c)).length
   return 14 - myTrump - countTrumpPlayed(view, userId) - discardTrump
+}
+
+// ─── Hand evaluation ──────────────────────────────────────────────────────────
+
+// Sum of card points for the top 2 non-trump cards in hand.
+// Returns 0 if fewer than 2 non-trump cards exist.
+export function buriablePoints(hand) {
+  const nonTrump = hand.filter(c => !c.hidden && !isTrump(c))
+  const sorted = [...nonTrump].sort((a, b) => cardPoints(b) - cardPoints(a))
+  return sorted.slice(0, 2).reduce((sum, c) => sum + cardPoints(c), 0)
+}
+
+// Combined hand quality score for the pick decision.
+// schwanzerPts * 4 + buriablePoints. Threshold: >= 24 → pick.
+export function handScore(hand) {
+  const schwanzerPts = hand.reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
+  return schwanzerPts * 4 + buriablePoints(hand)
 }

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -45,6 +45,6 @@ export function buriablePoints(hand) {
 // Combined hand quality score for the pick decision.
 // schwanzerPts * 4 + buriablePoints. Threshold: >= 24 → pick.
 export function handScore(hand) {
-  const schwanzerPts = hand.reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
+  const schwanzerPts = hand.filter(c => !c.hidden).reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
   return schwanzerPts * 4 + buriablePoints(hand)
 }

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -2,7 +2,7 @@
 // Pure functions that derive facts from a player's view (own hand + played cards).
 // No decisions, no side effects. All functions receive a getPlayerView-redacted view.
 
-import { isTrump, cardPoints, schwanzerCardPoints } from './gameEngine.js'
+import { isTrump, cardPoints, schwanzerCardPoints, effectiveSuit, trumpRank, suitRank } from './gameEngine.js'
 
 // ─── Trump tracking ───────────────────────────────────────────────────────────
 
@@ -47,4 +47,58 @@ export function buriablePoints(hand) {
 export function handScore(hand) {
   const schwanzerPts = hand.filter(c => !c.hidden).reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
   return schwanzerPts * 4 + buriablePoints(hand)
+}
+
+// ─── Trick evaluation ─────────────────────────────────────────────────────────
+
+// Returns true if challenger beats current card given the led suit.
+export function beats(challenger, current, ledSuit) {
+  if (!current || current.hidden || current.faceDown) return true
+  const cTrump = isTrump(challenger)
+  const wTrump = isTrump(current)
+  if (cTrump && !wTrump) return true
+  if (!cTrump && wTrump) return false
+  if (cTrump && wTrump) return trumpRank(challenger) < trumpRank(current)
+  const cIsLed = challenger.suit === ledSuit
+  const wIsLed = current.suit === ledSuit
+  if (cIsLed && !wIsLed) return true
+  if (!cIsLed && wIsLed) return false
+  if (challenger.suit !== current.suit) return false
+  return suitRank(challenger) < suitRank(current)
+}
+
+// Returns the play object currently winning the trick (array of {userId, card}).
+export function currentWinner(trick) {
+  if (!trick || trick.length === 0) return null
+  const first = trick[0]
+  const ledSuit = first.declaredSuit ?? effectiveSuit(first.card)
+  let winner = trick[0]
+  for (let i = 1; i < trick.length; i++) {
+    if (beats(trick[i].card, winner.card, ledSuit)) winner = trick[i]
+  }
+  return winner
+}
+
+// ─── Schmear detection ────────────────────────────────────────────────────────
+
+// Returns true if the player currently winning the trick is on the same team as userId.
+// Picker-team bots: teammate = picker or partner.
+// Opponent bots: only returns true when partner is known AND winner is confirmed opponent.
+//   If partner is null (unrevealed), returns false — unsafe to schmear.
+export function teammateWinning(view, userId) {
+  const { currentTrick, picker, partner } = view
+  if (!currentTrick || currentTrick.length === 0) return false
+
+  const winner = currentWinner(currentTrick)
+  if (!winner) return false
+  const winnerId = winner.userId
+
+  const onPickerTeam = userId === picker || userId === partner
+
+  if (onPickerTeam) {
+    return winnerId === picker || winnerId === partner
+  } else {
+    if (partner === null) return false
+    return winnerId !== picker && winnerId !== partner
+  }
 }

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -79,6 +79,61 @@ export function currentWinner(trick) {
   return winner
 }
 
+// ─── Void analysis ────────────────────────────────────────────────────────────
+
+// Returns 2 card IDs whose burial voids a non-trump suit with combined points >= 11,
+// or null if no qualifying void exists.
+//
+// For a 1-card suit: pairs the suit card with the highest-point eligible card from any
+// other suit (chosen for point value, not secondary voiding).
+// Among qualifying pairs, returns the highest-total pair.
+// Respects mustHold restrictions (same logic as decideDiscard).
+export function bestVoidDiscard(hand) {
+  const failAces = ['AC', 'AH', 'AS']
+  const failTens = ['10C', '10H', '10S']
+  const holdsAllAces = failAces.every(id => hand.some(c => c.id === id))
+  const holdsAllTens = failTens.every(id => hand.some(c => c.id === id))
+
+  let mustHold = []
+  if (holdsAllAces && holdsAllTens) mustHold = [...failAces, ...failTens]
+  else if (holdsAllAces) mustHold = [...failAces]
+
+  const eligible = hand.filter(c => !isTrump(c) && !mustHold.includes(c.id))
+
+  const bySuit = {}
+  for (const card of eligible) {
+    if (!bySuit[card.suit]) bySuit[card.suit] = []
+    bySuit[card.suit].push(card)
+  }
+
+  let bestPair = null
+  let bestTotal = 10  // require > 10 (i.e., >= 11)
+
+  for (const [suit, cards] of Object.entries(bySuit)) {
+    if (cards.length === 1) {
+      // Need a filler from another suit (highest-point eligible card)
+      const filler = eligible
+        .filter(c => c.suit !== suit)
+        .sort((a, b) => cardPoints(b) - cardPoints(a))[0]
+      if (!filler) continue
+      const total = cardPoints(cards[0]) + cardPoints(filler)
+      if (total > bestTotal) {
+        bestTotal = total
+        bestPair = [cards[0].id, filler.id]
+      }
+    } else if (cards.length === 2) {
+      const total = cardPoints(cards[0]) + cardPoints(cards[1])
+      if (total > bestTotal) {
+        bestTotal = total
+        bestPair = [cards[0].id, cards[1].id]
+      }
+    }
+    // 3+ cards: burying 2 won't void this suit — skip
+  }
+
+  return bestPair
+}
+
 // ─── Schmear detection ────────────────────────────────────────────────────────
 
 // Returns true if the player currently winning the trick is on the same team as userId.

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -2,13 +2,14 @@
 // Pure functions that derive facts from a player's view (own hand + played cards).
 // No decisions, no side effects. All functions receive a getPlayerView-redacted view.
 
-import { isTrump, cardPoints, schwanzerCardPoints, effectiveSuit, trumpRank, suitRank } from './gameEngine.js'
+import { isTrump } from './gameEngine.js'
 
 // ─── Trump tracking ───────────────────────────────────────────────────────────
 
 // Count trump cards visible in completed tricks and the current trick.
 // Skips hidden/face-down plays the bot cannot see.
-export function countTrumpPlayed(view, userId) {
+// userId is unused here but kept for API symmetry with trumpRemainingElsewhere
+export function countTrumpPlayed(view, _userId) {
   let count = 0
   for (const trick of (view.tricks ?? [])) {
     for (const play of trick.plays) {
@@ -26,5 +27,6 @@ export function countTrumpPlayed(view, userId) {
 // A result ≤ 2 means opponents are likely trump-exhausted.
 export function trumpRemainingElsewhere(view, userId) {
   const myTrump = (view.hands[userId] ?? []).filter(c => !c.hidden && isTrump(c)).length
-  return 14 - myTrump - countTrumpPlayed(view, userId)
+  const discardTrump = (view.discard ?? []).filter(c => !c.hidden && isTrump(c)).length
+  return 14 - myTrump - countTrumpPlayed(view, userId) - discardTrump
 }

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -1,0 +1,30 @@
+// ─── Bot Inference ────────────────────────────────────────────────────────────
+// Pure functions that derive facts from a player's view (own hand + played cards).
+// No decisions, no side effects. All functions receive a getPlayerView-redacted view.
+
+import { isTrump, cardPoints, schwanzerCardPoints, effectiveSuit, trumpRank, suitRank } from './gameEngine.js'
+
+// ─── Trump tracking ───────────────────────────────────────────────────────────
+
+// Count trump cards visible in completed tricks and the current trick.
+// Skips hidden/face-down plays the bot cannot see.
+export function countTrumpPlayed(view, userId) {
+  let count = 0
+  for (const trick of (view.tricks ?? [])) {
+    for (const play of trick.plays) {
+      if (!play.card.hidden && isTrump(play.card)) count++
+    }
+  }
+  for (const play of (view.currentTrick ?? [])) {
+    if (!play.card.hidden && isTrump(play.card)) count++
+  }
+  return count
+}
+
+// Estimate trump still held by players other than userId.
+// Formula: 14 total − own trump − trump seen in tricks.
+// A result ≤ 2 means opponents are likely trump-exhausted.
+export function trumpRemainingElsewhere(view, userId) {
+  const myTrump = (view.hands[userId] ?? []).filter(c => !c.hidden && isTrump(c)).length
+  return 14 - myTrump - countTrumpPlayed(view, userId)
+}

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -244,6 +244,7 @@ export function decidePlay(view, userId) {
       // Cash a fail Ace when opponents are likely trump-exhausted
       if (trumpRemainingElsewhere(view, userId) <= 2) {
         const failAces = realCards.filter(c => !isTrump(c) && c.rank === 'A')
+                                   .sort((a, b) => cardPoints(b) - cardPoints(a))
         if (failAces.length > 0) return failAces[0].id
       }
       // Lead strongest trump to win tricks and accumulate points
@@ -255,6 +256,7 @@ export function decidePlay(view, userId) {
       // Cash a fail Ace when picker team is likely trump-exhausted
       if (trumpRemainingElsewhere(view, userId) <= 2) {
         const failAces = realCards.filter(c => !isTrump(c) && c.rank === 'A')
+                                   .sort((a, b) => cardPoints(b) - cardPoints(a))
         if (failAces.length > 0) return failAces[0].id
       }
       // Opponent: lead a non-trump to avoid burning trump while looking for called suit

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidDiscard } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -117,6 +117,9 @@ export function decideBlitz(view, userId) {
 // ─── decideDiscard ────────────────────────────────────────────────────────────
 export function decideDiscard(view, userId) {
   const hand = view.hands[userId]  // 8 cards after picking up blind
+
+  const voidCards = bestVoidDiscard(hand)
+  if (voidCards) return voidCards
 
   // Replicate mustHold logic from gameEngine.discard to avoid illegal discards
   const failAces = ['AC', 'AH', 'AS']

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats } from './botInference.js'
+import { currentWinner, beats, handScore } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -101,23 +101,7 @@ function highestValueCard(cards) {
 // ─── decidePick ───────────────────────────────────────────────────────────────
 export function decidePick(view, userId) {
   const hand = view.hands[userId]
-  const schwanzerPts = hand.reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
-
-  if (schwanzerPts >= 7) return true
-
-  if (schwanzerPts >= 6) return true
-
-  if (schwanzerPts >= 5) {
-    // Must also have at least 20 points worth burying (fail aces/tens are ideal)
-    const nonTrump = hand.filter(c => !isTrump(c))
-    const burialPts = nonTrump
-      .sort((a, b) => cardPoints(b) - cardPoints(a))
-      .slice(0, 2)
-      .reduce((sum, c) => sum + cardPoints(c), 0)
-    return burialPts >= 20
-  }
-
-  return false
+  return handScore(hand) >= 24
 }
 
 // ─── decideBlitz ──────────────────────────────────────────────────────────────

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -187,7 +187,7 @@ export function decideCall(view, userId) {
       // Pick lowest-value non-trump card as under card; fall back to lowest trump
       const underCard =
         hand.filter(c => !isTrump(c)).sort((a, b) => cardPoints(a) - cardPoints(b))[0]
-        ?? hand.sort((a, b) => cardPoints(a) - cardPoints(b))[0]
+        ?? [...hand].sort((a, b) => cardPoints(a) - cardPoints(b))[0]
       return { type: 'ace_unknown', suit, underCardId: underCard.id }
     }
 
@@ -296,6 +296,8 @@ export function decidePlay(view, userId) {
       if (nonTrump.length > 0) return highestValueCard(nonTrump).id
       return lowestCard(realCards).id
     }
+    // Opponents play low when not schmearing — proactive trick-winning for opponents
+    // is out of scope for this iteration (see issue #82 for future improvements).
     return lowestCard(realCards).id
   }
 }

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidDiscard } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidDiscard, teammateWinning } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -257,12 +257,14 @@ export function decidePlay(view, userId) {
   // Following a trick
   const first = currentTrick[0]
   const ledSuit = first.declaredSuit ?? effectiveSuit(first.card)
-  const winner = currentWinner(currentTrick)
 
   if (isPickerTeam) {
-    // If a teammate is already winning, dump the lowest card (save resources)
-    const teammateWinning = winner && (winner.userId === picker || winner.userId === partner)
-    if (teammateWinning) return lowestCard(realCards).id
+    // Schmear: dump highest-point non-trump on teammate's winning trick
+    if (teammateWinning(view, userId)) {
+      const nonTrump = realCards.filter(c => !isTrump(c))
+      if (nonTrump.length > 0) return highestValueCard(nonTrump).id
+      return lowestCard(realCards).id  // only trump available — don't burn trump to schmear
+    }
 
     // Try to win with the lowest winning card
     const winning = realCards.filter(c => {
@@ -276,7 +278,12 @@ export function decidePlay(view, userId) {
     // Can't win; play lowest
     return lowestCard(realCards).id
   } else {
-    // Opponent: play low by default
+    // Opponent: schmear on confirmed teammate wins; otherwise play low
+    if (teammateWinning(view, userId)) {
+      const nonTrump = realCards.filter(c => !isTrump(c))
+      if (nonTrump.length > 0) return highestValueCard(nonTrump).id
+      return lowestCard(realCards).id
+    }
     return lowestCard(realCards).id
   }
 }

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidDiscard, teammateWinning } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidDiscard, teammateWinning, trumpRemainingElsewhere } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -241,12 +241,22 @@ export function decidePlay(view, userId) {
 
   if (isLeading) {
     if (isPickerTeam) {
+      // Cash a fail Ace when opponents are likely trump-exhausted
+      if (trumpRemainingElsewhere(view, userId) <= 2) {
+        const failAces = realCards.filter(c => !isTrump(c) && c.rank === 'A')
+        if (failAces.length > 0) return failAces[0].id
+      }
       // Lead strongest trump to win tricks and accumulate points
       const best = highestTrump(realCards)
       if (best) return best.id
       // No trump; lead highest-value fail card
       return highestValueCard(realCards).id
     } else {
+      // Cash a fail Ace when picker team is likely trump-exhausted
+      if (trumpRemainingElsewhere(view, userId) <= 2) {
+        const failAces = realCards.filter(c => !isTrump(c) && c.rank === 'A')
+        if (failAces.length > 0) return failAces[0].id
+      }
       // Opponent: lead a non-trump to avoid burning trump while looking for called suit
       const nonTrump = realCards.filter(c => !isTrump(c))
       if (nonTrump.length > 0) return lowestCard(nonTrump).id

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -148,6 +148,12 @@ export function decideDiscard(view, userId) {
 export function decideCall(view, userId) {
   const { callMode, hands, discard: discardCards } = view
   const hand = hands[userId]
+
+  // Go alone with a dominant trump hand
+  const trumpCount = hand.filter(c => isTrump(c)).length
+  const queenCount = hand.filter(c => c.rank === 'Q').length
+  if (trumpCount >= 6 && queenCount >= 2) return { type: 'alone' }
+
   const buried = (discardCards ?? []).filter(c => !c.hidden)
   const suits = ['C', 'H', 'S']
 

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,6 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
+import { currentWinner, beats } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -71,32 +72,6 @@ function getLegalCards(state, userId) {
 }
 
 // ─── Card comparison helpers ──────────────────────────────────────────────────
-
-function beats(challenger, current, ledSuit) {
-  if (!current || current.hidden || current.faceDown) return true
-  const cTrump = isTrump(challenger)
-  const wTrump = isTrump(current)
-  if (cTrump && !wTrump) return true
-  if (!cTrump && wTrump) return false
-  if (cTrump && wTrump) return trumpRank(challenger) < trumpRank(current)
-  const cIsLed = challenger.suit === ledSuit
-  const wIsLed = current.suit === ledSuit
-  if (cIsLed && !wIsLed) return true
-  if (!cIsLed && wIsLed) return false
-  if (challenger.suit !== current.suit) return false
-  return suitRank(challenger) < suitRank(current)
-}
-
-function currentWinner(trick) {
-  if (!trick || trick.length === 0) return null
-  const first = trick[0]
-  const ledSuit = first.declaredSuit ?? effectiveSuit(first.card)
-  let winner = trick[0]
-  for (let i = 1; i < trick.length; i++) {
-    if (beats(trick[i].card, winner.card, ledSuit)) winner = trick[i]
-  }
-  return winner
-}
 
 function lowestCard(cards) {
   // Prefer non-trump, then by point value ascending, then by trump rank descending (weaker trump)

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2056,3 +2056,87 @@ describe('decidePlay schmearing', () => {
     expect(decidePlay(view, 'p3')).toBe('9S')
   })
 })
+
+describe('decidePlay trump counting', () => {
+  function makeTrumpExhaustedView({ userId, picker, partner, handCards, trumpPlayed }) {
+    return {
+      hands: { [userId]: handCards },
+      currentTrick: [],
+      tricks: trumpPlayed.length > 0
+        ? [{ plays: trumpPlayed.map(card => ({ userId: 'other', card })), winner: 'other' }]
+        : [],
+      picker,
+      partner,
+      isLeaster: false,
+      phase: 'playing',
+      calledSuit: null,
+      calledAce: null,
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: false,
+      pickerForcedPlays: [],
+      underCard: null,
+      discard: [],
+    }
+  }
+
+  // Helper: build trump card object from ID string like 'QS', 'JC', '10D'
+  function trump(id) {
+    const rank = id.startsWith('10') ? '10' : id[0]
+    const suit = id[id.length - 1]
+    return { id, rank, suit }
+  }
+
+  it('picker team leads fail Ace instead of trump when opponents exhausted', () => {
+    // Own hand: QC (trump), AC (fail ace), KH (fail).
+    // Own trump: 1 (QC). Played trump: 13. Remaining elsewhere = 14 - 1 - 13 = 0 ≤ 2.
+    const playedTrump = ['QS','QH','QD','JC','JS','JH','JD','AD','10D','KD','9D','8D','7D'].map(trump)
+    const view = makeTrumpExhaustedView({
+      userId: 'p1',
+      picker: 'p1',
+      partner: 'p2',
+      handCards: [c('Q','C'), c('A','C'), c('K','H')],
+      trumpPlayed: playedTrump,
+    })
+    expect(decidePlay(view, 'p1')).toBe('AC')
+  })
+
+  it('picker team leads highest trump normally when opponents not exhausted', () => {
+    // No played trump → remaining = 14 - 1 - 0 = 13 > 2
+    const view = makeTrumpExhaustedView({
+      userId: 'p1',
+      picker: 'p1',
+      partner: 'p2',
+      handCards: [c('Q','C'), c('A','C'), c('K','H')],
+      trumpPlayed: [],
+    })
+    expect(decidePlay(view, 'p1')).toBe('QC')
+  })
+
+  it('opponent leads fail Ace when picker team exhausted', () => {
+    // Own trump: 0. Played trump: 13. Remaining elsewhere = 14 - 0 - 13 = 1 ≤ 2.
+    const playedTrump = ['QC','QS','QH','QD','JC','JS','JH','JD','AD','10D','KD','9D','8D'].map(trump)
+    const view = makeTrumpExhaustedView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p2',
+      handCards: [c('A','H'), c('9','S'), c('8','C')],
+      trumpPlayed: playedTrump,
+    })
+    expect(decidePlay(view, 'p3')).toBe('AH')
+  })
+
+  it('opponent leads lowest non-trump normally when trump not exhausted', () => {
+    const view = makeTrumpExhaustedView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p2',
+      handCards: [c('A','H'), c('9','S'), c('8','C')],
+      trumpPlayed: [],
+    })
+    // Normal opponent lead: lowestCard of non-trump
+    // AH=11, 9S=0, 8C=0 — lowest is 9S or 8C (both 0 pts, non-trump)
+    const result = decidePlay(view, 'p3')
+    expect(['8C', '9S']).toContain(result)
+  })
+})

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { decidePick } from './botStrategy.js'
+import { decidePick, decideDiscard } from './botStrategy.js'
 import {
   isTrump, trumpRank, suitRank, effectiveSuit, cardPoints,
   schwanzerCardPoints, resolveSchwanzer,
@@ -1933,5 +1933,25 @@ describe('decidePick', () => {
     // QC=3, JC=2 = 5 schwanzer pts; AC+AH non-trump = 22 burial; score = 42
     const hand = [c('Q','C'), c('J','C'), c('7','C'), c('A','C'), c('A','H'), c('8','S')]
     expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(true)
+  })
+})
+
+describe('decideDiscard', () => {
+  it('buries void pair when suit can be voided with >= 11 pts', () => {
+    // AC(11) + KC(4) in clubs = 15 pts → void clubs
+    const hand = [c('Q','C'), c('J','S'), c('A','D'), c('A','C'), c('K','C'), c('9','H'), c('8','S'), c('7','S')]
+    const result = decideDiscard({ hands: { p1: hand }, discard: [] }, 'p1')
+    expect(result).toHaveLength(2)
+    expect(result).toContain('AC')
+    expect(result).toContain('KC')
+  })
+
+  it('falls back to greedy when no qualifying void', () => {
+    // Hearts: 10H + 9H = 10 pts (< 11). Spades: 8S + 7S = 0 pts. No qualifying void.
+    // Greedy buries highest-point non-trump: AC(11) + 10H(10)
+    const hand = [c('Q','C'), c('J','S'), c('A','D'), c('A','C'), c('10','H'), c('9','H'), c('8','S'), c('7','S')]
+    const result = decideDiscard({ hands: { p1: hand }, discard: [] }, 'p1')
+    expect(result).toContain('AC')
+    expect(result).toContain('10H')
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -12,6 +12,7 @@ import {
 import {
   countTrumpPlayed, trumpRemainingElsewhere,
   buriablePoints, handScore,
+  currentWinner, teammateWinning,
 } from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -1735,5 +1736,89 @@ describe('handScore', () => {
     // QC=3, JC=2 = 5 schwanzer pts; AC=11, AH=11 → buriable=22; score = 5*4+22 = 42
     const hand = [c('Q','C'), c('J','C'), c('7','C'), c('A','C'), c('A','H'), c('8','S')]
     expect(handScore(hand)).toBe(42)
+  })
+})
+
+describe('currentWinner', () => {
+  it('returns the play with the highest trump when trump is led', () => {
+    const plays = [
+      { userId: 'p1', card: c('Q','C') },
+      { userId: 'p2', card: c('J','C') },
+      { userId: 'p3', card: c('A','D') },
+    ]
+    expect(currentWinner(plays).userId).toBe('p1')
+  })
+
+  it('returns the play with the highest led-suit card when no trump played', () => {
+    const plays = [
+      { userId: 'p1', card: c('K','H') },
+      { userId: 'p2', card: c('A','H') },
+      { userId: 'p3', card: c('9','H') },
+    ]
+    expect(currentWinner(plays).userId).toBe('p2')
+  })
+
+  it('trump beats led suit', () => {
+    const plays = [
+      { userId: 'p1', card: c('A','H') },
+      { userId: 'p2', card: c('7','D') },
+    ]
+    expect(currentWinner(plays).userId).toBe('p2')
+  })
+})
+
+describe('teammateWinning', () => {
+  it('returns true when picker is winning and bot is the partner', () => {
+    const view = {
+      currentTrick: [{ userId: 'p1', card: c('Q','C') }],
+      picker: 'p1',
+      partner: 'p2',
+    }
+    expect(teammateWinning(view, 'p2')).toBe(true)
+  })
+
+  it('returns true when partner is winning and bot is the picker', () => {
+    const view = {
+      currentTrick: [{ userId: 'p2', card: c('Q','C') }],
+      picker: 'p1',
+      partner: 'p2',
+    }
+    expect(teammateWinning(view, 'p1')).toBe(true)
+  })
+
+  it('returns false when an opponent is winning and bot is on picker team', () => {
+    const view = {
+      currentTrick: [{ userId: 'p3', card: c('Q','C') }],
+      picker: 'p1',
+      partner: 'p2',
+    }
+    expect(teammateWinning(view, 'p1')).toBe(false)
+  })
+
+  it('returns true when fellow opponent is winning and partner is known', () => {
+    const view = {
+      currentTrick: [{ userId: 'p4', card: c('Q','C') }],
+      picker: 'p1',
+      partner: 'p2',
+    }
+    expect(teammateWinning(view, 'p3')).toBe(true)
+  })
+
+  it('returns false when opponent bot cannot identify partner (partner null)', () => {
+    const view = {
+      currentTrick: [{ userId: 'p4', card: c('Q','C') }],
+      picker: 'p1',
+      partner: null,
+    }
+    expect(teammateWinning(view, 'p3')).toBe(false)
+  })
+
+  it('returns false when trick is empty (leading)', () => {
+    const view = {
+      currentTrick: [],
+      picker: 'p1',
+      partner: 'p2',
+    }
+    expect(teammateWinning(view, 'p1')).toBe(false)
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -11,6 +11,7 @@ import {
 } from './gameEngine.js'
 import {
   countTrumpPlayed, trumpRemainingElsewhere,
+  buriablePoints, handScore,
 } from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -1688,5 +1689,44 @@ describe('trumpRemainingElsewhere', () => {
       discard: [c('Q','S'), c('K','H')],  // picker sees their own real discard
     }
     expect(trumpRemainingElsewhere(view, 'p1')).toBe(12)
+  })
+})
+
+describe('buriablePoints', () => {
+  it('returns sum of top 2 non-trump cards by point value', () => {
+    // AC=11, 10H=10, KS=4 → top 2 are AC + 10H = 21
+    const hand = [c('Q','C'), c('J','S'), c('A','C'), c('10','H'), c('K','S'), c('9','C')]
+    expect(buriablePoints(hand)).toBe(21)
+  })
+
+  it('returns 0 when fewer than 2 non-trump cards exist', () => {
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('A','D'), c('10','D')]
+    expect(buriablePoints(hand)).toBe(0)
+  })
+
+  it('returns sum when exactly 2 non-trump cards exist', () => {
+    // KS=4, 9C=0 → 4
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('K','S'), c('9','C')]
+    expect(buriablePoints(hand)).toBe(4)
+  })
+})
+
+describe('handScore', () => {
+  it('scores at >= 24 for 6 schwanzer pts, 0 burial (6*4+0=24)', () => {
+    // QC=3, QS=3 = 6 schwanzer pts; all trump, no burial → score = 24
+    const hand = [c('Q','C'), c('Q','S'), c('A','D'), c('10','D'), c('9','D'), c('8','D')]
+    expect(handScore(hand)).toBeGreaterThanOrEqual(24)
+  })
+
+  it('scores < 24 for 5 schwanzer pts, 0 burial (5*4+0=20)', () => {
+    // QC=3, JC=2 = 5 schwanzer pts; zero-point non-trump cards → buriable=0; score = 20
+    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('8','C'), c('9','H'), c('8','H')]
+    expect(handScore(hand)).toBeLessThan(24)
+  })
+
+  it('scores at >= 24 for 5 schwanzer pts + two aces buried (5*4+22=42)', () => {
+    // QC=3, JC=2 = 5 schwanzer pts; AC=11, AH=11 → buriable=22; score = 42
+    const hand = [c('Q','C'), c('J','C'), c('A','D'), c('A','C'), c('A','H'), c('8','S')]
+    expect(handScore(hand)).toBeGreaterThanOrEqual(24)
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -9,6 +9,9 @@ import {
   setupLeaster, awardLeasterBlind, getPlayerView,
   rewindPlay, rewindTrick,
 } from './gameEngine.js'
+import {
+  countTrumpPlayed, trumpRemainingElsewhere,
+} from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
 
@@ -1594,5 +1597,84 @@ describe('getPlayerView', () => {
     }
     const view = getPlayerView(state, 'p1')
     expect(view.rewindHistory).toEqual([])
+  })
+})
+
+// ─── botInference helpers ─────────────────────────────────────────────────────
+const trick = (plays) => ({ plays: plays.map(([uid, card]) => ({ userId: uid, card })), winner: plays[0][0] })
+
+describe('countTrumpPlayed', () => {
+  it('counts trump in completed tricks', () => {
+    const view = {
+      tricks: [trick([['p1', c('Q','C')], ['p2', c('A','H')], ['p3', c('7','C')], ['p4', c('8','S')], ['p5', c('9','C')]])],
+      currentTrick: [],
+      hands: { p1: [] },
+    }
+    // QC is trump, rest are not
+    expect(countTrumpPlayed(view, 'p1')).toBe(1)
+  })
+
+  it('counts trump in currentTrick', () => {
+    const view = {
+      tricks: [],
+      currentTrick: [{ userId: 'p2', card: c('J','C') }, { userId: 'p3', card: c('K','H') }],
+      hands: { p1: [] },
+    }
+    // JC is trump, KH is not
+    expect(countTrumpPlayed(view, 'p1')).toBe(1)
+  })
+
+  it('skips hidden plays', () => {
+    const view = {
+      tricks: [{ plays: [{ userId: 'p2', card: { id: 'UNDER_CARD', hidden: true } }], winner: 'p2' }],
+      currentTrick: [],
+      hands: { p1: [] },
+    }
+    expect(countTrumpPlayed(view, 'p1')).toBe(0)
+  })
+
+  it('returns 0 when no tricks played', () => {
+    const view = { tricks: [], currentTrick: [], hands: { p1: [] } }
+    expect(countTrumpPlayed(view, 'p1')).toBe(0)
+  })
+})
+
+describe('trumpRemainingElsewhere', () => {
+  it('subtracts own trump and played trump from 14', () => {
+    // Own hand: QC, JC = 2 trump. Played: AD = 1 trump. Remaining = 14 - 2 - 1 = 11
+    const view = {
+      tricks: [trick([['p2', c('A','D')], ['p1', c('7','C')]])],
+      currentTrick: [],
+      hands: { p1: [c('Q','C'), c('J','C'), c('A','H'), c('K','S'), c('9','C'), c('8','S')] },
+    }
+    expect(trumpRemainingElsewhere(view, 'p1')).toBe(11)
+  })
+
+  it('returns 0 when all trump accounted for', () => {
+    // Own hand has 7 trump. Played tricks show 7 trump. 14 - 7 - 7 = 0.
+    const myTrump = [
+      { id: 'QC', rank: 'Q', suit: 'C' },
+      { id: 'QS', rank: 'Q', suit: 'S' },
+      { id: 'QH', rank: 'Q', suit: 'H' },
+      { id: 'QD', rank: 'Q', suit: 'D' },
+      { id: 'JC', rank: 'J', suit: 'C' },
+      { id: 'JS', rank: 'J', suit: 'S' },
+      { id: 'JH', rank: 'J', suit: 'H' },
+    ]
+    const playedTrump = [
+      { id: 'JD', rank: 'J', suit: 'D' },
+      { id: 'AD', rank: 'A', suit: 'D' },
+      { id: '10D', rank: '10', suit: 'D' },
+      { id: 'KD', rank: 'K', suit: 'D' },
+      { id: '9D', rank: '9', suit: 'D' },
+      { id: '8D', rank: '8', suit: 'D' },
+      { id: '7D', rank: '7', suit: 'D' },
+    ]
+    const view = {
+      tricks: [{ plays: playedTrump.map(card => ({ userId: 'p2', card })), winner: 'p2' }],
+      currentTrick: [],
+      hands: { p1: myTrump },
+    }
+    expect(trumpRemainingElsewhere(view, 'p1')).toBe(0)
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { decidePick, decideDiscard, decideCall } from './botStrategy.js'
+import { decidePick, decideDiscard, decideCall, decidePlay } from './botStrategy.js'
 import {
   isTrump, trumpRank, suitRank, effectiveSuit, cardPoints,
   schwanzerCardPoints, resolveSchwanzer,
@@ -1976,5 +1976,83 @@ describe('decideCall go-alone', () => {
     const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('A','D'), c('10','D'), c('A','H')]
     const view = { callMode: 'ace', hands: { p1: hand }, discard: [] }
     expect(decideCall(view, 'p1').type).not.toBe('alone')
+  })
+})
+
+describe('decidePlay schmearing', () => {
+  function makeFollowView({ userId, picker, partner, trickWinner, trickCard, handCards }) {
+    return {
+      hands: { [userId]: handCards },
+      currentTrick: [{ userId: trickWinner, card: trickCard }],
+      tricks: [],
+      picker,
+      partner,
+      isLeaster: false,
+      phase: 'playing',
+      calledSuit: null,
+      calledAce: null,
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: false,
+      pickerForcedPlays: [],
+      underCard: null,
+    }
+  }
+
+  it('picker-team bot schmears highest non-trump when partner is winning', () => {
+    // Bot is picker (p1). Partner (p2) leads QC (trump). Bot has AC(11), KH(4), 9S(0) — all off-suit.
+    // QC leads trump; bot has no trump. All cards legal (off-suit). Schmear: AC (11 pts).
+    const view = makeFollowView({
+      userId: 'p1',
+      picker: 'p1',
+      partner: 'p2',
+      trickWinner: 'p2',
+      trickCard: c('Q','C'),
+      handCards: [c('A','C'), c('K','H'), c('9','S')],
+    })
+    expect(decidePlay(view, 'p1')).toBe('AC')
+  })
+
+  it('opponent bot schmears highest non-trump when fellow opponent is winning (partner known)', () => {
+    // Bot is p3. Partner is p2 (revealed). p4 (fellow opponent) leads QC.
+    // Bot has AH(11), 9S(0), 8C(0) — all off-suit legal.
+    const view = makeFollowView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p2',
+      trickWinner: 'p4',
+      trickCard: c('Q','C'),
+      handCards: [c('A','H'), c('9','S'), c('8','C')],
+    })
+    expect(decidePlay(view, 'p3')).toBe('AH')
+  })
+
+  it('does not burn trump to schmear — plays lowest when only trump is legal', () => {
+    // Bot is picker (p1), partner (p2) winning with QC. Bot has only trump.
+    // Must follow trump. Should play lowest (7D), not burn JD.
+    const view = makeFollowView({
+      userId: 'p1',
+      picker: 'p1',
+      partner: 'p2',
+      trickWinner: 'p2',
+      trickCard: c('Q','C'),
+      handCards: [c('J','D'), c('7','D')],
+    })
+    expect(decidePlay(view, 'p1')).toBe('7D')
+  })
+
+  it('opponent does not schmear when partner is unknown (null)', () => {
+    // Bot is p3. Partner is null (unrevealed). p4 leading QC.
+    // teammateWinning returns false when partner is null → play low (9S)
+    const view = makeFollowView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      trickWinner: 'p4',
+      trickCard: c('Q','C'),
+      handCards: [c('A','H'), c('9','S'), c('8','C')],
+    })
+    // Should NOT schmear — play lowest
+    expect(decidePlay(view, 'p3')).not.toBe('AH')
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2139,4 +2139,18 @@ describe('decidePlay trump counting', () => {
     const result = decidePlay(view, 'p3')
     expect(['8C', '9S']).toContain(result)
   })
+
+  it('picks one of the fail Aces when multiple are held', () => {
+    // Own hand: QC (trump), AC, AH (two fail aces). 13 trump played. Remaining = 14 - 1 - 13 = 0.
+    const playedTrump = ['QS','QH','QD','JC','JS','JH','JD','AD','10D','KD','9D','8D','7D'].map(trump)
+    const view = makeTrumpExhaustedView({
+      userId: 'p1',
+      picker: 'p1',
+      partner: 'p2',
+      handCards: [c('Q','C'), c('A','C'), c('A','H')],
+      trumpPlayed: playedTrump,
+    })
+    // Should lead one of the fail Aces (both are 11 pts)
+    expect(['AC', 'AH']).toContain(decidePlay(view, 'p1'))
+  })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1902,4 +1902,15 @@ describe('bestVoidDiscard', () => {
     const hand = [c('A','C'), c('A','H'), c('A','S'), c('Q','C'), c('J','C'), c('K','S'), c('9','D'), c('8','D')]
     expect(bestVoidDiscard(hand)).toBeNull()
   })
+
+  it('excludes both fail aces AND fail tens when holding all 6', () => {
+    // Picker holds all 3 fail aces + all 3 fail tens → mustHold = [AC,AH,AS,10C,10H,10S]
+    // Only remaining non-trump eligible: KS (4 pts). No second eligible card → null
+    const hand = [
+      c('A','C'), c('A','H'), c('A','S'),
+      c('10','C'), c('10','H'), c('10','S'),
+      c('K','S'), c('Q','C'),
+    ]
+    expect(bestVoidDiscard(hand)).toBeNull()
+  })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -12,7 +12,7 @@ import {
 import {
   countTrumpPlayed, trumpRemainingElsewhere,
   buriablePoints, handScore,
-  currentWinner, teammateWinning,
+  beats, currentWinner, teammateWinning,
 } from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -1736,6 +1736,43 @@ describe('handScore', () => {
     // QC=3, JC=2 = 5 schwanzer pts; AC=11, AH=11 → buriable=22; score = 5*4+22 = 42
     const hand = [c('Q','C'), c('J','C'), c('7','C'), c('A','C'), c('A','H'), c('8','S')]
     expect(handScore(hand)).toBe(42)
+  })
+})
+
+describe('beats', () => {
+  it('trump beats non-trump', () => {
+    expect(beats(c('7','D'), c('A','H'), 'H')).toBe(true)   // 7D is trump, AH is not
+    expect(beats(c('A','H'), c('7','D'), 'H')).toBe(false)  // AH is not trump, 7D is
+  })
+
+  it('higher trump rank beats lower trump rank', () => {
+    expect(beats(c('Q','C'), c('Q','S'), 'T')).toBe(true)   // QC rank 0 beats QS rank 1
+    expect(beats(c('Q','S'), c('Q','C'), 'T')).toBe(false)  // QS rank 1 loses to QC rank 0
+    expect(beats(c('J','C'), c('7','D'), 'T')).toBe(true)   // JC rank 4 beats 7D rank 13
+  })
+
+  it('led-suit beats off-suit fail', () => {
+    expect(beats(c('7','H'), c('A','S'), 'H')).toBe(true)   // 7H is led suit, AS is off-suit
+    expect(beats(c('A','S'), c('7','H'), 'H')).toBe(false)  // AS is off-suit, 7H is led suit
+  })
+
+  it('higher card wins same suit', () => {
+    expect(beats(c('A','H'), c('K','H'), 'H')).toBe(true)   // A ranks higher than K
+    expect(beats(c('K','H'), c('A','H'), 'H')).toBe(false)
+  })
+
+  it('off-suit vs off-suit different suits — neither wins', () => {
+    // Challenger is off-suit (S), current is off-suit (C) — neither matches led (H)
+    expect(beats(c('A','S'), c('A','C'), 'H')).toBe(false)
+    expect(beats(c('A','C'), c('A','S'), 'H')).toBe(false)
+  })
+
+  it('returns true when current is hidden (challenger wins by default)', () => {
+    expect(beats(c('7','C'), { id: 'UNDER_CARD', hidden: true }, 'H')).toBe(true)
+  })
+
+  it('returns true when current is faceDown', () => {
+    expect(beats(c('7','C'), { id: 'UNDER_CARD', faceDown: true }, 'H')).toBe(true)
   })
 })
 

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1718,21 +1718,22 @@ describe('buriablePoints', () => {
 })
 
 describe('handScore', () => {
-  it('scores at >= 24 for 6 schwanzer pts, 0 burial (6*4+0=24)', () => {
-    // QC=3, QS=3 = 6 schwanzer pts; all trump, no burial → score = 24
-    const hand = [c('Q','C'), c('Q','S'), c('A','D'), c('10','D'), c('9','D'), c('8','D')]
-    expect(handScore(hand)).toBeGreaterThanOrEqual(24)
+  it('returns schwanzerPts * 4 + buriablePoints (exact formula check)', () => {
+    // QC=3, QS=3 = 6 schwanzer pts; 7C=0, 8C=0 non-trump → buriable=0; score = 6*4+0 = 24
+    const hand = [c('Q','C'), c('Q','S'), c('7','C'), c('8','C'), c('9','H'), c('8','H')]
+    expect(handScore(hand)).toBe(24)
   })
 
-  it('scores < 24 for 5 schwanzer pts, 0 burial (5*4+0=20)', () => {
-    // QC=3, JC=2 = 5 schwanzer pts; zero-point non-trump cards → buriable=0; score = 20
-    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('8','C'), c('9','H'), c('8','H')]
+  it('scores < 24 for 5 schwanzer pts, 0 burial', () => {
+    // QC=3, JC=2 = 5 schwanzer pts; 7C=0, 8C=0 non-trump → buriable=0; score = 5*4+0 = 20
+    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('8','C'), c('9','C'), c('9','H')]
     expect(handScore(hand)).toBeLessThan(24)
+    expect(handScore(hand)).toBe(20)
   })
 
-  it('scores at >= 24 for 5 schwanzer pts + two aces buried (5*4+22=42)', () => {
-    // QC=3, JC=2 = 5 schwanzer pts; AC=11, AH=11 → buriable=22; score = 42
-    const hand = [c('Q','C'), c('J','C'), c('A','D'), c('A','C'), c('A','H'), c('8','S')]
-    expect(handScore(hand)).toBeGreaterThanOrEqual(24)
+  it('scores >= 24 for 5 schwanzer pts + two aces to bury', () => {
+    // QC=3, JC=2 = 5 schwanzer pts; AC=11, AH=11 → buriable=22; score = 5*4+22 = 42
+    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('A','C'), c('A','H'), c('8','S')]
+    expect(handScore(hand)).toBe(42)
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1677,4 +1677,16 @@ describe('trumpRemainingElsewhere', () => {
     }
     expect(trumpRemainingElsewhere(view, 'p1')).toBe(0)
   })
+
+  it('subtracts trump visible in picker discard', () => {
+    // Picker (p1) buried QS (trump) in discard. Own hand: QC. No tricks played.
+    // Remaining = 14 - 1 (QC in hand) - 0 (played) - 1 (QS in discard) = 12
+    const view = {
+      tricks: [],
+      currentTrick: [],
+      hands: { p1: [c('Q','C'), c('A','H'), c('K','S'), c('9','C'), c('8','S'), c('7','H')] },
+      discard: [c('Q','S'), c('K','H')],  // picker sees their own real discard
+    }
+    expect(trumpRemainingElsewhere(view, 'p1')).toBe(12)
+  })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { decidePick, decideDiscard } from './botStrategy.js'
+import { decidePick, decideDiscard, decideCall } from './botStrategy.js'
 import {
   isTrump, trumpRank, suitRank, effectiveSuit, cardPoints,
   schwanzerCardPoints, resolveSchwanzer,
@@ -1953,5 +1953,28 @@ describe('decideDiscard', () => {
     const result = decideDiscard({ hands: { p1: hand }, discard: [] }, 'p1')
     expect(result).toContain('AC')
     expect(result).toContain('10H')
+  })
+})
+
+describe('decideCall go-alone', () => {
+  it('goes alone with 6 trump and 2 queens', () => {
+    // QC, QS (2 queens), JC, JH, AD, 10D = 6 trump
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','H'), c('A','D'), c('10','D')]
+    const view = { callMode: 'ace', hands: { p1: hand }, discard: [] }
+    expect(decideCall(view, 'p1').type).toBe('alone')
+  })
+
+  it('does not go alone with only 1 queen even with 6 trump', () => {
+    // QC (1 queen), JC, JS, JH, JD, AD = 6 trump
+    const hand = [c('Q','C'), c('J','C'), c('J','S'), c('J','H'), c('J','D'), c('A','D')]
+    const view = { callMode: 'ace', hands: { p1: hand }, discard: [] }
+    expect(decideCall(view, 'p1').type).not.toBe('alone')
+  })
+
+  it('does not go alone with 2 queens but only 5 trump', () => {
+    // QC, QS (2 queens), JC, AD, 10D = 5 trump; AH is fail
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('A','D'), c('10','D'), c('A','H')]
+    const view = { callMode: 'ace', hands: { p1: hand }, discard: [] }
+    expect(decideCall(view, 'p1').type).not.toBe('alone')
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
+import { decidePick } from './botStrategy.js'
 import {
   isTrump, trumpRank, suitRank, effectiveSuit, cardPoints,
   schwanzerCardPoints, resolveSchwanzer,
@@ -1912,5 +1913,25 @@ describe('bestVoidDiscard', () => {
       c('K','S'), c('Q','C'),
     ]
     expect(bestVoidDiscard(hand)).toBeNull()
+  })
+})
+
+describe('decidePick', () => {
+  it('picks when handScore >= 24 (6 schwanzer pts, 0 burial = 24)', () => {
+    // QC=3, QS=3 = 6 schwanzer pts; 7C+8C non-trump = 0 burial; score = 24
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('7','C'), c('8','C')]
+    expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(true)
+  })
+
+  it('passes when handScore < 24 (5 schwanzer pts, 0 burial = 20)', () => {
+    // QC=3, JC=2 = 5 schwanzer pts; 7C+8C non-trump = 0 burial; score = 20
+    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('8','C'), c('9','C'), c('9','H')]
+    expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(false)
+  })
+
+  it('picks when 5 schwanzer pts + two aces (score = 42)', () => {
+    // QC=3, JC=2 = 5 schwanzer pts; AC+AH non-trump = 22 burial; score = 42
+    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('A','C'), c('A','H'), c('8','S')]
+    expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(true)
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2052,7 +2052,7 @@ describe('decidePlay schmearing', () => {
       trickCard: c('Q','C'),
       handCards: [c('A','H'), c('9','S'), c('8','C')],
     })
-    // Should NOT schmear — play lowest
-    expect(decidePlay(view, 'p3')).not.toBe('AH')
+    // Should NOT schmear — play lowest (9S: 0 pts, first 0-pt non-trump encountered)
+    expect(decidePlay(view, 'p3')).toBe('9S')
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1704,6 +1704,12 @@ describe('buriablePoints', () => {
     expect(buriablePoints(hand)).toBe(0)
   })
 
+  it('returns 0 when exactly 1 non-trump card exists', () => {
+    // Only KS is non-trump; fewer than 2 → 0
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('A','D'), c('K','S')]
+    expect(buriablePoints(hand)).toBe(0)
+  })
+
   it('returns sum when exactly 2 non-trump cards exist', () => {
     // KS=4, 9C=0 → 4
     const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('K','S'), c('9','C')]

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -13,6 +13,7 @@ import {
   countTrumpPlayed, trumpRemainingElsewhere,
   buriablePoints, handScore,
   beats, currentWinner, teammateWinning,
+  bestVoidDiscard,
 } from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -1857,5 +1858,48 @@ describe('teammateWinning', () => {
       partner: 'p2',
     }
     expect(teammateWinning(view, 'p1')).toBe(false)
+  })
+})
+
+describe('bestVoidDiscard', () => {
+  it('returns 2-card IDs that void a suit when burial total >= 11', () => {
+    // AC(11) + KC(4) in clubs = 15 pts >= 11 → void clubs
+    const hand = [c('Q','C'), c('J','S'), c('A','D'), c('A','C'), c('K','C'), c('9','H'), c('8','S'), c('7','S')]
+    const result = bestVoidDiscard(hand)
+    expect(result).not.toBeNull()
+    expect(result).toHaveLength(2)
+    expect(result).toContain('AC')
+    expect(result).toContain('KC')
+  })
+
+  it('returns null when no suit can be voided with >= 11 pts', () => {
+    // Clubs: 7C + 8C = 0+0 = 0 pts, Hearts: 9H only (1 card), Spades: 7S + 8S = 0 pts
+    const hand = [c('Q','C'), c('J','S'), c('A','D'), c('10','D'), c('7','C'), c('8','C'), c('9','H'), c('7','S')]
+    expect(bestVoidDiscard(hand)).toBeNull()
+  })
+
+  it('handles 1-card suit: pairs with highest-point filler from another suit', () => {
+    // Spades: only KS (4 pts). Filler: AH (11 pts). Total = 15 → qualifies
+    const hand = [c('Q','C'), c('J','C'), c('A','D'), c('10','D'), c('K','S'), c('A','H'), c('8','C'), c('7','C')]
+    const result = bestVoidDiscard(hand)
+    expect(result).not.toBeNull()
+    expect(result).toContain('KS')
+    expect(result).toContain('AH')
+  })
+
+  it('returns null for suit with 3+ cards (burying 2 does not void it)', () => {
+    // Clubs: AC+KC+9C (3 cards), Hearts: AH+KH+9H (3 cards), Spades: AS+KS+9S (3 cards)
+    const hand = [c('Q','C'), c('A','C'), c('K','C'), c('A','H'), c('K','H'), c('A','S'), c('K','S'), c('9','C')]
+    expect(bestVoidDiscard(hand)).toBeNull()
+  })
+
+  it('excludes mustHold cards — cannot bury fail ace when holding all 3', () => {
+    // Picker holds AC, AH, AS — mustHold = [AC, AH, AS]
+    // After mustHold exclusion: no eligible cards in clubs except... check what's left
+    // Hand: AC(mustHold), AH(mustHold), AS(mustHold), QC, JC, KS, 9D, 8D
+    // Eligible non-trump non-mustHold: KS only (1 card, 4 pts). Need filler from other suit.
+    // No other eligible non-trump → null
+    const hand = [c('A','C'), c('A','H'), c('A','S'), c('Q','C'), c('J','C'), c('K','S'), c('9','D'), c('8','D')]
+    expect(bestVoidDiscard(hand)).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary

- **New module `shared/botInference.js`** — pure inference helpers that derive game facts from the bot's visible view (own hand + played cards only; no cheating)
- **Five strategy improvements to `shared/botStrategy.js`**:
  - **Schmearing** — dump highest-point non-trump on teammate's winning trick (both picker team and opponents)
  - **Void-aware discard** — prefer burying cards that void a suit when burial total ≥ 11 pts
  - **Trump counting** — lead fail Aces when `trumpRemainingElsewhere ≤ 2` (opponents can't trump them)
  - **Smarter go-alone** — picker goes alone when holding 6+ trump and 2+ queens
  - **Improved pick decision** — combined `handScore = schwanzerPts × 4 + buriablePoints ≥ 24` replaces tiered schwanzer-only thresholds
- **Bug fix** — `decideCall` ace_unknown fallback was mutating the live hand array in-place; fixed with `[...hand].sort(...)`

Closes #82

## Test Plan

- [ ] `npm test` passes (166 tests, up from 113)
- [ ] Play a game with bots and verify they schmear high-point cards on teammate wins
- [ ] Verify bots pick with mixed trump+burial hands that previously failed the old threshold
- [ ] Verify bots lead fail Aces in late tricks when trump is exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)