### PR TITLE
feat: opponent bot leads called suit when partner unrevealed

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -76,9 +76,10 @@ Play the **lowest-value card** always, to avoid winning tricks.
 4. If no trump and not the partner: lead the **highest-value fail card**.
 
 #### Opponent bot leading
-1. **Cash a fail ace** if the picker team is likely trump-exhausted (≤2 trump estimated remaining elsewhere).
-2. Otherwise, lead the **lowest non-trump card** to avoid burning trump.
-3. If no non-trump cards remain, lead the lowest card overall.
+1. **Cash a fail ace** if the picker team has **zero** trump remaining (all 14 trump accounted for in own hand, discard, and played tricks). The fail ace must not be the called card (in practice an opponent never holds the called card, but the code is explicit).
+2. **Lead called suit** (lowest card of that suit) if the partner has not yet been revealed and the bot holds at least one fail card of the called suit. This forces the partner to play their called card, revealing their identity.
+3. Otherwise, lead the **lowest non-trump card** to avoid burning trump.
+4. If no non-trump cards remain, lead the lowest card overall.
 
 ### Following a Trick
 

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -277,14 +277,23 @@ export function decidePlay(view, userId) {
       // No trump; lead highest-value fail card
       return highestValueCard(realCards).id
     } else {
-      // Cash a fail Ace when picker team is likely trump-exhausted
-      if (trumpRemainingElsewhere(view, userId) <= 2) {
-        const failAces = realCards.filter(c => !isTrump(c) && c.rank === 'A')
-                                   .sort((a, b) => cardPoints(b) - cardPoints(a))
+      // Cash a fail Ace only when picker team is completely out of trump
+      if (trumpRemainingElsewhere(view, userId) === 0) {
+        const { calledAce, calledTen, calledKing } = view
+        const calledCardId = calledAce?.aceId ?? calledTen?.tenId ?? calledKing?.kingId
+        const failAces = realCards
+          .filter(c => !isTrump(c) && c.rank === 'A' && c.id !== calledCardId)
+          .sort((a, b) => cardPoints(b) - cardPoints(a))
         if (failAces.length > 0) return failAces[0].id
       }
-      // Opponent: lead a non-trump to avoid burning trump while looking for called suit
+      // Lead called suit to flush out the unrevealed partner
+      const { calledSuit, partnerRevealed } = view
       const nonTrump = realCards.filter(c => !isTrump(c))
+      if (!partnerRevealed && calledSuit) {
+        const calledSuitCards = nonTrump.filter(c => effectiveSuit(c) === calledSuit)
+        if (calledSuitCards.length > 0) return lowestCard(calledSuitCards).id
+      }
+      // Otherwise: lead lowest non-trump to avoid burning trump
       if (nonTrump.length > 0) return lowestCard(nonTrump).id
       return lowestCard(realCards).id
     }

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2114,8 +2114,8 @@ describe('decidePlay trump counting', () => {
   })
 
   it('opponent leads fail Ace when picker team exhausted', () => {
-    // Own trump: 0. Played trump: 13. Remaining elsewhere = 14 - 0 - 13 = 1 ≤ 2.
-    const playedTrump = ['QC','QS','QH','QD','JC','JS','JH','JD','AD','10D','KD','9D','8D'].map(trump)
+    // Own trump: 0. Played trump: 14 (all). Remaining elsewhere = 14 - 0 - 14 = 0.
+    const playedTrump = ['QC','QS','QH','QD','JC','JS','JH','JD','AD','10D','KD','9D','8D','7D'].map(trump)
     const view = makeTrumpExhaustedView({
       userId: 'p3',
       picker: 'p1',
@@ -2124,6 +2124,33 @@ describe('decidePlay trump counting', () => {
       trumpPlayed: playedTrump,
     })
     expect(decidePlay(view, 'p3')).toBe('AH')
+  })
+
+  it('opponent does NOT lead fail Ace when picker team has 1 trump remaining', () => {
+    // 13 trump played, own trump = 0 → remaining = 14 - 0 - 13 = 1
+    const playedTrump = ['QC','QS','QH','QD','JC','JS','JH','JD','AD','10D','KD','9D','8D'].map(trump)
+    const view = makeTrumpExhaustedView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p2',
+      handCards: [c('A','H'), c('9','S'), c('8','C')],
+      trumpPlayed: playedTrump,
+    })
+    // Must NOT cash the ace — should fall through to lowest non-trump (9S or 8C)
+    expect(decidePlay(view, 'p3')).not.toBe('AH')
+  })
+
+  it('opponent does NOT lead fail Ace when picker team has 2 trump remaining', () => {
+    // 12 trump played, own trump = 0 → remaining = 14 - 0 - 12 = 2
+    const playedTrump = ['QC','QS','QH','QD','JC','JS','JH','JD','AD','10D','KD','9D'].map(trump)
+    const view = makeTrumpExhaustedView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p2',
+      handCards: [c('A','H'), c('9','S'), c('8','C')],
+      trumpPlayed: playedTrump,
+    })
+    expect(decidePlay(view, 'p3')).not.toBe('AH')
   })
 
   it('opponent leads lowest non-trump normally when trump not exhausted', () => {
@@ -2152,6 +2179,58 @@ describe('decidePlay trump counting', () => {
     })
     // Should lead one of the fail Aces (both are 11 pts)
     expect(['AC', 'AH']).toContain(decidePlay(view, 'p1'))
+  })
+})
+
+describe('decidePlay opponent leading called suit', () => {
+  function makeOpponentLeadView({ handCards, partnerRevealed, calledSuit = 'H' }) {
+    return {
+      hands: { p3: handCards },
+      currentTrick: [],
+      tricks: [],          // no trump played → fail-ace branch won't fire
+      picker: 'p1',
+      partner: partnerRevealed ? 'p2' : null,
+      isLeaster: false,
+      phase: 'playing',
+      calledSuit,
+      calledAce: { aceId: `A${calledSuit}` },
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed,
+      pickerForcedPlays: [],
+      underCard: null,
+      discard: [],
+    }
+  }
+
+  it('leads lowest called-suit card when partner is not yet revealed', () => {
+    // Hand: 10H (called suit, 10 pts), 8C (0 pts), 7S (0 pts)
+    // partnerRevealed=false → should lead called suit even though it is the highest-value card
+    const view = makeOpponentLeadView({
+      handCards: [c('10','H'), c('8','C'), c('7','S')],
+      partnerRevealed: false,
+    })
+    expect(decidePlay(view, 'p3')).toBe('10H')
+  })
+
+  it('does not lead called suit when partner is already revealed', () => {
+    // Same hand, partnerRevealed=true → falls through to lowest non-trump
+    const view = makeOpponentLeadView({
+      handCards: [c('10','H'), c('8','C'), c('7','S')],
+      partnerRevealed: true,
+    })
+    // 10H is 10pts; 8C and 7S are 0pts → lowest non-trump is 8C or 7S, not 10H
+    expect(['8C', '7S']).toContain(decidePlay(view, 'p3'))
+  })
+
+  it('falls through to lowest non-trump when bot holds no called-suit cards', () => {
+    // No hearts in hand; calledSuit='H' → no called-suit lead possible
+    const view = makeOpponentLeadView({
+      handCards: [c('9','C'), c('8','C'), c('7','S')],
+      partnerRevealed: false,
+    })
+    // All 0pt non-trump; lowestCard picks 9C (first encountered)
+    expect(decidePlay(view, 'p3')).toBe('9C')
   })
 })
 


### PR DESCRIPTION
## Summary
- Opponent bots now lead the called suit when they have the lead and the partner hasn't been revealed yet, forcing the partner to play their called card
- Tightened the fail ace cash condition from `<= 2` to `=== 0` trump remaining — opponents now only cash a fail ace when the picker team is completely out of trump
- Added explicit guard excluding the called card from fail ace candidates

## Test Plan
- [ ] 5 new tests added and passing (184 total)
- [ ] Verified: opponent leads called suit when partner unrevealed
- [ ] Verified: opponent does NOT lead called suit when partner already revealed
- [ ] Verified: fail ace NOT cashed when 1 trump remaining
- [ ] Verified: fail ace NOT cashed when 2 trump remaining
- [ ] Verified: fail ace IS cashed when 0 trump remaining

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)