### PR TITLE
Remove picker discard log entry

### DIFF
--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -240,7 +240,6 @@ export function discard(state, userId, cardIds) {
   newState.pickerMustHold = mustHold
   newState.callMode = callMode
   newState.phase = 'calling'
-  newState.log.push(`${userId} discarded 2 cards.`)
 
   return newState
 }


### PR DESCRIPTION
## Summary
- Removes the `"X discarded 2 cards."` line from the game log — it was noise that revealed nothing meaningful to other players and cluttered the play history display.

## Test plan
- [ ] Play a hand as picker, discard 2 cards — confirm no discard line appears in the log
- [ ] Confirm all other log entries (picking, calling, scoring) still appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)