### PR TITLE
feat: score display and editing in Account Management panel

### DIFF
--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -37,6 +37,9 @@ export const api = {
     getUser:      (id)        => request('GET',   `/admin/users/${id}`),
     updateUser:   (id, patch) => request('PATCH', `/admin/users/${id}`, patch),
     deleteUser: (id)        => request('DELETE', `/admin/users/${id}`),
+    adjustScore:  (id, newDayScore, newLifetimeScore) =>
+                    request('POST', `/admin/users/${id}/score-adjustment`,
+                      { new_day_score: newDayScore, new_lifetime_score: newLifetimeScore }),
     getConfig:    ()          => request('GET',   '/admin/config'),
     updateConfig: (patch)     => request('PATCH', '/admin/config', patch),
   },

--- a/frontend/src/pages/AccountManagementPage.jsx
+++ b/frontend/src/pages/AccountManagementPage.jsx
@@ -2,21 +2,24 @@ import { useState, useEffect } from 'react'
 import { api } from '../lib/api.js'
 
 function UserRow({ user, currentUserId, onSaved, onDeleted }) {
-  const [editing, setEditing]     = useState(false)
-  const [username, setUsername]   = useState(user.username)
-  const [isAdmin, setIsAdmin]     = useState(!!user.is_admin)
-  const [isBot, setIsBot]         = useState(!!user.is_bot)
-  const [password, setPassword]   = useState('')
-  const [saving, setSaving]       = useState(false)
-  const [deleting, setDeleting]   = useState(false)
-  const [error, setError]         = useState(null)
+  const [editing, setEditing]         = useState(false)
+  const [username, setUsername]       = useState(user.username)
+  const [isAdmin, setIsAdmin]         = useState(!!user.is_admin)
+  const [isBot, setIsBot]             = useState(!!user.is_bot)
+  const [password, setPassword]       = useState('')
+  const [draftDay, setDraftDay]       = useState(String(user.day_score ?? 0))
+  const [draftLifetime, setDraftLifetime] = useState(String(user.lifetime_score ?? 0))
+  const [saving, setSaving]           = useState(false)
+  const [deleting, setDeleting]       = useState(false)
+  const [error, setError]             = useState(null)
 
-  // Keep local state in sync when parent data refreshes
   useEffect(() => {
     if (!editing) {
       setUsername(user.username)
       setIsAdmin(!!user.is_admin)
       setIsBot(!!user.is_bot)
+      setDraftDay(String(user.day_score ?? 0))
+      setDraftLifetime(String(user.lifetime_score ?? 0))
     }
   }, [user, editing])
 
@@ -29,12 +32,30 @@ function UserRow({ user, currentUserId, onSaved, onDeleted }) {
         'You are about to remove your own admin access.\nYou will be locked out of admin features immediately.\nAre you sure?'
       )) return
     }
