### PR TITLE
refactor: rename discarding phase to burying (#124)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,7 @@ When reading instructions or discussing this project, check for terminology inco
 ### Game Flow
 - **Game** — A construct inside which hands are played by players.
 - **Blind** — The 2 cards set aside from the deal, available for the picker to take into their hand.
+- **Bury** — The act of the picker placing 2 cards face-down after picking up the blind. Buried cards count toward the picker's point pile at scoring; they are not discarded. The picker may not bury cards required for the partner call.
 - **Hand** — A single round of play within a game, from deal through scoring. Each hand begins with 6 cards dealt to each player plus a 2-card blind, proceeds through a picking phase, and ends with scores awarded. How a hand resolves depends on the picking phase outcome:
   - **Normal hand** — a picker is found, calls a partner (or goes alone), and 6 tricks are played
   - **Leaster** — no one picks; 6 tricks are played, but the player with the fewest card points wins

--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -28,12 +28,12 @@ Only considered when a potential blitz is available. The bot declares blitz if i
 
 ---
 
-## Discard Decision (`decideDiscard`)
+## Bury Decision (`decideBury`)
 
 After picking up the blind, the bot buries 2 cards using this priority:
 
 1. **Void a suit**: If burying 2 non-trump cards can void a non-trump suit and the pair is worth more than 10 card points combined, do that (respecting must-hold restrictions).
-2. **Otherwise**: Sort non-trump cards to the front (trump is never discarded if avoidable), then by card points descending. Bury the top 2 candidates.
+2. **Otherwise**: Sort non-trump cards to the front (trump is never buried if avoidable), then by card points descending. Bury the top 2 candidates.
 
 **Must-hold restriction**: If the bot holds all three fail aces, it cannot bury any of them (they must stay in hand for the "ace" call rules). If it also holds all three fail tens, neither aces nor tens can be buried.
 
@@ -76,7 +76,7 @@ Play the **lowest-value card** always, to avoid winning tricks.
 4. If no trump and not the partner: lead the **highest-value fail card**.
 
 #### Opponent bot leading
-1. **Cash a fail ace** if the picker team has **zero** trump remaining (all 14 trump accounted for in own hand, discard, and played tricks). The fail ace must not be the called card (in practice an opponent never holds the called card, but the code is explicit).
+1. **Cash a fail ace** if the picker team has **zero** trump remaining (all 14 trump accounted for in own hand, buried, and played tricks). The fail ace must not be the called card (in practice an opponent never holds the called card, but the code is explicit).
 2. **Lead called suit** (lowest card of that suit) if the partner has not yet been revealed and the bot holds at least one fail card of the called suit. This forces the partner to play their called card, revealing their identity.
 3. Otherwise, lead the **lowest non-trump card** to avoid burning trump.
 4. If no non-trump cards remain, lead the lowest card overall.
@@ -114,5 +114,5 @@ These pure functions support the strategy above but make no decisions themselves
 | `handScore` | Combined pick-quality score: `schwanzerPts × 4 + buriablePoints` |
 | `beats` | Returns true if a challenger card beats the current winner given led suit |
 | `currentWinner` | Returns the play object currently winning a trick |
-| `bestVoidDiscard` | Finds the best 2-card discard that voids a non-trump suit with ≥11 combined card points |
+| `bestVoidBury` | Finds the best 2-card bury that voids a non-trump suit with ≥11 combined card points |
 | `teammateWinning` | Returns true if the current trick leader is on the same team as the bot |

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -29,19 +29,19 @@ Total points in the deck: 120.
 
 ### 1. Picking
 
-Two blind cards are dealt face-down. Starting left of the dealer, each player may **pick** (take the blind and become the picker) or **pass**. If all five players pass, what happens depends on the game's no-pick variant: the hand is played as a **Leaster**, the stakes double (**Doublers**), or the hand is scored immediately as a **Schwanzer**.
+The **blind** is the 2 cards set aside from the deal face-down, available for the picker to take into their hand. Starting left of the dealer, each player may **pick** (take the blind and become the picker) or **pass**. If all five players pass, what happens depends on the game's no-pick variant: the hand is played as a **Leaster**, the stakes double (**Doublers**), or the hand is scored immediately as a **Schwanzer**.
 
 **Blitzing**
 
-A player holding both black queens (Queen of Clubs + Queen of Spades) or both red queens (Queen of Hearts + Queen of Diamonds) may **blitz** when it is their turn to pick. Blitzing forces the player to pick (they take the blind and proceed to discarding), and doubles the hand's final payout (×2 on top of all other multipliers).
+A player holding both black queens (Queen of Clubs + Queen of Spades) or both red queens (Queen of Hearts + Queen of Diamonds) may **blitz** when it is their turn to pick. Blitzing forces the player to pick (they take the blind and proceed to burying), and doubles the hand's final payout (×2 on top of all other multipliers).
 
-### 2. Discarding
+### 2. Burying
 
-The picker adds the 2 blind cards to their hand (8 total) and buries 2 cards face-down. The buried cards count toward the picker's point pile at scoring. The picker may not bury cards required for the partner call (see below).
+The picker adds the 2 blind cards to their hand (8 total) and **buries** 2 cards face-down. Burying is the act of setting those 2 cards aside; they are not discarded — they count toward the picker's point pile at scoring. The picker may not bury cards required for the partner call (see below).
 
 ### 3. Calling (Partner Selection)
 
-After discarding, the picker calls a partner using one of three modes determined by their hand, or goes alone.
+After burying, the picker calls a partner using one of three modes determined by their hand, or goes alone.
 
 **Call Mode: Ace** (default)
 

--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -8,7 +8,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     ? { background: 'rgba(124,58,237,0.3)', border: '1px solid rgba(124,58,237,0.5)' }
     : {}
   const turnLabel = actingForName ? `Acting for ${actingForName}` : 'Your turn'
-  const [selectedDiscards, setSelectedDiscards] = useState([])
+  const [selectedBuried, setSelectedBuried] = useState([])
   const [unknownSelectedSuit, setUnknownSelectedSuit] = useState(null)
   const [selectedUnderCard, setSelectedUnderCard] = useState(null)
   const [confirmingAlone, setConfirmingAlone] = useState(false)
@@ -53,7 +53,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     setError(null)
     try {
       await onAction(type, payload)
-      setSelectedDiscards([])
+      setSelectedBuried([])
     } catch (e) {
       setError(e.message)
     }
@@ -97,13 +97,13 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     )
   }
 
