### PR TITLE
fix: show alone badge on picker seat (#96)

### DIFF
--- a/frontend/src/components/PlayerSeat.jsx
+++ b/frontend/src/components/PlayerSeat.jsx
@@ -6,6 +6,7 @@ export default function PlayerSeat({
   player,
   isDealer,
   isPicker,
+  isGoingAlone,
   isPartner,
   isYou,
   isActiveTurn,
@@ -37,7 +38,8 @@ export default function PlayerSeat({
         {player.bot_type === 'play' && <span className="badge badge-bot">BOT</span>}
         {isYou     && <span className="badge badge-you">you</span>}
         {isDealer  && <span className="badge badge-dealer">D</span>}
-        {isPicker  && <span className="badge badge-picker">picker</span>}
+        {isPicker && !isGoingAlone && <span className="badge badge-picker">picker</span>}
+        {isGoingAlone && <span className="badge badge-alone">alone</span>}
         {isPicker && blitzType === 'black' && <span className="badge badge-blitz-black">Black Blitz</span>}
         {isPicker && blitzType === 'red'   && <span className="badge badge-blitz-red">Red Blitz</span>}
         {isPartner && <span className="badge badge-partner">partner</span>}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -191,6 +191,7 @@ body {
 .badge-picker       { background: #3b82f6; color: #fff; }
 .badge-partner      { background: #10b981; color: #fff; }
 .badge-you          { background: #8b5cf6; color: #fff; }
+.badge-alone        { background: #a855f7; color: #fff; }
 .badge-blitz-black  { background: #1f2937; color: #fff; border: 1px solid #6b7280; }
 .badge-blitz-red    { background: #dc2626; color: #fff; }
 

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -530,6 +530,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
     return {
       isDealer:      uid === dealerUserId,
       isPicker:      uid === pickerUserId,
+      isGoingAlone:  uid === pickerUserId && !!state.goingAlone,
       isPartner:     uid === partnerUserId,
       isYou:         uid === myUserId,
       isActiveTurn:  uid === turnUserId,


### PR DESCRIPTION
## Summary
- Adds an `alone` badge next to the player name when the picker has declared going alone
- Replaces (rather than supplements) the `picker` badge when going alone
- Adds `.badge-alone` CSS with purple styling matching the existing going-alone banner

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)