### PR TITLE
fix: open hand recap links in new tab

### DIFF
--- a/frontend/src/components/GameLog.jsx
+++ b/frontend/src/components/GameLog.jsx
@@ -25,7 +25,7 @@ function LogLine({ text, gameId }) {
   const href = `#/recap/${gameId}/${handNumber}`
   return (
     <p>
-      --- <a href={href} style={{ color: '#58a6ff' }}>Hand {handNumber}</a> complete ---
+      --- <a href={href} target="_blank" rel="noopener noreferrer" style={{ color: '#58a6ff' }}>Hand {handNumber}</a> complete ---
     </p>
   )
 }


### PR DESCRIPTION
## Summary
- Hand recap links in the game log now open in a new tab via `target="_blank"` (with `rel="noopener noreferrer"`).

## Test plan
- [ ] Click a "Hand N complete" link in the game log and confirm it opens in a new tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)