### PR TITLE
fix: prevent cross-hand stale key collision in autoplay and bot play triggers

### DIFF
--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -201,7 +201,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
     // Schedule the play — but only once per (turn, trick-progress) pair so
     // repeated polling of an unchanged state doesn't keep resetting the timer.
-    const key = `${turnUserId}:${state.currentTrick?.length ?? 0}`
+    const key = `${state.handNumber}:${turnUserId}:${state.currentTrick?.length ?? 0}`
     if (autoPlayRef.current.key === key) return
     if (autoPlayRef.current.timer) clearTimeout(autoPlayRef.current.timer)
     autoPlayRef.current.key = key
@@ -236,7 +236,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
     const currentPlayerData = players?.find(p => String(p.user_id) === turnUserId)
     if (currentPlayerData?.bot_type !== 'play') return
 
-    const key = `${turnUserId}:${state.tricks?.length ?? 0}:${state.currentTrick?.length ?? 0}`
+    const key = `${state.handNumber}:${turnUserId}:${state.tricks?.length ?? 0}:${state.currentTrick?.length ?? 0}`
     if (botPlayRef.current.key === key) return
     if (botPlayRef.current.timer) clearTimeout(botPlayRef.current.timer)
     botPlayRef.current.key = key


### PR DESCRIPTION
Closes #100

## Root Cause

Both the autoplay-last-trick effect (`autoPlayRef`) and the bot-play trigger effect (`botPlayRef`) use a string key to deduplicate timer scheduling — preventing repeated polls of an unchanged game state from resetting the timer on every render cycle.

The bug is that neither key included `state.handNumber`, making them hand-agnostic:

- `autoPlayRef` key was: `"${turnUserId}:${currentTrick.length}"`
- `botPlayRef` key was: `"${turnUserId}:${tricks.length}:${currentTrick.length}"`

These keys are set when the "last trick" condition is detected and a timer is scheduled. Crucially, **they are never explicitly reset between hands** — the only thing that clears the key is scheduling a new timer for a *different* key value.

When a new hand is dealt, `state.tricks` resets to `[]` and `state.currentTrick` resets to `[]`, so the last trick of any hand always produces `tricks.length === 5` and `currentTrick.length` varies `0–4`. This means: **if the same player occupies the same position in the last trick of two consecutive hands, their key is identical across both hands.**

The sequence that causes the bug:

1. Last trick of hand N: human player's turn → key set to `"alice:2"`, timer fires, card played ✓
2. Hand N+1 is dealt, tricks play out normally
3. Last trick of hand N+1: human player's turn again at the same trick position → key computed as `"alice:2"` again
4. `autoPlayRef.current.key === key` → **true** (stale key from hand N still in ref)
5. Timer is never scheduled → player must click manually

The same logic applies to `botPlayRef`, which could cause a bot to silently skip its card play in the same scenario.

## Fix

Prefix both keys with `state.handNumber`, which increments with every new hand deal:

- `autoPlayRef` key: `"${state.handNumber}:${turnUserId}:${currentTrick.length}"`
- `botPlayRef` key: `"${state.handNumber}:${turnUserId}:${tricks.length}:${currentTrick.length}"`

Identical positions in different hands now produce distinct keys, so the deduplication guard never suppresses a legitimate timer schedule.

## Test plan

- [ ] Play a multi-hand game against bots; confirm autoplay fires automatically in the last trick across consecutive hands
- [ ] Confirm bots continue to play sequentially (no skipped bot plays between hands)
- [ ] Confirm no double-firing: polling the same unchanged state within a hand does not reset or duplicate the timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)