### PR TITLE
feat: enforce picker called-suit holding rule

### DIFF
--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -68,7 +68,7 @@ The player left of the dealer leads the first trick. Players must follow suit if
 
 **Partner reveal** — the partner is identified to all players the moment they play the called card (Ace, Ten, or King) in response to the called suit being led.
 
-**Partner restrictions before reveal:**
+**Partner restrictions before the called suit has been led:**
 - The partner may not lead the called suit unless they lead with the called card.
 - The partner must play the called card when the called suit is led and they hold it.
 - The called card may not be played by the partner in any other situation (unless it is their last card).

--- a/docs/RULES.md
+++ b/docs/RULES.md
@@ -73,6 +73,11 @@ The player left of the dealer leads the first trick. Players must follow suit if
 - The partner must play the called card when the called suit is led and they hold it.
 - The called card may not be played by the partner in any other situation (unless it is their last card).
 
+**Picker restrictions before the called suit is led:**
+- The picker must keep at least one card of the called suit in hand to play when the called suit is led. They may sluff other fail cards of the called suit on off-suit tricks, but they may not empty their called-suit holding.
+- In a Ten or King call, every card listed as a forced play (the Ace for a Ten call; the Ace and Ten for a King call) must likewise be held until the called suit is led.
+- If the called suit is never led, the reserved called-suit card(s) are played on the final trick of the hand.
+
 **Under card rules:**
 - The under card has no trick-taking power (it cannot win a trick).
 - The picker must play the under card when the called suit is led.

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -107,13 +107,35 @@ function getLegalCardIds(state, userId, hand) {
 
   // Called card cannot be played unless the called suit is led
   // (except when it's the player's only remaining card)
-  const playableCards = (
+  let playableCards = (
     calledCardId &&
     ledSuit !== calledSuit &&
     handCards.some(c => c.id !== calledCardId)
   )
     ? handCards.filter(c => c.id !== calledCardId)
     : handCards
+
+  // Picker called-suit holding rule: must keep ≥1 called-suit card (plus any
+  // pickerForcedPlays) in hand until the called suit is led.
+  if (
+    userId === picker &&
+    calledSuit &&
+    !partnerRevealed &&
+    ledSuit !== calledSuit &&
+    playableCards.length > 1
+  ) {
+    const filtered = playableCards.filter(card => {
+      if (pickerForcedPlays.includes(card.id)) return false
+      if (effectiveSuit(card) === calledSuit) {
+        const remaining = playableCards.filter(
+          c => c.id !== card.id && effectiveSuit(c) === calledSuit
+        ).length
+        if (remaining === 0) return false
+      }
+      return true
+    })
+    if (filtered.length > 0) playableCards = filtered
+  }
 
   const hasSuit = playableCards.some(c => effectiveSuit(c) === ledSuit)
   return hasSuit

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -57,13 +57,36 @@ function getLegalCards(state, userId) {
   }
 
   // Called card cannot be played unless the called suit is led (mirrors gameEngine restriction)
-  const playableCards = (
+  let playableCards = (
     calledCardId &&
     ledSuit !== calledSuit &&
     handCards.some(c => c.id !== calledCardId)
   )
     ? handCards.filter(c => c.id !== calledCardId)
     : handCards
+
+  // Picker called-suit holding rule: until the called suit is led, the picker
+  // must keep ≥1 card of the called suit in hand (plus any pickerForcedPlays
+  // cards in ten/king calls). Mirrors gameEngine validatePlay.
+  if (
+    userId === picker &&
+    calledSuit &&
+    !partnerRevealed &&
+    ledSuit !== calledSuit &&
+    playableCards.length > 1
+  ) {
+    const filtered = playableCards.filter(card => {
+      if (pickerForcedPlays.includes(card.id)) return false
+      if (effectiveSuit(card) === calledSuit) {
+        const remaining = playableCards.filter(
+          c => c.id !== card.id && effectiveSuit(c) === calledSuit
+        ).length
+        if (remaining === 0) return false
+      }
+      return true
+    })
+    if (filtered.length > 0) playableCards = filtered
+  }
 
   const hasSuit = playableCards.some(c => effectiveSuit(c) === ledSuit)
   return hasSuit

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -635,6 +635,39 @@ function validatePlay(state, userId, card) {
       )
     }
   }
+
+  // Picker called-suit holding rule: until the called suit is led (signalled by
+  // partnerRevealed, which flips the moment the partner plays the called card),
+  // the picker must keep at least one card of the called suit in hand for the
+  // eventual called-suit trick. In ten/king calls, each forced-play card is a
+  // required hold. Only lifts on the last trick when no alternative card exists.
+  if (
+    userId === state.picker &&
+    state.calledSuit &&
+    !state.partnerRevealed &&
+    ledSuit !== state.calledSuit
+  ) {
+    const alternatives = hand.filter(c => c.id !== card.id)
+    const isForcedPlay = (state.pickerForcedPlays ?? []).includes(card.id)
+    const isCalledSuitFail = effectiveSuit(card) === state.calledSuit
+    if (alternatives.length > 0) {
+      if (isForcedPlay) {
+        throw new Error(
+          `Picker must keep ${card.id} for when the called suit is led.`
+        )
+      }
+      if (isCalledSuitFail) {
+        const remainingCalledSuit = alternatives.filter(
+          c => effectiveSuit(c) === state.calledSuit
+        ).length
+        if (remainingCalledSuit === 0) {
+          throw new Error(
+            `Picker must keep a card of the called suit (${state.calledSuit}) until it is led.`
+          )
+        }
+      }
+    }
+  }
 }
 
 // Validate that the picker is allowed to play the under card right now.

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -794,6 +794,133 @@ describe('playCard', () => {
   })
 })
 