+
+    const newDay = parseInt(draftDay, 10)
+    const newLifetime = parseInt(draftLifetime, 10)
+    if (!Number.isInteger(newDay))      return setError('Day score must be an integer.')
+    if (!Number.isInteger(newLifetime)) return setError('Lifetime score must be an integer.')
+
     setSaving(true)
     setError(null)
     try {
+      let updated = { ...user }
+
+      // Account fields update
       const patch = { username, is_admin: isAdmin, is_bot: isBot }
       if (password) patch.password = password
-      const updated = await api.admin.updateUser(user.id, patch)
+      const accountResult = await api.admin.updateUser(user.id, patch)
+      updated = { ...updated, ...accountResult }
+
+      // Score adjustment (only if values changed)
+      const scoreChanged = newDay !== (user.day_score ?? 0) || newLifetime !== (user.lifetime_score ?? 0)
+      if (scoreChanged) {
+        const scoreResult = await api.admin.adjustScore(user.id, newDay, newLifetime)
+        updated = { ...updated, day_score: scoreResult.day_score, lifetime_score: scoreResult.lifetime_score }
+      }
+
       setPassword('')
       setEditing(false)
       onSaved(updated)
@@ -50,6 +71,8 @@ function UserRow({ user, currentUserId, onSaved, onDeleted }) {
     setIsAdmin(!!user.is_admin)
     setIsBot(!!user.is_bot)
     setPassword('')
+    setDraftDay(String(user.day_score ?? 0))
+    setDraftLifetime(String(user.lifetime_score ?? 0))
     setError(null)
     setEditing(false)
   }
@@ -82,6 +105,8 @@ function UserRow({ user, currentUserId, onSaved, onDeleted }) {
         <td style={{ color: '#888' }}>
           {new Date(user.created_at).toLocaleDateString()}
         </td>
+        <td style={{ textAlign: 'right' }}>{user.day_score ?? 0}</td>
+        <td style={{ textAlign: 'right' }}>{user.lifetime_score ?? 0}</td>
         <td>
           <div style={{ display: 'flex', gap: 4 }}>
             <button className="outline" style={{ padding: '2px 8px' }} onClick={() => setEditing(true)}>
@@ -144,6 +169,22 @@ function UserRow({ user, currentUserId, onSaved, onDeleted }) {
         />
       </td>
       <td>
+        <input
+          type="number"
+          value={draftDay}
+          onChange={e => setDraftDay(e.target.value)}
+          style={{ margin: 0, padding: '2px 6px', width: '100%', boxSizing: 'border-box', textAlign: 'right' }}
+        />
+      </td>
+      <td>
+        <input
+          type="number"
+          value={draftLifetime}
+          onChange={e => setDraftLifetime(e.target.value)}
+          style={{ margin: 0, padding: '2px 6px', width: '100%', boxSizing: 'border-box', textAlign: 'right' }}
+        />
+      </td>
+      <td>
         <div style={{ display: 'flex', gap: 4 }}>
           <button
             style={{ padding: '2px 8px' }}
@@ -203,7 +244,6 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
 
   function handleSaved(updated) {
     setUsers(prev => prev.map(u => u.id === updated.id ? { ...u, ...updated } : u))
-    // If admin removed their own access, boot them back to lobby
     if (updated.removedOwnAdmin) {
       alert('Your admin access has been removed. Returning to lobby.')
       onNavigate('/lobby')
@@ -241,7 +281,7 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
   }
 
   return (
-    <div style={{ maxWidth: 900, margin: '0 auto', padding: 24 }}>
+    <div style={{ maxWidth: 1000, margin: '0 auto', padding: 24 }}>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 20 }}>
         <h2 style={{ margin: 0 }}>Account Management</h2>
         <button className="outline" onClick={() => onNavigate('/admin')}>← Back to admin panel</button>
@@ -256,12 +296,14 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
           <style>{`.acct-mgmt td, .acct-mgmt th { padding: 4px 6px; }`}</style>
           <table className="acct-mgmt" style={{ width: '100%', tableLayout: 'fixed', fontSize: '0.74rem' }}>
               <colgroup>
+                <col style={{ width: '4%' }} />
+                <col style={{ width: '20%' }} />
                 <col style={{ width: '5%' }} />
-                <col style={{ width: '27%' }} />
                 <col style={{ width: '6%' }} />
-                <col style={{ width: '7%' }} />
-                <col style={{ width: '25%' }} />
-                <col style={{ width: '30%' }} />
+                <col style={{ width: '14%' }} />
+                <col style={{ width: '8%' }} />
+                <col style={{ width: '9%' }} />
+                <col style={{ width: '34%' }} />
               </colgroup>
               <thead>
                 <tr>
@@ -270,6 +312,8 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
                   <SortTh col="is_admin">Admin</SortTh>
                   <SortTh col="is_bot">Test Bot</SortTh>
                   <SortTh col="created_at">Created / New password</SortTh>
+                  <SortTh col="day_score">Day</SortTh>
+                  <SortTh col="lifetime_score">Lifetime</SortTh>
                   <th>Actions</th>
                 </tr>
               </thead>

--- a/frontend/src/pages/AccountManagementPage.jsx
+++ b/frontend/src/pages/AccountManagementPage.jsx
@@ -298,12 +298,12 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
               <colgroup>
                 <col style={{ width: '4%' }} />
                 <col style={{ width: '20%' }} />
-                <col style={{ width: '5%' }} />
                 <col style={{ width: '6%' }} />
-                <col style={{ width: '14%' }} />
-                <col style={{ width: '8%' }} />
+                <col style={{ width: '7%' }} />
+                <col style={{ width: '12%' }} />
+                <col style={{ width: '7%' }} />
                 <col style={{ width: '9%' }} />
-                <col style={{ width: '34%' }} />
+                <col style={{ width: '35%' }} />
               </colgroup>
               <thead>
                 <tr>
@@ -311,7 +311,7 @@ export default function AccountManagementPage({ currentUser, onNavigate }) {
                   <SortTh col="username">Username</SortTh>
                   <SortTh col="is_admin">Admin</SortTh>
                   <SortTh col="is_bot">Test Bot</SortTh>
-                  <SortTh col="created_at">Created / New password</SortTh>
+                  <SortTh col="created_at">Created</SortTh>
                   <SortTh col="day_score">Day</SortTh>
                   <SortTh col="lifetime_score">Lifetime</SortTh>
                   <th>Actions</th>

--- a/functions/api/_botHelpers.js
+++ b/functions/api/_botHelpers.js
@@ -1,6 +1,8 @@
 // ─── Bot helpers ─────────────────────────────────────────────────────────────
 // Shared utilities for play bot allocation and server-side bot turn processing.
 
+import { centralDate } from './_helpers.js'
+
 import {
   currentPicker, currentPlayer,
   pick, blitz, pass, discard,
@@ -27,10 +29,11 @@ export async function finishHand(DB, gameId, state) {
     state.scores = scores
   }
 
+  const today = centralDate()
   const stmts = Object.entries(scores).map(([userId, delta]) =>
     DB.prepare(
-      'INSERT INTO score_events (user_id, game_id, hand_number, delta) VALUES (?, ?, ?, ?)'
-    ).bind(Number(userId), gameId, state.handNumber, delta)
+      'INSERT INTO score_events (user_id, game_id, hand_number, delta, game_date) VALUES (?, ?, ?, ?, ?)'
+    ).bind(Number(userId), gameId, state.handNumber, delta, today)
   )
   await DB.batch(stmts)
 

--- a/functions/api/_helpers.js
+++ b/functions/api/_helpers.js
@@ -81,3 +81,13 @@ export function sessionCookie(token, expire = false) {
   const maxAge = 7 * 24 * 60 * 60
   return `session=${token}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${maxAge}`
 }
+
+/**
+ * Returns today's date in America/Chicago timezone as a YYYY-MM-DD string.
+ * Uses Intl (supported in Cloudflare Workers) so DST is handled automatically.
+ */
+export function centralDate() {
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'America/Chicago',
+  }).format(new Date())
+}

--- a/functions/api/admin/users/[id]/index.js
+++ b/functions/api/admin/users/[id]/index.js
@@ -1,4 +1,4 @@
-import { json, err, requireAdmin, hashPassword, randomHex, AuthError } from '../../../_helpers.js'
+import { json, err, requireAdmin, hashPassword, randomHex, AuthError, centralDate } from '../../../_helpers.js'
 
 export async function onRequest({ request, env, params }) {
   try {
@@ -28,8 +28,8 @@ async function getUser({ request, env, params }) {
   ).bind(userId).first()
 
   const today = await env.DB.prepare(
-    "SELECT COALESCE(SUM(delta), 0) as total FROM score_events WHERE user_id = ? AND date(recorded_at) = date('now')"
-  ).bind(userId).first()
+    'SELECT COALESCE(SUM(delta), 0) as total FROM score_events WHERE user_id = ? AND game_date = ?'
+  ).bind(userId, centralDate()).first()
 
   return json({ ...user, lifetimeScore: lifetime?.total ?? 0, todayScore: today?.total ?? 0 })
 }

--- a/functions/api/admin/users/[id]/score-adjustment.js
+++ b/functions/api/admin/users/[id]/score-adjustment.js
@@ -38,7 +38,7 @@ export async function onRequestPost({ request, env, params }) {
     if (day_delta !== 0) {
       stmts.push(
         env.DB.prepare(
-          'INSERT INTO score_events (user_id, game_id, hand_number, delta, game_date, is_adjustment) VALUES (?, 0, 0, ?, ?, 1)'
+          'INSERT INTO score_events (user_id, game_id, hand_number, delta, game_date, is_adjustment) VALUES (?, NULL, 0, ?, ?, 1)'
         ).bind(userId, day_delta, today)
       )
     }
@@ -46,7 +46,7 @@ export async function onRequestPost({ request, env, params }) {
     if (lifetime_only_delta !== 0) {
       stmts.push(
         env.DB.prepare(
-          'INSERT INTO score_events (user_id, game_id, hand_number, delta, game_date, is_adjustment) VALUES (?, 0, 0, ?, NULL, 1)'
+          'INSERT INTO score_events (user_id, game_id, hand_number, delta, game_date, is_adjustment) VALUES (?, NULL, 0, ?, NULL, 1)'
         ).bind(userId, lifetime_only_delta)
       )
     }

--- a/functions/api/admin/users/[id]/score-adjustment.js
+++ b/functions/api/admin/users/[id]/score-adjustment.js
@@ -1,0 +1,73 @@
+import { json, err, requireAdmin, AuthError, centralDate } from '../../../_helpers.js'
+
+export async function onRequestPost({ request, env, params }) {
+  try {
+    const _admin = await requireAdmin(request, env.DB)
+    const userId = Number(params.id)
+
+    const target = await env.DB.prepare('SELECT id FROM users WHERE id = ?').bind(userId).first()
+    if (!target) return err('User not found.', 404)
+
+    let body
+    try { body = await request.json() } catch { return err('Invalid JSON.') }
+
+    const { new_day_score, new_lifetime_score } = body
+    if (typeof new_day_score !== 'number' || !Number.isInteger(new_day_score))
+      return err('new_day_score must be an integer.')
+    if (typeof new_lifetime_score !== 'number' || !Number.isInteger(new_lifetime_score))
+      return err('new_lifetime_score must be an integer.')
+
+    const today = centralDate()
+
+    // Read current values
+    const lifetimeRow = await env.DB.prepare(
+      'SELECT COALESCE(SUM(delta), 0) AS total FROM score_events WHERE user_id = ?'
+    ).bind(userId).first()
+    const dayRow = await env.DB.prepare(
+      'SELECT COALESCE(SUM(delta), 0) AS total FROM score_events WHERE user_id = ? AND game_date = ?'
+    ).bind(userId, today).first()
+
+    const current_lifetime = lifetimeRow?.total ?? 0
+    const current_day = dayRow?.total ?? 0
+
+    const day_delta = new_day_score - current_day
+    const lifetime_only_delta = new_lifetime_score - (current_lifetime + day_delta)
+
+    const stmts = []
+
+    if (day_delta !== 0) {
+      stmts.push(
+        env.DB.prepare(
+          'INSERT INTO score_events (user_id, game_id, hand_number, delta, game_date, is_adjustment) VALUES (?, 0, 0, ?, ?, 1)'
+        ).bind(userId, day_delta, today)
+      )
+    }
+
+    if (lifetime_only_delta !== 0) {
+      stmts.push(
+        env.DB.prepare(
+          'INSERT INTO score_events (user_id, game_id, hand_number, delta, game_date, is_adjustment) VALUES (?, 0, 0, ?, NULL, 1)'
+        ).bind(userId, lifetime_only_delta)
+      )
+    }
+
+    if (stmts.length > 0) await env.DB.batch(stmts)
+
+    // Return updated scores
+    const updatedLifetime = await env.DB.prepare(
+      'SELECT COALESCE(SUM(delta), 0) AS total FROM score_events WHERE user_id = ?'
+    ).bind(userId).first()
+    const updatedDay = await env.DB.prepare(
+      'SELECT COALESCE(SUM(delta), 0) AS total FROM score_events WHERE user_id = ? AND game_date = ?'
+    ).bind(userId, today).first()
+
+    return json({
+      id: userId,
+      day_score: updatedDay?.total ?? 0,
+      lifetime_score: updatedLifetime?.total ?? 0,
+    })
+  } catch (e) {
+    if (e instanceof AuthError) return err(e.message, e.message === 'Admin access required.' ? 403 : 401)
+    return err(e.message, 500)
+  }
+}

--- a/functions/api/admin/users/index.js
+++ b/functions/api/admin/users/index.js
@@ -1,14 +1,17 @@
-import { json, err, requireAdmin, AuthError } from '../../_helpers.js'
+import { json, err, requireAdmin, AuthError, centralDate } from '../../_helpers.js'
 
 export async function onRequestGet({ request, env }) {
   try {
     const _admin = await requireAdmin(request, env.DB)
 
+    const today = centralDate()
     const { results } = await env.DB.prepare(
-      `SELECT id, username, is_admin, is_bot, created_at
-       FROM users
-       ORDER BY is_bot ASC, is_admin DESC, username ASC`
-    ).all()
+      `SELECT u.id, u.username, u.is_admin, u.is_bot, u.created_at,
+         COALESCE((SELECT SUM(se.delta) FROM score_events se WHERE se.user_id = u.id), 0) AS lifetime_score,
+         COALESCE((SELECT SUM(se.delta) FROM score_events se WHERE se.user_id = u.id AND se.game_date = ?), 0) AS day_score
+       FROM users u
+       ORDER BY u.is_bot ASC, u.is_admin DESC, u.username ASC`
+    ).bind(today).all()
 
     return json(results)
   } catch (e) {

--- a/functions/api/auth/me.js
+++ b/functions/api/auth/me.js
@@ -1,4 +1,4 @@
-import { json, err, getUser } from '../_helpers.js'
+import { json, err, getUser, centralDate } from '../_helpers.js'
 
 export async function onRequestGet({ request, env }) {
   const user = await getUser(request, env.DB)
@@ -10,8 +10,8 @@ export async function onRequestGet({ request, env }) {
   ).bind(user.user_id).first()
 
   const today = await env.DB.prepare(
-    "SELECT COALESCE(SUM(delta), 0) as total FROM score_events WHERE user_id = ? AND date(recorded_at) = date('now')"
-  ).bind(user.user_id).first()
+    'SELECT COALESCE(SUM(delta), 0) as total FROM score_events WHERE user_id = ? AND game_date = ?'
+  ).bind(user.user_id, centralDate()).first()
 
   return json({
     id: user.user_id,

--- a/migrations/0008_score_events_game_date.sql
+++ b/migrations/0008_score_events_game_date.sql
@@ -1,0 +1,2 @@
+ALTER TABLE score_events ADD COLUMN game_date TEXT;
+ALTER TABLE score_events ADD COLUMN is_adjustment INTEGER NOT NULL DEFAULT 0;

--- a/migrations/0009_score_events_nullable_game_id.sql
+++ b/migrations/0009_score_events_nullable_game_id.sql
@@ -1,0 +1,29 @@
+-- Make game_id nullable on score_events so that admin adjustment events
+-- (which have no associated game) can be inserted with game_id = NULL.
+
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE score_events_new (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id INTEGER NOT NULL REFERENCES users(id),
+  game_id INTEGER,
+  hand_number INTEGER NOT NULL,
+  delta INTEGER NOT NULL,
+  recorded_at TEXT NOT NULL DEFAULT (datetime('now')),
+  game_date TEXT,
+  is_adjustment INTEGER NOT NULL DEFAULT 0
+);
+
+INSERT INTO score_events_new (id, user_id, game_id, hand_number, delta, recorded_at, game_date, is_adjustment)
+  SELECT id, user_id, game_id, hand_number, delta, recorded_at, game_date, is_adjustment
+  FROM score_events;
+
+DROP TABLE score_events;
+
+ALTER TABLE score_events_new RENAME TO score_events;
+
+CREATE INDEX idx_score_events_user ON score_events(user_id);
+CREATE INDEX idx_score_events_game ON score_events(game_id);
+CREATE INDEX idx_score_events_date ON score_events(recorded_at);
+
+PRAGMA foreign_keys=ON;


### PR DESCRIPTION
Closes #107

## Summary
- Adds `game_date` (America/Chicago date string) and `is_adjustment` columns to `score_events` via two new migrations
- Surfaces **Day** and **Lifetime** score columns in the Account Management table
- Admins can edit scores inline; changes are persisted as adjustment events (`is_adjustment = 1`) rather than modifying existing rows
- Fixes the existing today-score query in `me.js` and the admin user endpoint, which were comparing UTC dates instead of Central time

## Test plan
- [ ] Navigate to Admin Panel → Account Management — Day and Lifetime columns appear with correct values
- [ ] Click Edit on a user — score inputs are pre-filled with current values
- [ ] Change Day score, save — new value appears; Lifetime updates accordingly
- [ ] Change Lifetime score only, save — Day score unchanged
- [ ] Change both, save — both update correctly
- [ ] Cancel edit — values revert to original
- [ ] Verify adjustment rows in DB: `SELECT * FROM score_events WHERE is_adjustment = 1;`
- [ ] Existing account edits (username, admin, bot, password) still work

## Notes
- Scores for users with no events show `0`
- Adjustment events use `game_id = NULL` (migration 0009 makes `game_id` nullable) and `hand_number = 0` as sentinels
- Follow-up issue for removing timezone coupling from schema: #111