### PR TITLE
fix: bot opponents trump in on called suit; partner leads called suit or lowest fail

### DIFF
--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -250,6 +250,20 @@ export function decidePlay(view, userId) {
       // Lead strongest trump to win tricks and accumulate points
       const best = highestTrump(realCards)
       if (best) return best.id
+
+      // Partner with no trump: lead called suit if previous trick was low on trump,
+      // otherwise lead the lowest-point fail card
+      if (userId === partner) {
+        const { calledSuit, lastTrick = [] } = view
+        const lastTrumpCount = lastTrick.filter(p => !p.card?.hidden && isTrump(p.card)).length
+        if (lastTrumpCount <= 3) {
+          const calledSuitCards = realCards.filter(c => effectiveSuit(c) === calledSuit)
+          if (calledSuitCards.length > 0) return lowestCard(calledSuitCards).id
+        }
+        const fails = realCards.filter(c => !isTrump(c))
+        return fails.length > 0 ? lowestCard(fails).id : lowestCard(realCards).id
+      }
+
       // No trump; lead highest-value fail card
       return highestValueCard(realCards).id
     } else {
@@ -296,8 +310,16 @@ export function decidePlay(view, userId) {
       if (nonTrump.length > 0) return highestValueCard(nonTrump).id
       return lowestCard(realCards).id
     }
-    // Opponents play low when not schmearing — proactive trick-winning for opponents
-    // is out of scope for this iteration (see issue #82 for future improvements).
+    // Trump in on called suit if picker team is currently winning the trick
+    const { calledSuit } = view
+    if (ledSuit === calledSuit) {
+      const winner = currentWinner(currentTrick)
+      const opponentWinning = winner && winner.userId !== picker && winner.userId !== partner
+      if (!opponentWinning) {
+        const trumpCards = realCards.filter(c => isTrump(c))
+        if (trumpCards.length > 0) return lowestCard(trumpCards).id
+      }
+    }
     return lowestCard(realCards).id
   }
 }

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2154,3 +2154,99 @@ describe('decidePlay trump counting', () => {
     expect(['AC', 'AH']).toContain(decidePlay(view, 'p1'))
   })
 })
+
+describe('decidePlay (botStrategy)', () => {
+  function makeView({ userId, hand, trick = [], picker, partner, calledSuit, lastTrick = [] }) {
+    return {
+      hands: { [userId]: hand },
+      currentTrick: trick,
+      picker,
+      partner,
+      isLeaster: false,
+      calledSuit,
+      calledAce: calledSuit ? { aceId: `A${calledSuit}` } : null,
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: true,
+      underCard: null,
+      pickerForcedPlays: [],
+      lastTrick,
+    }
+  }
+
+  it('opponent plays trump when called suit is led and picker team is winning', () => {
+    // p1 (picker) leads 9♥ (called suit), p2 (partner) plays K♥ and is winning
+    // p3 has trump (J♦) and two fails — should trump in
+    const view = makeView({
+      userId: 'p3',
+      hand: [c('J','D'), c('8','S'), c('7','C')],
+      trick: [
+        { userId: 'p1', card: c('9','H') },
+        { userId: 'p2', card: c('K','H') },
+      ],
+      picker: 'p1',
+      partner: 'p2',
+      calledSuit: 'H',
+    })
+    expect(decidePlay(view, 'p3')).toBe('JD')
+  })
+
+  it('opponent does not trump in when another opponent is already winning the called suit trick', () => {
+    // p1 (picker) leads 9♥, p4 (opponent) trumps in with Q♥ and is winning
+    // p3 should play low rather than wasting trump
+    // lowestCard([J♦, 8♠, 7♣]) = 8♠ (first 0-pt non-trump in reduce order)
+    const view = makeView({
+      userId: 'p3',
+      hand: [c('J','D'), c('8','S'), c('7','C')],
+      trick: [
+        { userId: 'p1', card: c('9','H') },
+        { userId: 'p4', card: c('Q','H') },
+      ],
+      picker: 'p1',
+      partner: 'p2',
+      calledSuit: 'H',
+    })
+    expect(decidePlay(view, 'p3')).toBe('8S')
+  })
+
+  it('partner with no trump leads called suit when previous trick had few trump', () => {
+    // p2 (partner, revealed) leads with no trump; last trick had 1 trump (≤3)
+    // hand: 9♥ (called suit, 0pts), 10♣ (10pts), 7♠ (0pts)
+    // current code would lead 10♣ (highestValueCard); fix should lead 9♥ (called suit)
+    const view = makeView({
+      userId: 'p2',
+      hand: [c('9','H'), c('10','C'), c('7','S')],
+      picker: 'p1',
+      partner: 'p2',
+      calledSuit: 'H',
+      lastTrick: [
+        { userId: 'p1', card: c('Q','D') },   // 1 trump
+        { userId: 'p3', card: c('A','C') },
+        { userId: 'p4', card: c('K','C') },
+        { userId: 'p5', card: c('9','C') },
+      ],
+    })
+    expect(decidePlay(view, 'p2')).toBe('9H')
+  })
+
+  it('partner with no trump leads lowest fail when previous trick had many trump', () => {
+    // p2 (partner, revealed) leads with no trump; last trick had 4 trump (>3)
+    // hand: 10♥ (called suit, 10pts), 10♣ (10pts), 7♠ (0pts)
+    // fix should lead 7♠ (lowest fail), not 10♥ or 10♣
+    const view = makeView({
+      userId: 'p2',
+      hand: [c('10','H'), c('10','C'), c('7','S')],
+      picker: 'p1',
+      partner: 'p2',
+      calledSuit: 'H',
+      lastTrick: [
+        { userId: 'p1', card: c('Q','D') },   // trump
+        { userId: 'p3', card: c('J','D') },   // trump
+        { userId: 'p4', card: c('Q','H') },   // trump
+        { userId: 'p5', card: c('Q','S') },   // trump (4 total)
+        { userId: 'p2', card: c('A','C') },   // fail
+      ],
+    })
+    expect(decidePlay(view, 'p2')).toBe('7S')
+  })
+})


### PR DESCRIPTION
## Summary

- Opponents now play their lowest trump when following a trick where the called suit is led and the picker team is currently winning — unless another opponent has already taken the trick
- Partner bot with no trump now leads the called suit when the previous trick had ≤3 trump played, or leads the lowest-point fail card when trump is more exhausted (>3 trump last trick)

Closes #88

## Test plan

- [ ] All 117 existing tests pass (`npx vitest run shared/gameEngine.test.js`)
- [ ] 4 new tests added covering both behaviors and their guard conditions
- [ ] Manually verify opponent bots trump in on called suit during normal play
- [ ] Manually verify partner bot leads called suit / lowest fail correctly when out of trump

🤖 Generated with [Claude Code](https://claude.com/claude-code)