### PR TITLE
refactor: rename ace-unknown call to ace-under

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -46,7 +46,7 @@ The bot goes alone if it has **6 or more trump cards** AND **2 or more queens**.
 
 ### Ace Call (`callMode === 'ace'`)
 1. **Normal ace call**: Find suits where the bot does not hold or have buried the ace, and does hold at least one fail card of that suit. Among qualifying suits, pick the one with the fewest fail cards (most likely the opponent holds the ace). Call that suit's ace.
-2. **Ace-unknown call**: If no normal ace call is possible, look for suits where the bot holds neither the ace nor any fail cards of that suit. Pick an under card (cheapest non-trump; fall back to cheapest trump) and declare an ace-unknown call.
+2. **Ace-under call**: If no normal ace call is possible, look for suits where the bot holds neither the ace nor any fail cards of that suit. Pick an under card (cheapest non-trump; fall back to cheapest trump) and declare an ace-under call.
 3. **Fallback**: Go alone.
 
 ### Ten Call (`callMode === 'ten'`)

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -48,7 +48,7 @@ After burying, the picker calls a partner using one of three modes determined by
 The picker calls the Ace of a non-trump suit they neither hold nor buried.
 
 - *Normal call* — the picker holds at least one fail card of the called suit. The holder of the called Ace is the partner; the partner is revealed when the called suit is led and the partner plays the Ace.
-- *Unknown call* — the picker holds **no** fail card of the called suit (only available when no normal ace call exists). The picker places one card face-down from their hand as an **under card**. The picker must play the under card whenever the called suit is led; it is revealed only to the trick winner.
+- *Under call* — the picker holds **no** fail card of the called suit (only available when no normal ace call exists). The picker places one card face-down from their hand as an **under card**. The picker must play the under card whenever the called suit is led; it is revealed only to the trick winner.
 
 **Call Mode: Ten** (picker holds all 3 fail Aces)
 

--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -9,7 +9,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     : {}
   const turnLabel = actingForName ? `Acting for ${actingForName}` : 'Your turn'
   const [selectedBuried, setSelectedBuried] = useState([])
-  const [unknownSelectedSuit, setUnknownSelectedSuit] = useState(null)
+  const [underSelectedSuit, setUnderSelectedSuit] = useState(null)
   const [selectedUnderCard, setSelectedUnderCard] = useState(null)
   const [confirmingAlone, setConfirmingAlone] = useState(false)
   const [error, setError] = useState(null)
@@ -208,13 +208,13 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
     const isFailCard = (c, s) => c.suit === s && c.rank !== 'Q' && c.rank !== 'J'
     const candidateSuits = ['C', 'H', 'S'].filter(s => !heldIds.has(`A${s}`) && !buriedIds.has(`A${s}`))
     const normalSuits = candidateSuits.filter(s => myHand.some(c => isFailCard(c, s)))
-    const unknownSuits = candidateSuits.filter(s => !myHand.some(c => isFailCard(c, s)))
+    const underSuits = candidateSuits.filter(s => !myHand.some(c => isFailCard(c, s)))
 
-    if (unknownSelectedSuit) {
+    if (underSelectedSuit) {
       // Situation B: pick the under card from hand
       return (
         <div className="action-panel" style={botStyle}>
-          <h4>Place an under card for A{SUIT_SYMBOLS[unknownSelectedSuit]} Unknown</h4>
+          <h4>Place an under card for A{SUIT_SYMBOLS[underSelectedSuit]} Under</h4>
           <p style={{ fontSize: '0.85rem', color: '#ccc' }}>
             Choose any card to place face-down as the under card. It has no power; it must be played
             when the called suit is led.
@@ -228,14 +228,14 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
           <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 8 }}>
             <button
               disabled={!selectedUnderCard || loading}
-              onClick={() => act('call_ace_unknown', { suit: unknownSelectedSuit, underCardId: selectedUnderCard })
-                .then(() => { setUnknownSelectedSuit(null); setSelectedUnderCard(null) })}
+              onClick={() => act('call_ace_under', { suit: underSelectedSuit, underCardId: selectedUnderCard })
+                .then(() => { setUnderSelectedSuit(null); setSelectedUnderCard(null) })}
             >
               Confirm
             </button>
             <button
               className="secondary"
-              onClick={() => { setUnknownSelectedSuit(null); setSelectedUnderCard(null) }}
+              onClick={() => { setUnderSelectedSuit(null); setSelectedUnderCard(null) }}
               disabled={loading}
             >
               Back
@@ -264,19 +264,19 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
           ))}
         </div>
         {/* Under card calls are only allowed when there is no normal call available. */}