+describe('picker called-suit holding rule', () => {
+  // p1 is picker, called AC (clubs). Trick is led with fail spades; p1 is void in
+  // spades and is deciding what to sluff. Partner not yet revealed.
+  function makePickerSluffingState(pickerHand) {
+    return {
+      phase: 'playing',
+      picker: 'p1',
+      partner: 'p2',
+      goingAlone: false,
+      calledAce: { suit: 'C', aceId: 'AC' },
+      calledSuit: 'C',
+      calledTen: null,
+      calledKing: null,
+      partnerRevealed: false,
+      pickerForcedPlays: [],
+      underCard: null,
+      pickOrder: ['p3', 'p1', 'p2', 'p4', 'p5'],
+      doublerMultiplier: 1,
+      handCrackMultiplier: 1,
+      blitzes: [],
+      buried: [],
+      tricks: [],
+      currentTrick: [
+        { userId: 'p3', card: c('8', 'S') }, // fail-spade lead
+      ],
+      currentLeader: 'p3',
+      log: [],
+      scores: {},
+      hands: {
+        p1: pickerHand,
+        p2: [c('A', 'C')],
+        p3: [],
+        p4: [c('K', 'S')],
+        p5: [c('9', 'S')],
+      },
+    }
+  }
+
+  it('rejects picker sluffing their last fail card of the called suit', () => {
+    // p1 (picker) holds a single called-suit card (8C) plus trump/other-suit
+    // cards; sluffing 8C would leave them with zero clubs.
+    const state = makePickerSluffingState([
+      c('8', 'C'),
+      c('10', 'D'), // trump
+      c('9', 'D'),  // trump
+    ])
+    expect(() => playCard(state, 'p1', '8C')).toThrow(/called suit/)
+  })
+
+  it('allows picker to sluff a fail card of the called suit if another remains', () => {
+    // p1 holds two clubs (8C, 9C); sluffing 9C still leaves 8C in hand.
+    const state = makePickerSluffingState([
+      c('8', 'C'),
+      c('9', 'C'),
+      c('10', 'D'),
+    ])
+    expect(() => playCard(state, 'p1', '9C')).not.toThrow()
+  })
+
+  it('allows picker to play their last called-suit card when the called suit is led', () => {
+    const state = {
+      ...makePickerSluffingState([c('8', 'C'), c('10', 'D')]),
+      currentTrick: [{ userId: 'p3', card: c('7', 'C') }], // clubs led
+      currentLeader: 'p3',
+    }
+    expect(() => playCard(state, 'p1', '8C')).not.toThrow()
+  })
+
+  it('allows picker to play their last called-suit card after partner has been revealed', () => {
+    const state = {
+      ...makePickerSluffingState([c('8', 'C'), c('10', 'D')]),
+      partnerRevealed: true,
+    }
+    expect(() => playCard(state, 'p1', '8C')).not.toThrow()
+  })
+
+  it('allows picker to play their last called-suit card on the last trick (no alternative)', () => {
+    // Hand has only the club; picker must play it regardless.
+    const state = makePickerSluffingState([c('8', 'C')])
+    expect(() => playCard(state, 'p1', '8C')).not.toThrow()
+  })
+
+  it('does not restrict non-picker players from sluffing called-suit cards', () => {
+    // p4 is an opponent with a single 8C plus KS; sluffing 8C is fine.
+    const state = {
+      ...makePickerSluffingState([c('Q', 'C')]),
+      currentTrick: [
+        { userId: 'p3', card: c('10', 'S') },
+        { userId: 'p1', card: c('Q', 'C') }, // picker plays trump
+        { userId: 'p2', card: c('K', 'S') },
+      ],
+      currentLeader: 'p3',
+      hands: {
+        p1: [],
+        p2: [],
+        p3: [],
+        p4: [c('8', 'C'), c('J', 'H')],
+        p5: [c('9', 'S')],
+      },
+    }
+    expect(() => playCard(state, 'p4', '8C')).not.toThrow()
+  })
+
+  it('does not apply when the picker went alone (no called suit)', () => {
+    const state = {
+      ...makePickerSluffingState([c('8', 'C'), c('10', 'D')]),
+      goingAlone: true,
+      partner: null,
+      calledAce: null,
+      calledSuit: null,
+    }
+    expect(() => playCard(state, 'p1', '8C')).not.toThrow()
+  })
+
+  it('rejects picker sluffing the forced ace in a ten call', () => {
+    // Ten-call: picker holds all three fail aces; the ace of called suit is
+    // listed in pickerForcedPlays and must be kept for the called-suit trick.
+    const state = {
+      ...makePickerSluffingState([c('A', 'C'), c('10', 'D'), c('9', 'D')]),
+      calledAce: null,
+      calledTen: { suit: 'C', tenId: '10C' },
+      pickerForcedPlays: ['AC'],
+    }
+    expect(() => playCard(state, 'p1', 'AC')).toThrow(/called suit/)
+  })
+})
+
 describe('computeScores', () => {
   // Create a fake card with a specific point rank (suit doesn't affect scoring)
   let fakeId = 0


### PR DESCRIPTION
## Summary

- Enforces the picker-side holding rule: the picker must keep at least one card of the called suit in hand until the called suit is led (on the last trick, when there's no alternative, the card is simply played). In Ten/King calls, each `pickerForcedPlays` card is similarly reserved.
- Mirrors the rule across `shared/gameEngine.js` (`validatePlay`), `shared/botStrategy.js` (`getLegalCards`), and `frontend/src/pages/GamePage.jsx` (`getLegalCardIds`).
- Documents the rule in `docs/RULES.md` and tightens the neighboring partner-restrictions section title for clarity.

This fixes a real misplay observed in game 1 / hand 1 of local play: Oliver (picker, called AC) sluffed his only club on an off-suit trick, leaving no called-suit card for the partner-reveal trick.

## Test plan

- [x] 8 new unit tests in `shared/gameEngine.test.js` covering: single-club sluff rejected; sluff allowed with ≥2 clubs; allowed when called suit led; allowed after partner reveal; allowed on last trick / no alternative; doesn't affect non-picker players; doesn't apply when going alone; Ten-call forced-ace hold enforced.
- [x] Full suite: 186/186 passing.
- [ ] Exercise a local game where the picker holds a single fail card of the called suit and verify neither the bot nor the human UI offers it as a legal sluff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)