### PR TITLE
feat: reorganize game table layout

### DIFF
--- a/frontend/src/components/TrickArea.jsx
+++ b/frontend/src/components/TrickArea.jsx
@@ -68,9 +68,9 @@ export default function TrickArea({ trick = [], seats = {}, blind = [] }) {
 export function LastTrickArea({ lastTrick = [], seats = {} }) {
   if (!lastTrick || lastTrick.length === 0) return null
   return (
-    <div className="last-trick-area">
+    <>
       <div className="last-trick-label">Last trick</div>
       <TrickGrid entries={lastTrick} seats={seats} mini />
-    </div>
+    </>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -126,10 +126,10 @@ body {
   grid-template-areas:
     "top-left  center    top-right"
     "left      center    right"
-    ".         info-bar  last-trick"
-    ".         bottom    last-trick"
-    ".         action    ."
-    "log       log       scores";
+    "log         info-bar  last-trick"
+    "log         bottom    last-trick"
+    "log         action    last-trick"
+    ".       .         .";
   /* Side columns are a fixed width so left and right seats stay symmetric
      regardless of hand size or whether the last-trick widget is showing.
      Width is sized to comfortably hold a full 8-card mini-card-stack. */
@@ -278,11 +278,11 @@ body {
   background: rgba(0,0,0,0.25);
   border-radius: 8px;
   padding: 8px;
-  opacity: 0.7;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
+  gap: 8px;
   align-self: stretch;
   justify-self: stretch;
   box-sizing: border-box;
@@ -295,6 +295,12 @@ body {
 }
 
 /* ── Action panel ────────────────────────────────────────── */
+.action-panel.action-panel-discard-overlay {
+  grid-area: center;
+  z-index: 10;
+  background: #1a3d25;
+}
+
 .action-panel {
   background: rgba(0,0,0,0.35);
   border-radius: 8px;
@@ -312,7 +318,7 @@ body {
   padding: 10px;
   color: #ccc;
   font-size: 0.78rem;
-  max-height: 180px;
+  max-height: 400px;
   overflow-y: auto;
 }
 

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -559,6 +559,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
   const isMyPlayingTurn = state.phase === 'playing' && turnUserId === effectiveUserId
   const legalIds = isMyPlayingTurn ? getLegalCardIds(state, effectiveUserId, activeHand) : []
+  const isPickerOverlay = (state.phase === 'discarding' || state.phase === 'calling') && state.picker === effectiveUserId
 
   return (
     <div className="game-table">
@@ -584,8 +585,40 @@ export default function GamePage({ gameId, user, onNavigate }) {
         blind={state.phase === 'picking' ? (state.blind ?? []) : []}
       />
 
-      {/* ── Last trick (mini, mirrors seat positions) ── */}
-      <LastTrickArea lastTrick={lastTrick} seats={seats} />
+      {/* ── Right panel: last trick + game options + leave game ── */}
+      <div className="last-trick-area">
+        <LastTrickArea lastTrick={lastTrick} seats={seats} />
+        {isGameAdmin && (
+          <div style={{ width: '100%', borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 8 }}>
+            <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+              <span style={{ color: '#aaa', fontSize: '0.78rem' }}>
+                {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+                Partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'shown' : 'hidden'}
+                {(dobEnabled ?? gameData.double_on_bump ?? true) ? ' · DOB' : ''}
+              </span>
+              <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+                onClick={() => setShowOptions(true)}>
+                ⚙ Edit
+              </button>
+            </div>
+            <GameOptionsPanel
+              mode="update"
+              gameId={gameId}
+              open={showOptions}
+              values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.reveal_partner ?? true, double_on_bump: dobEnabled ?? gameData.double_on_bump ?? true }}
+              onUpdated={handleSettingsUpdate}
+              onClose={() => setShowOptions(false)}
+            />
+          </div>
+        )}
+        <div style={{ marginTop: 'auto', width: '100%', display: 'flex', justifyContent: 'flex-end', paddingTop: 8 }}>
+          <button className="outline contrast" style={{ fontSize: '0.8rem' }}
+            onClick={handleLeave} aria-busy={leaving} disabled={leaving}>
+            Leave game
+          </button>
+        </div>
+      </div>
 
       {/* ── Info bar: called ace + partner reveal ── */}
       <div className="info-bar">
@@ -628,7 +661,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
       {/* ── Action panel (hidden on your real playing turn — cards in seat instead) ── */}
       {!(isMyPlayingTurn && !isActingForBot) && (
-        <div className="action-panel">
+        <div className={`action-panel${isPickerOverlay ? ' action-panel-discard-overlay' : ''}`}>
           <ActionPanel
             state={state}
             myUserId={effectiveUserId}
@@ -671,39 +704,6 @@ export default function GamePage({ gameId, user, onNavigate }) {
       {/* ── Game log ── */}
       <GameLog entries={resolvedLog} />
 
-      {/* ── Game admin settings (game creator only) ── */}
-      {isGameAdmin && (
-        <div className="score-board">
-          <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
-          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-            <span style={{ color: '#aaa', fontSize: '0.78rem' }}>
-              {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
-              Partner: {(revealPartner ?? gameData.reveal_partner ?? true) ? 'shown' : 'hidden'}
-              {(dobEnabled ?? gameData.double_on_bump ?? true) ? ' · DOB' : ''}
-            </span>
-            <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
-              onClick={() => setShowOptions(true)}>
-              ⚙ Edit
-            </button>
-          </div>
-          <GameOptionsPanel
-            mode="update"
-            gameId={gameId}
-            open={showOptions}
-            values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.reveal_partner ?? true, double_on_bump: dobEnabled ?? gameData.double_on_bump ?? true }}
-            onUpdated={handleSettingsUpdate}
-            onClose={() => setShowOptions(false)}
-          />
-        </div>
-      )}
-
-      {/* ── Leave button ── */}
-      <div style={{ gridColumn: '1 / -1', textAlign: 'right', padding: '0 4px' }}>
-        <button className="outline contrast" style={{ fontSize: '0.8rem' }}
-          onClick={handleLeave} aria-busy={leaving} disabled={leaving}>
-          Leave game
-        </button>
-      </div>
 
     </div>
   )


### PR DESCRIPTION
## Summary
- Consolidate right column: last trick, game options, and leave game button now stack in a single panel instead of being spread across separate grid rows at the bottom
- Move game log to left column (below Oliver's seat) instead of spanning the full bottom row
- Action panel overlays the trick area with an opaque background during discard and calling phases when the player is the picker

## Test plan
- [ ] Play a hand through picking → discarding: verify the discard card selection UI covers the trick area cleanly
- [ ] Continue through calling phase: verify call-an-ace UI also overlays the trick area
- [ ] Verify right panel stacks correctly: last trick cards appear, then game options (admin only), then Leave game button
- [ ] Verify game log appears in left column and scrolls normally
- [ ] Verify layout looks correct during all other phases (picking, playing, scoring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)