-  // ── Discarding phase ──────────────────────────────────────
-  if (phase === 'discarding') {
+  // ── Burying phase ─────────────────────────────────────────
+  if (phase === 'burying') {
     if (picker !== myUserId) {
-      return <div className="action-panel"><p>Waiting for picker to discard…</p></div>
+      return <div className="action-panel"><p>Waiting for picker to bury…</p></div>
     }
-    const toggleDiscard = (card) => {
-      setSelectedDiscards(prev => {
+    const toggleBury = (card) => {
+      setSelectedBuried(prev => {
         if (prev.find(c => c.id === card.id)) return prev.filter(c => c.id !== card.id)
         if (prev.length >= 2) return prev
         return [...prev, card]
@@ -111,20 +111,20 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     }
     return (
       <div className="action-panel" style={botStyle}>
-        <h4>Select 2 cards to discard</h4>
-        <p className="discard-hint">({selectedDiscards.length}/2 selected)</p>
+        <h4>Select 2 cards to bury</h4>
+        <p className="bury-hint">({selectedBuried.length}/2 selected)</p>
         <Hand
           cards={myHand}
           playableIds={myHand.map(c => c.id)}
-          selectedIds={selectedDiscards.map(c => c.id)}
-          onCardClick={toggleDiscard}
+          selectedIds={selectedBuried.map(c => c.id)}
+          onCardClick={toggleBury}
         />
         <button
-          disabled={selectedDiscards.length !== 2 || loading}
-          onClick={() => act('discard', { cardIds: selectedDiscards.map(c => c.id) })}
+          disabled={selectedBuried.length !== 2 || loading}
+          onClick={() => act('bury', { cardIds: selectedBuried.map(c => c.id) })}
           style={{ marginTop: 8 }}
         >
-          Confirm Discard
+          Confirm Bury
         </button>
         {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
       </div>
@@ -141,7 +141,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     const heldIds = new Set(myHand.map(c => c.id))
     // Cards the picker buried — cannot call any of these since the "partner" would be
     // nobody (the card is in the blind, never played).
-    const buriedIds = new Set((state.discard ?? []).filter(c => !c.hidden).map(c => c.id))
+    const buriedIds = new Set((state.buried ?? []).filter(c => !c.hidden).map(c => c.id))
 
     // ── King mode: picker holds all 3 fail aces and all 3 fail tens.
     //    Calls the King of any fail suit they don't hold (mathematically all 3).

--- a/frontend/src/components/recap/BlindStrip.jsx
+++ b/frontend/src/components/recap/BlindStrip.jsx
@@ -8,7 +8,7 @@ function CardStatic({ id }) {
   return <div className={`recap-card-static${isRed(id) ? ' red' : ''}`}>{id.replace(/([AKQJ]|10)([CDHS])/, '$1$2')}</div>
 }
 
-export default function BlindStrip({ blind, pickerDiscards }) {
+export default function BlindStrip({ blind, pickerBuried }) {
   if (!blind) return null
   return (
     <div className="recap-blind">
@@ -16,10 +16,10 @@ export default function BlindStrip({ blind, pickerDiscards }) {
         <div className="label">Blind (picked up)</div>
         <div className="cards">{blind.map(id => <CardStatic key={id} id={id} />)}</div>
       </div>
-      {pickerDiscards && pickerDiscards.length > 0 && (
+      {pickerBuried && pickerBuried.length > 0 && (
         <div className="group right">
-          <div className="label">Picker discarded</div>
-          <div className="cards">{pickerDiscards.map(id => <CardStatic key={id} id={id} />)}</div>
+          <div className="label">Picker buried</div>
+          <div className="cards">{pickerBuried.map(id => <CardStatic key={id} id={id} />)}</div>
         </div>
       )}
     </div>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -296,7 +296,7 @@ body {
 }
 
 /* ── Action panel ────────────────────────────────────────── */
-.action-panel.action-panel-discard-overlay {
+.action-panel.action-panel-bury-overlay {
   grid-area: center;
   z-index: 10;
   background: #1a3d25;
@@ -419,8 +419,8 @@ body {
   accent-color: #7c3aed;
 }
 
-/* Discard selection hint */
-.discard-hint {
+/* Bury selection hint */
+.bury-hint {
   color: #aaa;
   font-size: 0.8rem;
   margin-top: 4px;

--- a/frontend/src/pages/DetailedReplayPage.jsx
+++ b/frontend/src/pages/DetailedReplayPage.jsx
@@ -82,11 +82,11 @@ export default function DetailedReplayPage({ gameId, handNumber, startSeq, onNav
   const seatTopRight = players.find(p => p.seat === 3)
   const seatRight = players.find(p => p.seat === 4)
 
-  // The picker's play-phase hand is (dealt + blind) − pickerDiscards, not the raw dealt array.
-  const pickerPlayHand = pickerId && digest.blind && digest.pickerDiscards
+  // The picker's play-phase hand is (dealt + blind) − pickerBuried, not the raw dealt array.
+  const pickerPlayHand = pickerId && digest.blind && digest.pickerBuried
     ? (() => {
-        const discards = new Set(digest.pickerDiscards)
-        return [...(digest.dealt[pickerId] ?? []), ...digest.blind].filter(c => !discards.has(c))
+        const buried = new Set(digest.pickerBuried)
+        return [...(digest.dealt[pickerId] ?? []), ...digest.blind].filter(c => !buried.has(c))
       })()
     : null
   const dealtOf = uid => (uid === pickerId && pickerPlayHand) ? pickerPlayHand : (digest.dealt[uid] ?? [])
@@ -181,7 +181,7 @@ function describePlay(action, players) {
     case 'call_ace':  return `${uname} called ace`
     case 'call_ten':  return `${uname} called ten`
     case 'call_king': return `${uname} called king`
-    case 'discard':   return `${uname} discarded`
+    case 'bury':      return `${uname} buried`
     case 'play_card': return `${uname} played`
     default:          return action.type
   }

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -46,7 +46,7 @@ function currentTurnPlayer(state) {
   if (!state) return null
   const { phase, pickOrder, pickIndex, currentTrick, currentLeader } = state
   if (phase === 'picking')                            return pickOrder?.[pickIndex] ?? null
-  if (phase === 'discarding' || phase === 'calling')  return state.picker
+  if (phase === 'burying' || phase === 'calling')  return state.picker
   if (phase === 'playing') {
     const played    = (currentTrick ?? []).map(p => p.userId)
     const leaderIdx = pickOrder.indexOf(currentLeader)
@@ -563,7 +563,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
   const isMyPlayingTurn = state.phase === 'playing' && turnUserId === effectiveUserId
   const legalIds = isMyPlayingTurn ? getLegalCardIds(state, effectiveUserId, activeHand) : []
-  const isPickerOverlay = (state.phase === 'discarding' || state.phase === 'calling') && state.picker === effectiveUserId
+  const isPickerOverlay = (state.phase === 'burying' || state.phase === 'calling') && state.picker === effectiveUserId
 
   return (
     <div className="game-table">
@@ -665,7 +665,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
       {/* ── Action panel (hidden on your real playing turn — cards in seat instead) ── */}
       {!(isMyPlayingTurn && !isActingForBot) && (
-        <div className={`action-panel${isPickerOverlay ? ' action-panel-discard-overlay' : ''}`}>
+        <div className={`action-panel${isPickerOverlay ? ' action-panel-bury-overlay' : ''}`}>
           <ActionPanel
             state={state}
             myUserId={effectiveUserId}

--- a/frontend/src/pages/RecapPage.jsx
+++ b/frontend/src/pages/RecapPage.jsx
@@ -35,7 +35,7 @@ export default function RecapPage({ gameId, handNumber, onNavigate }) {
         <div className="sub">Game #{digest.gameId}{dateStr && ` · played ${dateStr}`}</div>
       </div>
       <MetaStrip digest={digest} />
-      <BlindStrip blind={digest.blind} pickerDiscards={digest.pickerDiscards} />
+      <BlindStrip blind={digest.blind} pickerBuried={digest.pickerBuried} />
       <TrickTable digest={digest} onCardClick={onCardClick} />
       <div className="recap-legend">
         <span>Green outline = trick winner · Yellow outline = led the trick · Click a card to open the step-by-step replay at that point</span>

--- a/functions/api/_botHelpers.js
+++ b/functions/api/_botHelpers.js
@@ -3,7 +3,7 @@
 
 import {
   currentPicker, currentPlayer,
-  pick, blitz, pass, discard,
+  pick, blitz, pass, bury,
   callAce, callAceUnknown, callTen, callKing, goAlone,
   playCard, crack, recrack,
   setupLeaster, awardLeasterBlind, resolveLeaster,
@@ -12,7 +12,7 @@ import {
 } from '../../shared/gameEngine.js'
 
 import {
-  decidePick, decideBlitz, decideDiscard, decideCall, decidePlay,
+  decidePick, decideBlitz, decideBury, decideCall, decidePlay,
 } from '../../shared/botStrategy.js'
 
 async function appendAction(DB, gameId, handNumber, type, userId, payload) {
@@ -159,7 +159,7 @@ async function createPlayBots(DB, count) {
 // ─── processBotTurns ─────────────────────────────────────────────────────────
 // Advances the game state through consecutive bot turns with two modes:
 //
-//   Non-playing phases (picking, discarding, calling): loop freely — these
+//   Non-playing phases (picking, burying, calling): loop freely — these
 //   resolve instantly because there's nothing visible to animate.
 //
 //   Playing phase: execute exactly ONE card play then stop. The frontend
@@ -254,7 +254,7 @@ export async function processBotTurns(state, gameId, DB, game, { allowTrick1Lead
 function getNextActor(state) {
   switch (state.phase) {
     case 'picking':    return currentPicker(state)
-    case 'discarding': return state.picker
+    case 'burying':    return state.picker
     case 'calling':    return state.picker
     case 'playing':    return currentPlayer(state)
     default:           return null
@@ -275,9 +275,9 @@ function applyBotDecision(state, userId, view) {
       return { state: pass(state, userId), actionType: 'pass', payload: null }
     }
 
-    case 'discarding': {
-      const cardIds = decideDiscard(view, userId)
-      return { state: discard(state, userId, cardIds), actionType: 'discard', payload: { cardIds } }
+    case 'burying': {
+      const cardIds = decideBury(view, userId)
+      return { state: bury(state, userId, cardIds), actionType: 'bury', payload: { cardIds } }
     }
 
     case 'calling': {

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -1,6 +1,6 @@
 import { json, err, requireUser, AuthError } from '../../_helpers.js'
 import {
-  pick, blitz, pass, discard, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
+  pick, blitz, pass, bury, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
   crack, recrack,
   setupLeaster, awardLeasterBlind, resolveLeaster,
   resolveSchwanzer,
@@ -115,9 +115,9 @@ export async function onRequestPost({ request, env, params }) {
         break
       }
 
-      case 'discard':
-        state = discard(state, userId, payload?.cardIds)
-        await appendAction(env.DB, gameId, state.handNumber, 'discard', userId, { cardIds: payload?.cardIds })
+      case 'bury':
+        state = bury(state, userId, payload?.cardIds)
+        await appendAction(env.DB, gameId, state.handNumber, 'bury', userId, { cardIds: payload?.cardIds })
         break
 
       case 'call_ace':

--- a/shared/actionReplay.js
+++ b/shared/actionReplay.js
@@ -1,5 +1,5 @@
 import {
-  pick, blitz, pass, discard,
+  pick, blitz, pass, bury,
   callAce, callAceUnknown, callTen, callKing, goAlone,
   playCard, crack, recrack,
   setupLeaster, awardLeasterBlind,
@@ -28,7 +28,7 @@ export function replayActions(actions) {
       case 'blitz':            state = blitz(state, uid); break
       case 'pass':             state = pass(state, uid); break
       case 'setup_leaster':    state = setupLeaster(state); break
-      case 'discard':          state = discard(state, uid, payload.cardIds); break
+      case 'bury':             state = bury(state, uid, payload.cardIds); break
       case 'call_ace':         state = callAce(state, uid, payload.suit); break
       case 'call_ace_unknown': state = callAceUnknown(state, uid, payload.suit, payload.underCardId); break
       case 'call_ten':         state = callTen(state, uid, payload.suit); break

--- a/shared/actionReplay.test.js
+++ b/shared/actionReplay.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { replayActions } from './actionReplay.js'
-import { dealHand, pick, discard, pass, setupLeaster, awardLeasterBlind, playCard, currentPlayer } from './gameEngine.js'
+import { dealHand, pick, bury, pass, setupLeaster, awardLeasterBlind, playCard, currentPlayer } from './gameEngine.js'
 
 describe('replayActions', () => {
   it('throws if no actions provided', () => {
@@ -30,32 +30,32 @@ describe('replayActions', () => {
       { type: 'pick', user_id: Number(pickerId), payload_json: null },
     ]
     const result = replayActions(actions)
-    expect(result.phase).toBe('discarding')
+    expect(result.phase).toBe('burying')
     expect(result.picker).toBe(pickerId)
   })
 
-  it('produces the same state as direct engine calls through pick and discard', () => {
+  it('produces the same state as direct engine calls through pick and bury', () => {
     const playerIds = ['1', '2', '3', '4', '5']
     const initial = dealHand(playerIds, 0, 1, 1)
     const pickerId = initial.pickOrder[0]
 
     // Direct engine path
     let direct = pick(initial, pickerId)
-    const cardIdsToDiscard = direct.hands[pickerId].slice(0, 2).map(c => c.id)
-    direct = discard(direct, pickerId, cardIdsToDiscard)
+    const cardIdsToBury = direct.hands[pickerId].slice(0, 2).map(c => c.id)
+    direct = bury(direct, pickerId, cardIdsToBury)
 
     // Replay path
     const actions = [
       { type: 'deal',    user_id: null,             payload_json: JSON.stringify(initial) },
       { type: 'pick',    user_id: Number(pickerId), payload_json: null },
-      { type: 'discard', user_id: Number(pickerId), payload_json: JSON.stringify({ cardIds: cardIdsToDiscard }) },
+      { type: 'bury',    user_id: Number(pickerId), payload_json: JSON.stringify({ cardIds: cardIdsToBury }) },
     ]
     const replayed = replayActions(actions)
 
     expect(replayed.phase).toBe('calling')
     expect(replayed.picker).toBe(pickerId)
     expect(replayed.hands[pickerId]).toHaveLength(6)
-    expect(replayed.discard).toEqual(direct.discard)
+    expect(replayed.buried).toEqual(direct.buried)
   })
 
   it('throws on unknown action type', () => {

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -27,8 +27,8 @@ export function countTrumpPlayed(view, _userId) {
 // A result ≤ 2 means opponents are likely trump-exhausted.
 export function trumpRemainingElsewhere(view, userId) {
   const myTrump = (view.hands[userId] ?? []).filter(c => !c.hidden && isTrump(c)).length
-  const discardTrump = (view.discard ?? []).filter(c => !c.hidden && isTrump(c)).length
-  return 14 - myTrump - countTrumpPlayed(view, userId) - discardTrump
+  const buriedTrump = (view.buried ?? []).filter(c => !c.hidden && isTrump(c)).length
+  return 14 - myTrump - countTrumpPlayed(view, userId) - buriedTrump
 }
 
 // ─── Hand evaluation ──────────────────────────────────────────────────────────
@@ -87,8 +87,8 @@ export function currentWinner(trick) {
 // For a 1-card suit: pairs the suit card with the highest-point eligible card from any
 // other suit (chosen for point value, not secondary voiding).
 // Among qualifying pairs, returns the highest-total pair.
-// Respects mustHold restrictions (same logic as decideDiscard).
-export function bestVoidDiscard(hand) {
+// Respects mustHold restrictions (same logic as decideBury).
+export function bestVoidBury(hand) {
   const failAces = ['AC', 'AH', 'AS']
   const failTens = ['10C', '10H', '10S']
   const holdsAllAces = failAces.every(id => hand.some(c => c.id === id))

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidDiscard, teammateWinning, trumpRemainingElsewhere } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, trumpRemainingElsewhere } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -124,14 +124,14 @@ export function decideBlitz(view, userId) {
   return schwanzerPts >= 7
 }
 
-// ─── decideDiscard ────────────────────────────────────────────────────────────
-export function decideDiscard(view, userId) {
+// ─── decideBury ───────────────────────────────────────────────────────────────
+export function decideBury(view, userId) {
   const hand = view.hands[userId]  // 8 cards after picking up blind
 
-  const voidCards = bestVoidDiscard(hand)
+  const voidCards = bestVoidBury(hand)
   if (voidCards) return voidCards
 
-  // Replicate mustHold logic from gameEngine.discard to avoid illegal discards
+  // Replicate mustHold logic from gameEngine.bury to avoid illegal buries
   const failAces = ['AC', 'AH', 'AS']
   const failTens = ['10C', '10H', '10S']
   const holdsAllAces = failAces.every(id => hand.some(c => c.id === id))
@@ -156,7 +156,7 @@ export function decideDiscard(view, userId) {
 
 // ─── decideCall ───────────────────────────────────────────────────────────────
 export function decideCall(view, userId) {
-  const { callMode, hands, discard: discardCards } = view
+  const { callMode, hands, buried: buriedCards } = view
   const hand = hands[userId]
 
   // Go alone with a dominant trump hand
@@ -164,7 +164,7 @@ export function decideCall(view, userId) {
   const queenCount = hand.filter(c => c.rank === 'Q').length
   if (trumpCount >= 6 && queenCount >= 2) return { type: 'alone' }
 
-  const buried = (discardCards ?? []).filter(c => !c.hidden)
+  const buried = (buriedCards ?? []).filter(c => !c.hidden)
   const suits = ['C', 'H', 'S']
 
   if (callMode === 'ace') {

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -103,7 +103,7 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
   }
 
   return {
-    phase: 'picking',          // picking | discarding | calling | playing | scoring | complete
+    phase: 'picking',          // picking | burying | calling | playing | scoring | complete
     handNumber,
     dealerSeat,
     doublerMultiplier,
@@ -117,12 +117,12 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     calledSuit: null,          // 'C'|'H'|'S' — unifying field across all call types
     callMode: null,            // null | 'ace' | 'ten' | 'king'
     underCard: null,           // { id, suit, rank, ownerId, played } — server-side full info
-    pickerMustHold: [],        // card ids the picker may not bury during discard
+    pickerMustHold: [],        // card ids the picker may not bury during the burying phase
     pickerForcedPlays: [],     // card ids the picker must play when called suit is led
     partnerRevealed: false,
     goingAlone: false,
     blind,
-    discard: [],               // picker's 2 discarded cards
+    buried: [],                // picker's 2 buried cards
     hands,                     // { userId: [cards] }
     tricks: [],                // completed tricks: [{ leader, plays: [{userId, card}], winner }]
     currentTrick: [],          // in-progress: [{userId, card}]
@@ -148,7 +148,7 @@ export function pick(state, userId) {
   // Give picker the blind
   newState.hands[userId] = [...newState.hands[userId], ...newState.blind]
   newState.blind = []
-  newState.phase = 'discarding'
+  newState.phase = 'burying'
   newState.log.push(`${userId} picked.`)
 
   return newState
@@ -170,7 +170,7 @@ export function blitz(state, userId) {
   // Give picker the blind
   newState.hands[userId] = [...newState.hands[userId], ...newState.blind]
   newState.blind = []
-  newState.phase = 'discarding'
+  newState.phase = 'burying'
   newState.log.push(`${userId} ${potentialBlitz.type === 'black' ? 'Black' : 'Red'} Blitzed!`)
 
   return newState
@@ -196,16 +196,16 @@ export function currentPicker(state) {
   return state.pickOrder[state.pickIndex]
 }
 
-// ─── Discard phase ───────────────────────────────────────────────────────────
-export function discard(state, userId, cardIds) {
-  assertPhase(state, 'discarding')
-  if (state.picker !== userId) throw new Error('Only the picker can discard.')
-  if (!Array.isArray(cardIds) || cardIds.length !== 2) throw new Error('Must discard exactly 2 cards.')
+// ─── Burying phase ───────────────────────────────────────────────────────────
+export function bury(state, userId, cardIds) {
+  assertPhase(state, 'burying')
+  if (state.picker !== userId) throw new Error('Only the picker can bury.')
+  if (!Array.isArray(cardIds) || cardIds.length !== 2) throw new Error('Must bury exactly 2 cards.')
 
   const newState = deepClone(state)
   const hand = newState.hands[userId]
 
-  // Determine calling mode based on the picker's 8-card hand BEFORE discard
+  // Determine calling mode based on the picker's 8-card hand BEFORE burying
   const failAces = ['AC', 'AH', 'AS']
   const failTens = ['10C', '10H', '10S']
   const holdsAllAces = failAces.every(id => hand.some(c => c.id === id))
@@ -221,21 +221,21 @@ export function discard(state, userId, cardIds) {
     callMode = 'ten'
   }
 
-  // Reject discards that bury cards the picker must keep for the partner call
+  // Reject burying cards the picker must keep for the partner call
   for (const cid of cardIds) {
     if (mustHold.includes(cid)) {
       throw new Error(`Cannot bury ${cid} — must keep for partner call.`)
     }
   }
 
-  const discarded = []
+  const buried = []
   for (const cid of cardIds) {
     const idx = hand.findIndex(c => c.id === cid)
     if (idx === -1) throw new Error(`Card ${cid} not in hand.`)
-    discarded.push(hand.splice(idx, 1)[0])
+    buried.push(hand.splice(idx, 1)[0])
   }
 
-  newState.discard = discarded
+  newState.buried = buried
   newState.pickerMustHold = mustHold
   newState.callMode = callMode
   newState.phase = 'calling'
@@ -262,7 +262,7 @@ export function callAce(state, userId, suit) {
   if (state.hands[userId].some(c => c.id === aceId)) {
     throw new Error(`Picker holds the ${aceId} — cannot call it.`)
   }
-  if (state.discard.some(c => c.id === aceId)) {
+  if (state.buried.some(c => c.id === aceId)) {
     throw new Error(`Picker buried the ${aceId} — cannot call it.`)
   }
 
@@ -315,7 +315,7 @@ export function callAceUnknown(state, userId, suit, underCardId) {
   if (state.hands[userId].some(c => c.id === aceId)) {
     throw new Error(`Picker holds the ${aceId} — cannot call it.`)
   }
-  if (state.discard.some(c => c.id === aceId)) {
+  if (state.buried.some(c => c.id === aceId)) {
     throw new Error(`Picker buried the ${aceId} — cannot call it.`)
   }
 
@@ -330,7 +330,7 @@ export function callAceUnknown(state, userId, suit, underCardId) {
   const hasNormalCall = ['C', 'H', 'S'].some(s => {
     const a = `A${s}`
     if (state.hands[userId].some(c => c.id === a)) return false
-    if (state.discard.some(c => c.id === a)) return false
+    if (state.buried.some(c => c.id === a)) return false
     return state.hands[userId].some(c => c.suit === s && !isTrump(c))
   })
   if (hasNormalCall) {
@@ -365,7 +365,7 @@ export function callTen(state, userId, suit) {
   if (state.hands[userId].some(c => c.id === tenId)) {
     throw new Error(`Picker holds the ${tenId} — cannot call it.`)
   }
-  if (state.discard.some(c => c.id === tenId)) {
+  if (state.buried.some(c => c.id === tenId)) {
     throw new Error(`Picker buried the ${tenId} — cannot call it.`)
   }
 
@@ -393,7 +393,7 @@ export function callKing(state, userId, suit) {
   if (state.hands[userId].some(c => c.id === kingId)) {
     throw new Error(`Picker holds the ${kingId} — cannot call it.`)
   }
-  if (state.discard.some(c => c.id === kingId)) {
+  if (state.buried.some(c => c.id === kingId)) {
     throw new Error(`Picker buried the ${kingId} — cannot call it.`)
   }
 
@@ -690,7 +690,7 @@ function beats(challenger, current, ledSuit) {
 
 // ─── Scoring ─────────────────────────────────────────────────────────────────
 export function computeScores(state) {
-  const { tricks, picker, partner, goingAlone, discard, doublerMultiplier } = state
+  const { tricks, picker, partner, goingAlone, buried, doublerMultiplier } = state
 
   // Gather all trick winners' point piles
   const pointsByPlayer = {}
@@ -703,8 +703,8 @@ export function computeScores(state) {
     pointsByPlayer[trick.winner] = (pointsByPlayer[trick.winner] ?? 0) + pts
   }
 
-  // Add buried discard points to picker's pile
-  for (const c of discard) {
+  // Add buried card points to picker's pile
+  for (const c of buried) {
     pointsByPlayer[picker] = (pointsByPlayer[picker] ?? 0) + cardPoints(c)
   }
 
@@ -793,7 +793,7 @@ export function resolveLeaster(state) {
     tricksByPlayer[trick.winner] = (tricksByPlayer[trick.winner] ?? 0) + 1
   }
 
-  // Add points from blind (blind is exposed in leaster — no discard)
+  // Add points from blind (blind is exposed in leaster — no burying)
   // In leasters, the blind is placed with whoever wins trick 1
   // We handle blind awarding in the action handler
 
@@ -884,9 +884,9 @@ export function getPlayerView(state, userId) {
   }
 
   // Picker can see blind during picking (they just picked it up — this is after picking)
-  // Discard is visible to the picker (they buried it); hidden to everyone else.
+  // Buried cards are visible to the picker; hidden to everyone else.
   if (userId !== view.picker) {
-    view.discard = view.discard.map(() => ({ id: 'HIDDEN', hidden: true }))
+    view.buried = view.buried.map(() => ({ id: 'HIDDEN', hidden: true }))
   }
 
   // Under card: picker (who placed it) can see its identity; other players cannot.

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,10 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { decidePick, decideDiscard, decideCall, decidePlay } from './botStrategy.js'
+import { decidePick, decideBury, decideCall, decidePlay } from './botStrategy.js'
 import {
   isTrump, trumpRank, suitRank, effectiveSuit, cardPoints,
   schwanzerCardPoints, resolveSchwanzer,
   dealHand, pick, pass, blitz,
-  discard, callAce, goAlone, callTen, callKing,
+  bury, callAce, goAlone, callTen, callKing,
   callAceUnknown, crack, recrack,
   playCard, computeScores, resolveLeaster,
   setupLeaster, awardLeasterBlind, getPlayerView,
@@ -13,7 +13,7 @@ import {
   countTrumpPlayed, trumpRemainingElsewhere,
   buriablePoints, handScore,
   beats, currentWinner, teammateWinning,
-  bestVoidDiscard,
+  bestVoidBury,
 } from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -266,10 +266,10 @@ describe('pick / pass / blitz', () => {
   }
 
   describe('pick', () => {
-    it('transitions to discarding phase', () => {
+    it('transitions to burying phase', () => {
       const state = makePickingState()
       const next = pick(state, state.pickOrder[0])
-      expect(next.phase).toBe('discarding')
+      expect(next.phase).toBe('burying')
     })
 
     it('gives the picker 8 cards (hand + blind)', () => {
@@ -318,7 +318,7 @@ describe('pick / pass / blitz', () => {
   })
 
   describe('blitz', () => {
-    it('transitions to discarding phase', () => {
+    it('transitions to burying phase', () => {
       const state = makePickingState()
       const firstPicker = state.pickOrder[0]
       const stateWithBlitz = {
@@ -326,7 +326,7 @@ describe('pick / pass / blitz', () => {
         potentialBlitzes: [{ userId: firstPicker, type: 'black' }],
       }
       const next = blitz(stateWithBlitz, firstPicker)
-      expect(next.phase).toBe('discarding')
+      expect(next.phase).toBe('burying')
     })
 
     it('records the blitz in state.blitzes', () => {
@@ -347,52 +347,52 @@ describe('pick / pass / blitz', () => {
   })
 })
 
-describe('discard', () => {
-  function makeDiscardingState() {
+describe('bury', () => {
+  function makeBuryingState() {
     const state = dealHand(['p1','p2','p3','p4','p5'], 0, 1, 1)
     return pick(state, state.pickOrder[0])
-    // picker now has 8 cards; phase = 'discarding'
+    // picker now has 8 cards; phase = 'burying'
   }
 
   it('transitions to calling phase', () => {
-    const state = makeDiscardingState()
+    const state = makeBuryingState()
     const cardIds = state.hands[state.picker].slice(-2).map(cd => cd.id)
-    const next = discard(state, state.picker, cardIds)
+    const next = bury(state, state.picker, cardIds)
     expect(next.phase).toBe('calling')
   })
 
   it('picker ends with 6 cards', () => {
-    const state = makeDiscardingState()
+    const state = makeBuryingState()
     const cardIds = state.hands[state.picker].slice(-2).map(cd => cd.id)
-    const next = discard(state, state.picker, cardIds)
+    const next = bury(state, state.picker, cardIds)
     expect(next.hands[next.picker]).toHaveLength(6)
   })
 
-  it('stores the 2 discarded cards in state.discard', () => {
-    const state = makeDiscardingState()
+  it('stores the 2 buried cards in state.buried', () => {
+    const state = makeBuryingState()
     const cardIds = state.hands[state.picker].slice(-2).map(cd => cd.id)
-    const next = discard(state, state.picker, cardIds)
-    expect(next.discard).toHaveLength(2)
-    expect(next.discard.map(cd => cd.id)).toEqual(expect.arrayContaining(cardIds))
+    const next = bury(state, state.picker, cardIds)
+    expect(next.buried).toHaveLength(2)
+    expect(next.buried.map(cd => cd.id)).toEqual(expect.arrayContaining(cardIds))
   })
 
-  it('throws when not exactly 2 cards are discarded', () => {
-    const state = makeDiscardingState()
+  it('throws when not exactly 2 cards are buried', () => {
+    const state = makeBuryingState()
     const oneCard = [state.hands[state.picker][0].id]
-    expect(() => discard(state, state.picker, oneCard)).toThrow('Must discard exactly 2 cards.')
+    expect(() => bury(state, state.picker, oneCard)).toThrow('Must bury exactly 2 cards.')
   })
 
-  it('throws if a non-picker tries to discard', () => {
-    const state = makeDiscardingState()
+  it('throws if a non-picker tries to bury', () => {
+    const state = makeBuryingState()
     const nonPicker = state.pickOrder.find(p => p !== state.picker)
     const cardIds = state.hands[state.picker].slice(-2).map(cd => cd.id)
-    expect(() => discard(state, nonPicker, cardIds)).toThrow('Only the picker can discard.')
+    expect(() => bury(state, nonPicker, cardIds)).toThrow('Only the picker can bury.')
   })
 
   it('throws when trying to bury a card the picker must keep for the partner call', () => {
     // Picker holds all 3 fail aces → callMode becomes 'ten', mustHold = [AC, AH, AS]
     const state = {
-      phase: 'discarding',
+      phase: 'burying',
       picker: 'p1',
       pickOrder: ['p1','p2','p3','p4','p5'],
       blind: [],
@@ -402,7 +402,7 @@ describe('discard', () => {
         p2: [], p3: [], p4: [], p5: [],
       },
     }
-    expect(() => discard(state, 'p1', ['AC', 'QC'])).toThrow('Cannot bury AC')
+    expect(() => bury(state, 'p1', ['AC', 'QC'])).toThrow('Cannot bury AC')
   })
 })
 
@@ -422,7 +422,7 @@ describe('partner calling', () => {
         p4: [c('7','H'), c('10','C'), c('K','D'), c('9','D'), c('8','D'), c('7','D')],
         p5: [c('Q','S'), c('Q','H'), c('J','S'), c('J','H'), c('10','D'), c('10','S')],
       },
-      discard: [c('Q','D'), c('J','D')],
+      buried: [c('Q','D'), c('J','D')],
       log: [],
     }
   }
@@ -482,7 +482,7 @@ describe('partner calling', () => {
           p4: [c('7','H'), c('8','C'), c('A','D'), c('9','D'), c('8','D'), c('7','D')],
           p5: [c('Q','H'), c('Q','D'), c('J','H'), c('J','D'), c('10','D'), c('10','H')],
         },
-        discard: [c('10','S'), c('K','C')],
+        buried: [c('10','S'), c('K','C')],
         log: [],
       }
       const next = callTen(state, 'p1', 'C')
@@ -507,7 +507,7 @@ describe('partner calling', () => {
           p4: [c('7','H'), c('8','C'), c('A','D'), c('9','D'), c('8','D'), c('7','D')],
           p5: [c('Q','C'), c('Q','H'), c('J','C'), c('J','H'), c('10','D'), c('Q','D')],
         },
-        discard: [c('J','D'), c('K','D')],
+        buried: [c('J','D'), c('K','D')],
         log: [],
       }
       const next = callKing(state, 'p1', 'C')
@@ -538,7 +538,7 @@ describe('playCard', () => {
       doublerMultiplier: 1,
       handCrackMultiplier: 1,
       blitzes: [],
-      discard: [],
+      buried: [],
       tricks: [],
       currentTrick: [
         { userId: 'p1', card: c('K','H') },
@@ -582,7 +582,7 @@ describe('playCard', () => {
       doublerMultiplier: 1,
       handCrackMultiplier: 1,
       blitzes: [],
-      discard: [],
+      buried: [],
       tricks: [],
       currentTrick: [
         { userId: 'p1', card: c('K','H') },
@@ -634,7 +634,7 @@ describe('playCard', () => {
       doublerMultiplier: 1,
       handCrackMultiplier: 1,
       blitzes: [],
-      discard: [],
+      buried: [],
       tricks: [],
       currentTrick: [],
       currentLeader: 'p1',
@@ -677,7 +677,7 @@ describe('playCard', () => {
       doublerMultiplier: 1,
       handCrackMultiplier: 1,
       blitzes: [],
-      discard: [],
+      buried: [],
       tricks: [],
       currentTrick: [],
       currentLeader: 'p1',
@@ -717,7 +717,7 @@ describe('playCard', () => {
       doublerMultiplier: 1,
       handCrackMultiplier: 1,
       blitzes: [],
-      discard: [],
+      buried: [],
       tricks: [],
       currentTrick: [],
       currentLeader: 'p1',
@@ -769,7 +769,7 @@ describe('playCard', () => {
       doublerMultiplier: 1,
       handCrackMultiplier: 1,
       blitzes: [],
-      discard: [],
+      buried: [],
       tricks: tricksComplete,
       currentTrick: [
         { userId: 'p1', card: c('A','C') },
@@ -816,7 +816,7 @@ describe('computeScores', () => {
       doublerMultiplier: 1,
       handCrackMultiplier: 1,
       blitzes: [],
-      discard: [],
+      buried: [],
       log: [],
       hands: { p1:[], p2:[], p3:[], p4:[], p5:[] },
       tricks,
@@ -879,8 +879,8 @@ describe('computeScores', () => {
     expect(scores.p3).toBe(-2)
   })
 
-  it('discard points count toward the picker\'s total', () => {
-    // p1 wins 1 trick with 39 pts + discard has 2 aces (22 pts) = 61 → wins
+  it('buried points count toward the picker\'s total', () => {
+    // p1 wins 1 trick with 39 pts + buried has 2 aces (22 pts) = 61 → wins
     const tricks = [
       makeTrick('p1', [fk('A'), fk('10'), fk('K'), fk('10'), fk('K')]),  // 11+10+4+10+4 = 39
       makeTrick('p3', [fk('7'), fk('7'), fk('7'), fk('7'), fk('7')]),
@@ -889,8 +889,8 @@ describe('computeScores', () => {
       makeTrick('p3', [fk('7'), fk('7'), fk('7'), fk('7'), fk('7')]),
       makeTrick('p3', [fk('7'), fk('7'), fk('7'), fk('7'), fk('7')]),
     ]
-    // discard: [A, A] = 22 pts → picker total = 39+22 = 61 → wins
-    const state = baseState(tricks, { discard: [fk('A'), fk('A')] })
+    // buried: [A, A] = 22 pts → picker total = 39+22 = 61 → wins
+    const state = baseState(tricks, { buried: [fk('A'), fk('A')] })
     const scores = computeScores(state)
     expect(scores.p1).toBe(2)   // picker wins
   })
@@ -1126,7 +1126,7 @@ describe('callAceUnknown', () => {
         p4: [c('7','H'), c('10','C'), c('K','D'), c('9','D'), c('8','D'), c('7','D')],
         p5: [c('J','H'), c('J','D'), c('10','D'), c('A','D'), c('8','C'), c('9','C')],
       },
-      discard: [c('K','C'), c('8','S')],  // AC not buried
+      buried: [c('K','C'), c('8','S')],  // AC not buried
       log: [],
     }
   }
@@ -1141,7 +1141,7 @@ describe('callAceUnknown', () => {
 
   it('throws when a normal ace call is available for another suit', () => {
     const state = makeUnknownCallingState()
-    // Add a fail heart (KH) — p1 doesn't hold AH, AH not in discard → normal call available for H
+    // Add a fail heart (KH) — p1 doesn't hold AH, AH not buried → normal call available for H
     state.hands.p1 = [c('Q','C'), c('Q','S'), c('Q','H'), c('Q','D'), c('J','C'), c('K','H')]
     expect(() => callAceUnknown(state, 'p1', 'C', 'QS')).toThrow('normal ace call is available')
   })
@@ -1249,7 +1249,7 @@ describe('getPlayerView', () => {
       partnerRevealed: false,
       goingAlone: false,
       blind: [],
-      discard: [c('Q','D'), c('J','D')],
+      buried: [c('Q','D'), c('J','D')],
       underCard: null,
       tricks: [],
       currentTrick: [],
@@ -1272,12 +1272,12 @@ describe('getPlayerView', () => {
     expect(view.hands.p3.every(card => card.hidden === true)).toBe(true)
   })
 
-  it('picker can see the discard; opponents see hidden placeholders', () => {
+  it('picker can see buried cards; opponents see hidden placeholders', () => {
     const pickerView = getPlayerView(makeViewState(), 'p1')
-    expect(pickerView.discard.every(card => card.hidden !== true)).toBe(true)
+    expect(pickerView.buried.every(card => card.hidden !== true)).toBe(true)
 
     const oppView = getPlayerView(makeViewState(), 'p3')
-    expect(oppView.discard.every(card => card.hidden === true)).toBe(true)
+    expect(oppView.buried.every(card => card.hidden === true)).toBe(true)
   })
 
   it('partner identity is hidden from opponents when partnerRevealed is false', () => {
@@ -1387,14 +1387,14 @@ describe('trumpRemainingElsewhere', () => {
     expect(trumpRemainingElsewhere(view, 'p1')).toBe(0)
   })
 
-  it('subtracts trump visible in picker discard', () => {
-    // Picker (p1) buried QS (trump) in discard. Own hand: QC. No tricks played.
-    // Remaining = 14 - 1 (QC in hand) - 0 (played) - 1 (QS in discard) = 12
+  it('subtracts trump visible in picker buried', () => {
+    // Picker (p1) buried QS (trump). Own hand: QC. No tricks played.
+    // Remaining = 14 - 1 (QC in hand) - 0 (played) - 1 (QS buried) = 12
     const view = {
       tricks: [],
       currentTrick: [],
       hands: { p1: [c('Q','C'), c('A','H'), c('K','S'), c('9','C'), c('8','S'), c('7','H')] },
-      discard: [c('Q','S'), c('K','H')],  // picker sees their own real discard
+      buried: [c('Q','S'), c('K','H')],  // picker sees their own real buried cards
     }
     expect(trumpRemainingElsewhere(view, 'p1')).toBe(12)
   })
@@ -1567,11 +1567,11 @@ describe('teammateWinning', () => {
   })
 })
 
-describe('bestVoidDiscard', () => {
+describe('bestVoidBury', () => {
   it('returns 2-card IDs that void a suit when burial total >= 11', () => {
     // AC(11) + KC(4) in clubs = 15 pts >= 11 → void clubs
     const hand = [c('Q','C'), c('J','S'), c('A','D'), c('A','C'), c('K','C'), c('9','H'), c('8','S'), c('7','S')]
-    const result = bestVoidDiscard(hand)
+    const result = bestVoidBury(hand)
     expect(result).not.toBeNull()
     expect(result).toHaveLength(2)
     expect(result).toContain('AC')
@@ -1581,13 +1581,13 @@ describe('bestVoidDiscard', () => {
   it('returns null when no suit can be voided with >= 11 pts', () => {
     // Clubs: 7C + 8C = 0+0 = 0 pts, Hearts: 9H only (1 card), Spades: 7S + 8S = 0 pts
     const hand = [c('Q','C'), c('J','S'), c('A','D'), c('10','D'), c('7','C'), c('8','C'), c('9','H'), c('7','S')]
-    expect(bestVoidDiscard(hand)).toBeNull()
+    expect(bestVoidBury(hand)).toBeNull()
   })
 
   it('handles 1-card suit: pairs with highest-point filler from another suit', () => {
     // Spades: only KS (4 pts). Filler: AH (11 pts). Total = 15 → qualifies
     const hand = [c('Q','C'), c('J','C'), c('A','D'), c('10','D'), c('K','S'), c('A','H'), c('8','C'), c('7','C')]
-    const result = bestVoidDiscard(hand)
+    const result = bestVoidBury(hand)
     expect(result).not.toBeNull()
     expect(result).toContain('KS')
     expect(result).toContain('AH')
@@ -1596,7 +1596,7 @@ describe('bestVoidDiscard', () => {
   it('returns null for suit with 3+ cards (burying 2 does not void it)', () => {
     // Clubs: AC+KC+9C (3 cards), Hearts: AH+KH+9H (3 cards), Spades: AS+KS+9S (3 cards)
     const hand = [c('Q','C'), c('A','C'), c('K','C'), c('A','H'), c('K','H'), c('A','S'), c('K','S'), c('9','C')]
-    expect(bestVoidDiscard(hand)).toBeNull()
+    expect(bestVoidBury(hand)).toBeNull()
   })
 
   it('excludes mustHold cards — cannot bury fail ace when holding all 3', () => {
@@ -1606,7 +1606,7 @@ describe('bestVoidDiscard', () => {
     // Eligible non-trump non-mustHold: KS only (1 card, 4 pts). Need filler from other suit.
     // No other eligible non-trump → null
     const hand = [c('A','C'), c('A','H'), c('A','S'), c('Q','C'), c('J','C'), c('K','S'), c('9','D'), c('8','D')]
-    expect(bestVoidDiscard(hand)).toBeNull()
+    expect(bestVoidBury(hand)).toBeNull()
   })
 
   it('excludes both fail aces AND fail tens when holding all 6', () => {
@@ -1617,7 +1617,7 @@ describe('bestVoidDiscard', () => {
       c('10','C'), c('10','H'), c('10','S'),
       c('K','S'), c('Q','C'),
     ]
-    expect(bestVoidDiscard(hand)).toBeNull()
+    expect(bestVoidBury(hand)).toBeNull()
   })
 })
 
@@ -1641,11 +1641,11 @@ describe('decidePick', () => {
   })
 })
 
-describe('decideDiscard', () => {
+describe('decideBury', () => {
   it('buries void pair when suit can be voided with >= 11 pts', () => {
     // AC(11) + KC(4) in clubs = 15 pts → void clubs
     const hand = [c('Q','C'), c('J','S'), c('A','D'), c('A','C'), c('K','C'), c('9','H'), c('8','S'), c('7','S')]
-    const result = decideDiscard({ hands: { p1: hand }, discard: [] }, 'p1')
+    const result = decideBury({ hands: { p1: hand }, buried: [] }, 'p1')
     expect(result).toHaveLength(2)
     expect(result).toContain('AC')
     expect(result).toContain('KC')
@@ -1655,7 +1655,7 @@ describe('decideDiscard', () => {
     // Hearts: 10H + 9H = 10 pts (< 11). Spades: 8S + 7S = 0 pts. No qualifying void.
     // Greedy buries highest-point non-trump: AC(11) + 10H(10)
     const hand = [c('Q','C'), c('J','S'), c('A','D'), c('A','C'), c('10','H'), c('9','H'), c('8','S'), c('7','S')]
-    const result = decideDiscard({ hands: { p1: hand }, discard: [] }, 'p1')
+    const result = decideBury({ hands: { p1: hand }, buried: [] }, 'p1')
     expect(result).toContain('AC')
     expect(result).toContain('10H')
   })
@@ -1665,21 +1665,21 @@ describe('decideCall go-alone', () => {
   it('goes alone with 6 trump and 2 queens', () => {
     // QC, QS (2 queens), JC, JH, AD, 10D = 6 trump
     const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','H'), c('A','D'), c('10','D')]
-    const view = { callMode: 'ace', hands: { p1: hand }, discard: [] }
+    const view = { callMode: 'ace', hands: { p1: hand }, buried: [] }
     expect(decideCall(view, 'p1').type).toBe('alone')
   })
 
   it('does not go alone with only 1 queen even with 6 trump', () => {
     // QC (1 queen), JC, JS, JH, JD, AD = 6 trump
     const hand = [c('Q','C'), c('J','C'), c('J','S'), c('J','H'), c('J','D'), c('A','D')]
-    const view = { callMode: 'ace', hands: { p1: hand }, discard: [] }
+    const view = { callMode: 'ace', hands: { p1: hand }, buried: [] }
     expect(decideCall(view, 'p1').type).not.toBe('alone')
   })
 
   it('does not go alone with 2 queens but only 5 trump', () => {
     // QC, QS (2 queens), JC, AD, 10D = 5 trump; AH is fail
     const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('A','D'), c('10','D'), c('A','H')]
-    const view = { callMode: 'ace', hands: { p1: hand }, discard: [] }
+    const view = { callMode: 'ace', hands: { p1: hand }, buried: [] }
     expect(decideCall(view, 'p1').type).not.toBe('alone')
   })
 })
@@ -1781,7 +1781,7 @@ describe('decidePlay trump counting', () => {
       partnerRevealed: false,
       pickerForcedPlays: [],
       underCard: null,
-      discard: [],
+      buried: [],
     }
   }
 
@@ -1904,7 +1904,7 @@ describe('decidePlay opponent leading called suit', () => {
       partnerRevealed,
       pickerForcedPlays: [],
       underCard: null,
-      discard: [],
+      buried: [],
     }
   }
 
@@ -2086,7 +2086,7 @@ describe('decidePlay trump efficiency — trump trick (Scenario 1)', () => {
     // 0 opponents remain (p3,p4,p5 all played; p2=partner played).
     // Picker (p1) hand: 10D(rank9), 9D(rank11). Both beat 8D(rank12).
     //   10D: trumpRank(10D)=9 < 12 ✓   9D: trumpRank(9D)=11 < 12 ✓
-    // Old lowestCard: 9D=0pts < 10D=10pts → picks 9D. Bug: discards 10pts from pile.
+    // Old lowestCard: 9D=0pts < 10D=10pts → picks 9D. Bug: loses 10pts from pile.
     // New: tier1=[10D] → return 10D.
     const view = makeTrumpEfficiencyView({
       userId: 'p1', picker: 'p1', partner: 'p2',

--- a/shared/recapDigest.js
+++ b/shared/recapDigest.js
@@ -22,13 +22,13 @@ export function buildHandDigest(actions, players, scoreEventsByUser) {
 
   const variant = detectVariant(actions, finalState)
 
-  // Primary path: the discard action's cardIds is the production source of truth.
-  // Fallback reads finalState.discard for synthetic state-only fixtures that skip
-  // the discard action — inert in production since a normal hand always has one.
-  const discardAction = actions.find(a => a.type === 'discard')
-  const pickerDiscards = discardAction
-    ? JSON.parse(discardAction.payload_json).cardIds
-    : (finalState.discard ?? []).map(c => c.id)
+  // Primary path: the bury action's cardIds is the production source of truth.
+  // Fallback reads finalState.buried for synthetic state-only fixtures that skip
+  // the bury action — inert in production since a normal hand always has one.
+  const buryAction = actions.find(a => a.type === 'bury')
+  const pickerBuried = buryAction
+    ? JSON.parse(buryAction.payload_json).cardIds
+    : (finalState.buried ?? []).map(c => c.id)
 
   const calledCard =
     finalState.calledAce?.aceId ??
@@ -74,8 +74,8 @@ export function buildHandDigest(actions, players, scoreEventsByUser) {
     const pts = t.plays.reduce((s, p) => s + cardPoints(p.card), 0)
     cardPointsByUser[t.winner] = (cardPointsByUser[t.winner] ?? 0) + pts
   }
-  if (finalState.picker && finalState.discard) {
-    for (const c of finalState.discard) {
+  if (finalState.picker && finalState.buried) {
+    for (const c of finalState.buried) {
       cardPointsByUser[finalState.picker] += cardPoints(c)
     }
   }
@@ -101,7 +101,7 @@ export function buildHandDigest(actions, players, scoreEventsByUser) {
       ? { userId: finalState.partner, revealedOnTrick: partnerRevealedOnTrick }
       : null,
     calledCard,
-    pickerDiscards: variant === 'normal' ? pickerDiscards : null,
+    pickerBuried: variant === 'normal' ? pickerBuried : null,
     tricks,
     scores,
   }

--- a/shared/recapDigest.test.js
+++ b/shared/recapDigest.test.js
@@ -58,7 +58,7 @@ describe('buildHandDigest — Normal variant', () => {
     initial.partner = '2'
     initial.calledAce = { suit: 'C', aceId: 'AC' }
     initial.callMode = 'ace'
-    initial.discard = [{ id: 'X1', suit: 'C', rank: '7', points: 0 }, { id: 'X2', suit: 'D', rank: '8', points: 0 }]
+    initial.buried = [{ id: 'X1', suit: 'C', rank: '7', points: 0 }, { id: 'X2', suit: 'D', rank: '8', points: 0 }]
     initial.tricks = Array.from({ length: 6 }, () => ({
       leader: '1',
       plays: [
@@ -81,7 +81,7 @@ describe('buildHandDigest — Normal variant', () => {
     expect(digest.picker.userId).toBe('1')
     expect(digest.partner.userId).toBe('2')
     expect(digest.calledCard).toBe('AC')
-    expect(digest.pickerDiscards).toEqual(['X1', 'X2'])
+    expect(digest.pickerBuried).toEqual(['X1', 'X2'])
     expect(digest.scores).toContainEqual({ userId: '1', cardPoints: expect.any(Number), scoreDelta: -2 })
   })
 })
@@ -101,7 +101,7 @@ describe('buildHandDigest — Schwanzer variant', () => {
     expect(digest.tricks).toEqual([])
     expect(digest.picker).toBeNull()
     expect(digest.blind).toBeNull()
-    expect(digest.pickerDiscards).toBeNull()
+    expect(digest.pickerBuried).toBeNull()
     expect(digest.dealt['1']).toHaveLength(6)
     expect(digest.scores.find(s => s.userId === '4').scoreDelta).toBe(-4)
   })
@@ -128,6 +128,6 @@ describe('buildHandDigest — Leaster variant', () => {
     expect(digest.partner).toBeNull()
     expect(digest.calledCard).toBeNull()
     expect(digest.blind).toBeNull()
-    expect(digest.pickerDiscards).toBeNull()
+    expect(digest.pickerBuried).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- Rename the `discarding` phase to `burying` throughout the codebase (engine, actions, bot helpers, recap digest, frontend)
- Add **Bury** and **Blind** definitions to `docs/RULES.md` and `CLAUDE.md` Game Terminology
- Sync `docs/BOTS.md` terminology and verify it matches `botStrategy.js` / `botInference.js`

Closes #124.

No backward-compat shim — DB is still empty so action type `'discard'` is replaced outright by `'bury'`.

## Test plan
- [x] `npm test` — all 178 tests pass
- [x] `npm run build` — frontend builds clean
- [x] Manual: play a hand through picking → burying → calling in dev server to confirm UI copy ("Select 2 cards to bury", "Confirm Bury") and phase transitions

🤖 Generated with [Claude Code](https://claude.com/claude-code)