-        {normalSuits.length === 0 && unknownSuits.length > 0 && (
+        {normalSuits.length === 0 && underSuits.length > 0 && (
           <>
             <p style={{ fontSize: '0.8rem', color: '#ccc', marginTop: 8 }}>
-              You hold no fail card of any callable suit. Place an under card and call Unknown:
+              You hold no fail card of any callable suit. Place an under card and call Under:
             </p>
             <div className="suit-picker">
-              {unknownSuits.map(suit => (
+              {underSuits.map(suit => (
                 <button
                   key={suit}
                   className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
-                  onClick={() => setUnknownSelectedSuit(suit)}
+                  onClick={() => setUnderSelectedSuit(suit)}
                   disabled={loading}
-                  title={`Call A${suit} Unknown`}
+                  title={`Call A${suit} Under`}
                 >
                   A{SUIT_SYMBOLS[suit]}?
                 </button>
@@ -284,7 +284,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
             </div>
           </>
         )}
-        {normalSuits.length === 0 && unknownSuits.length === 0 && (
+        {normalSuits.length === 0 && underSuits.length === 0 && (
           <p style={{ color: '#f87171' }}>No valid suit to call. Contact the game admin.</p>
         )}
         {goAloneSection}

--- a/functions/api/_botHelpers.js
+++ b/functions/api/_botHelpers.js
@@ -4,7 +4,7 @@
 import {
   currentPicker, currentPlayer,
   pick, blitz, pass, bury,
-  callAce, callAceUnknown, callTen, callKing, goAlone,
+  callAce, callAceUnder, callTen, callKing, goAlone,
   playCard, crack, recrack,
   setupLeaster, awardLeasterBlind, resolveLeaster,
   resolveSchwanzer,
@@ -285,8 +285,8 @@ function applyBotDecision(state, userId, view) {
       switch (decision.type) {
         case 'ace':
           return { state: callAce(state, userId, decision.suit), actionType: 'call_ace', payload: { suit: decision.suit } }
-        case 'ace_unknown':
-          return { state: callAceUnknown(state, userId, decision.suit, decision.underCardId), actionType: 'call_ace_unknown', payload: { suit: decision.suit, underCardId: decision.underCardId } }
+        case 'ace_under':
+          return { state: callAceUnder(state, userId, decision.suit, decision.underCardId), actionType: 'call_ace_under', payload: { suit: decision.suit, underCardId: decision.underCardId } }
         case 'ten':
           return { state: callTen(state, userId, decision.suit), actionType: 'call_ten', payload: { suit: decision.suit } }
         case 'king':

--- a/functions/api/games/[id]/action.js
+++ b/functions/api/games/[id]/action.js
@@ -1,6 +1,6 @@
 import { json, err, requireUser, AuthError } from '../../_helpers.js'
 import {
-  pick, blitz, pass, bury, callAce, callAceUnknown, callTen, callKing, goAlone, playCard,
+  pick, blitz, pass, bury, callAce, callAceUnder, callTen, callKing, goAlone, playCard,
   crack, recrack,
   setupLeaster, awardLeasterBlind, resolveLeaster,
   resolveSchwanzer,
@@ -125,9 +125,9 @@ export async function onRequestPost({ request, env, params }) {
         await appendAction(env.DB, gameId, state.handNumber, 'call_ace', userId, { suit: payload?.suit })
         break
 
-      case 'call_ace_unknown':
-        state = callAceUnknown(state, userId, payload?.suit, payload?.underCardId)
-        await appendAction(env.DB, gameId, state.handNumber, 'call_ace_unknown', userId, { suit: payload?.suit, underCardId: payload?.underCardId })
+      case 'call_ace_under':
+        state = callAceUnder(state, userId, payload?.suit, payload?.underCardId)
+        await appendAction(env.DB, gameId, state.handNumber, 'call_ace_under', userId, { suit: payload?.suit, underCardId: payload?.underCardId })
         break
 
       case 'call_ten':

--- a/shared/actionReplay.js
+++ b/shared/actionReplay.js
@@ -1,6 +1,6 @@
 import {
   pick, blitz, pass, bury,
-  callAce, callAceUnknown, callTen, callKing, goAlone,
+  callAce, callAceUnder, callTen, callKing, goAlone,
   playCard, crack, recrack,
   setupLeaster, awardLeasterBlind,
 } from './gameEngine.js'
@@ -30,7 +30,7 @@ export function replayActions(actions) {
       case 'setup_leaster':    state = setupLeaster(state); break
       case 'bury':             state = bury(state, uid, payload.cardIds); break
       case 'call_ace':         state = callAce(state, uid, payload.suit); break
-      case 'call_ace_unknown': state = callAceUnknown(state, uid, payload.suit, payload.underCardId); break
+      case 'call_ace_under':   state = callAceUnder(state, uid, payload.suit, payload.underCardId); break
       case 'call_ten':         state = callTen(state, uid, payload.suit); break
       case 'call_king':        state = callKing(state, uid, payload.suit); break
       case 'go_alone':         state = goAlone(state, uid); break

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -184,21 +184,21 @@ export function decideCall(view, userId) {
       return { type: 'ace', suit: ranked[0].suit }
     }
 
-    // Try ace-unknown call: suits where picker doesn't hold/bury the ace and has NO fail cards
-    const unknownSuits = suits.filter(suit => {
+    // Try ace-under call: suits where picker doesn't hold/bury the ace and has NO fail cards
+    const underSuits = suits.filter(suit => {
       const aceId = `A${suit}`
       return !hand.some(c => c.id === aceId)
         && !buried.some(c => c.id === aceId)
         && !hand.some(c => c.suit === suit && !isTrump(c))
     })
 
-    if (unknownSuits.length > 0) {
-      const suit = unknownSuits[0]
+    if (underSuits.length > 0) {
+      const suit = underSuits[0]
       // Pick lowest-value non-trump card as under card; fall back to lowest trump
       const underCard =
         hand.filter(c => !isTrump(c)).sort((a, b) => cardPoints(a) - cardPoints(b))[0]
         ?? [...hand].sort((a, b) => cardPoints(a) - cardPoints(b))[0]
-      return { type: 'ace_unknown', suit, underCardId: underCard.id }
+      return { type: 'ace_under', suit, underCardId: underCard.id }
     }
 
     return { type: 'alone' }

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -111,7 +111,7 @@ export function dealHand(playerIds, dealerSeat, handNumber, doublerMultiplier) {
     pickIndex: 0,              // index into pickOrder of whose turn it is to pick/pass
     picker: null,              // userId of picker
     partner: null,             // userId of partner (set when ace is called)
-    calledAce: null,           // { suit, aceId, unknown? } — set for ace and ace-unknown calls
+    calledAce: null,           // { suit, aceId, under? } — set for ace and ace-under calls
     calledTen: null,           // { suit, tenId } — set when picker holds all 3 fail aces
     calledKing: null,          // { suit, kingId } — set when picker holds all 3 fail aces and tens
     calledSuit: null,          // 'C'|'H'|'S' — unifying field across all call types
@@ -267,10 +267,10 @@ export function callAce(state, userId, suit) {
   }
 
   // Picker must hold at least one fail card of the called suit (called-suit holding rule).
-  // If they don't, they must use call_ace_unknown with an under card instead.
+  // If they don't, they must use call_ace_under with an under card instead.
   const failOfSuit = state.hands[userId].filter(c => c.suit === suit && !isTrump(c))
   if (failOfSuit.length === 0) {
-    throw new Error(`Cannot call A${suit} normally — picker holds no fail card of that suit. Use call_ace_unknown.`)
+    throw new Error(`Cannot call A${suit} normally — picker holds no fail card of that suit. Use call_ace_under.`)
   }
 
   const newState = deepClone(state)
@@ -305,10 +305,10 @@ export function goAlone(state, userId) {
 
 // Situation B: picker calls an ace of a suit in which they hold no fail card,
 // placing one card from their hand face-down on the table as the "under card."
-export function callAceUnknown(state, userId, suit, underCardId) {
+export function callAceUnder(state, userId, suit, underCardId) {
   assertPhase(state, 'calling')
   if (state.picker !== userId) throw new Error('Only the picker calls the ace.')
-  if (state.callMode !== 'ace') throw new Error(`Picker must call a ${state.callMode}, not an unknown ace.`)
+  if (state.callMode !== 'ace') throw new Error(`Picker must call a ${state.callMode}, not an under ace.`)
   if (!['C', 'H', 'S'].includes(suit)) throw new Error('Must call a non-trump suit ace.')
 
   const aceId = `A${suit}`
@@ -321,7 +321,7 @@ export function callAceUnknown(state, userId, suit, underCardId) {
 
   const failOfSuit = state.hands[userId].filter(c => c.suit === suit && !isTrump(c))
   if (failOfSuit.length > 0) {
-    throw new Error(`Cannot call A${suit} unknown — picker holds fail card(s) of that suit. Use call_ace.`)
+    throw new Error(`Cannot call A${suit} under — picker holds fail card(s) of that suit. Use call_ace.`)
   }
 
   // Under card calls are only legal when the picker has no normal call available.
@@ -334,7 +334,7 @@ export function callAceUnknown(state, userId, suit, underCardId) {
     return state.hands[userId].some(c => c.suit === s && !isTrump(c))
   })
   if (hasNormalCall) {
-    throw new Error('Cannot call an unknown ace when a normal ace call is available.')
+    throw new Error('Cannot call an under ace when a normal ace call is available.')
   }
 
   const cardIdx = state.hands[userId].findIndex(c => c.id === underCardId)
@@ -343,12 +343,12 @@ export function callAceUnknown(state, userId, suit, underCardId) {
   const newState = deepClone(state)
   const card = newState.hands[userId].splice(cardIdx, 1)[0]
   newState.underCard = { id: card.id, suit: card.suit, rank: card.rank, ownerId: userId, played: false }
-  newState.calledAce = { suit, aceId, unknown: true }
+  newState.calledAce = { suit, aceId, under: true }
   newState.calledSuit = suit
   newState.partner = findHolder(newState.hands, aceId, userId)
   newState.phase = 'playing'
   newState.currentLeader = newState.pickOrder[0]
-  newState.log.push(`${userId} called A${suit} Unknown and placed an under card.`)
+  newState.log.push(`${userId} called A${suit} Under and placed an under card.`)
   return newState
 }
 

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -5,7 +5,7 @@ import {
   schwanzerCardPoints, resolveSchwanzer,
   dealHand, pick, pass, blitz,
   bury, callAce, goAlone, callTen, callKing,
-  callAceUnknown, crack, recrack,
+  callAceUnder, crack, recrack,
   playCard, computeScores, resolveLeaster,
   setupLeaster, awardLeasterBlind, getPlayerView,
 } from './gameEngine.js'
@@ -1110,8 +1110,8 @@ describe('resolveLeaster', () => {
   })
 })
 
-describe('callAceUnknown', () => {
-  function makeUnknownCallingState() {
+describe('callAceUnder', () => {
+  function makeUnderCallingState() {
     return {
       phase: 'calling',
       picker: 'p1',
@@ -1131,19 +1131,19 @@ describe('callAceUnknown', () => {
     }
   }
 
-  it('sets underCard, calledAce (unknown:true), partner, and advances to playing', () => {
-    const next = callAceUnknown(makeUnknownCallingState(), 'p1', 'C', 'QS')
+  it('sets underCard, calledAce (under:true), partner, and advances to playing', () => {
+    const next = callAceUnder(makeUnderCallingState(), 'p1', 'C', 'QS')
     expect(next.phase).toBe('playing')
     expect(next.underCard).toMatchObject({ id: 'QS', ownerId: 'p1', played: false })
-    expect(next.calledAce).toEqual({ suit: 'C', aceId: 'AC', unknown: true })
+    expect(next.calledAce).toEqual({ suit: 'C', aceId: 'AC', under: true })
     expect(next.partner).toBe('p2')
   })
 
   it('throws when a normal ace call is available for another suit', () => {
-    const state = makeUnknownCallingState()
+    const state = makeUnderCallingState()
     // Add a fail heart (KH) — p1 doesn't hold AH, AH not buried → normal call available for H
     state.hands.p1 = [c('Q','C'), c('Q','S'), c('Q','H'), c('Q','D'), c('J','C'), c('K','H')]
-    expect(() => callAceUnknown(state, 'p1', 'C', 'QS')).toThrow('normal ace call is available')
+    expect(() => callAceUnder(state, 'p1', 'C', 'QS')).toThrow('normal ace call is available')
   })
 })
 


### PR DESCRIPTION
## Summary
- Closes #42. Renames the "unknown" terminology for the no-fail-card ace call to "under" across the codebase, so the call matches the physical "under card" it produces.
- Covers engine (`callAceUnknown` → `callAceUnder`), action-type string (`call_ace_unknown` → `call_ace_under`), bot decision type, `calledAce.unknown` → `calledAce.under` flag, UI strings in `ActionPanel.jsx`, and `docs/RULES.md` + `docs/BOTS.md`.
- No DB migration — table is empty. Generic `"unknown action type"` error paths and `"partner is unknown"` (meaning unrevealed) are left alone.

## Test plan
- [x] Full vitest suite passes (178/178)
- [ ] Manual: pick a hand with no fail cards of any callable suit, confirm the "Call Under" flow works end-to-end and the log reads "… called A♣ Under …"
- [ ] Manual: verify bot picks an under call when its hand requires one