### PR TITLE
fix: compact admin panel table columns

### DIFF
--- a/frontend/src/pages/AccountManagementPage.jsx
+++ b/frontend/src/pages/AccountManagementPage.jsx
@@ -252,14 +252,16 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
       {loading
         ? <p aria-busy="true">Loading users…</p>
         : (
-          <table style={{ width: '100%', tableLayout: 'fixed', fontSize: '0.78rem' }}>
+          <>
+          <style>{`.acct-mgmt td, .acct-mgmt th { padding: 4px 6px; }`}</style>
+          <table className="acct-mgmt" style={{ width: '100%', tableLayout: 'fixed', fontSize: '0.74rem' }}>
               <colgroup>
-                <col style={{ width: '4%' }} />
-                <col style={{ width: '20%' }} />
+                <col style={{ width: '5%' }} />
+                <col style={{ width: '27%' }} />
+                <col style={{ width: '6%' }} />
                 <col style={{ width: '7%' }} />
-                <col style={{ width: '9%' }} />
-                <col style={{ width: '26%' }} />
-                <col style={{ width: '34%' }} />
+                <col style={{ width: '25%' }} />
+                <col style={{ width: '30%' }} />
               </colgroup>
               <thead>
                 <tr>
@@ -283,6 +285,7 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
                 ))}
               </tbody>
             </table>
+          </>
         )
       }
     </div>


### PR DESCRIPTION
## Summary
- Widens ID column (4% → 5%) so multi-digit IDs don't wrap
- Redistributes column widths to better fit content (username gets more space, actions column trimmed)
- Reduces font size from 0.78rem to 0.74rem
- Overrides PicoCSS default cell padding to 4px 6px for shorter rows

Closes #85

## Test plan
- [ ] Open Admin → Account Management and verify ID column doesn't wrap for multi-digit IDs
- [ ] Verify rows are visibly more compact than before
- [ ] Verify edit mode still lays out correctly (inputs, checkboxes, save/cancel buttons)

🤖 Generated with [Claude Code](https://claude.com/claude-code)