### PR TITLE
Show game settings to all players + log admin changes (closes #114)

### DIFF
--- a/docs/superpowers/plans/2026-04-18-game-mode-visibility.md
+++ b/docs/superpowers/plans/2026-04-18-game-mode-visibility.md
@@ -1,0 +1,822 @@
+# Game Mode Visibility & Change Logging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display the current game settings to non-admin players in the same places admins see them, and log admin settings changes as a single `Next Hand: …` line in the play history when the admin presses Done.
+
+**Architecture:** A shared `formatSettingsSummary(settings)` helper in `shared/` is the single source of truth for the summary body string, imported by both server and frontend. The existing `PATCH /api/games/:id/settings` endpoint gains an optional `log_change: true` flag — when present and the game is active, the server appends `Next Hand: <summary>` to `state.log` after persisting settings. The `GameOptionsPanel` update mode is reworked from per-toggle auto-save to deferred-save: local state until the admin presses Done (commits via one batched PATCH) or Escape/backdrop (cancels and discards).
+
+**Tech Stack:** React 18 + Vite (frontend), Cloudflare Pages Functions (backend, plain JS), D1 (SQLite) via `env.DB`, Vitest for unit tests, `shared/` modules consumed by both sides.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-game-mode-visibility-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+
+- `shared/settingsSummary.js` — Pure function `formatSettingsSummary(settings)` returning the summary body string.
+- `shared/settingsSummary.test.js` — Vitest unit tests for the formatter.
+- `frontend/src/components/SettingsSummary.jsx` — Small presentational component rendering `formatSettingsSummary(settings)` output. No edit button; caller decides layout.
+
+**Modify:**
+
+- `functions/api/games/[id]/settings.js` — Validate optional `log_change: boolean`; after persisting settings, if `log_change === true` and a `game_state` row exists, append `Next Hand: <summary>` to `state.log` and write back.
+- `frontend/src/components/GameOptionsPanel.jsx` — Rework `update` mode to deferred save. Remove per-toggle auto-save. Add commit-on-Done / cancel-on-close (Escape/backdrop). Remove per-control Saving/Saved UI; add single save state on Done. No change to `create` mode.
+- `frontend/src/pages/GamePage.jsx` — Replace the two inline admin summary blocks with `<SettingsSummary>`. Render it for non-admin players in both the waiting screen and the active-play right panel. Remove the old non-admin `No-pick variant: …` line.
+
+**Do not touch:**
+
+- `shared/gameEngine.js` — no rule changes.
+- `docs/RULES.md` / `docs/BOTS.md` — no rule or bot changes.
+
+---
+
+## Summary Format Reference
+
+`formatSettingsSummary(settings)` returns the body string with every setting always rendered:
+
+| Input | Output |
+|---|---|
+| `{ no_pick_variant: 'leasters', reveal_partner: true,  double_on_bump: true  }` | `Leasters · Partner: shown · DOB: on` |
+| `{ no_pick_variant: 'doublers', reveal_partner: false, double_on_bump: false }` | `Doublers · Partner: hidden · DOB: off` |
+| `{ no_pick_variant: 'schwanzers', reveal_partner: true, double_on_bump: false }` | `Schwanzers · Partner: shown · DOB: off` |
+
+The log line prepends `Next Hand: ` to this body. The on-screen summary renders the body verbatim.
+
+**Note on DOB display:** Today's admin UI hides DOB when off. The new shared formatter always renders DOB state (`on`/`off`). This is an intentional alignment with the spec's requirement that every setting is listed whether or not it changed. After Task 3 the admin on-screen summary will show `DOB: off` instead of hiding it, matching the log line.
+
+---
+
+## Task 1: Shared settings summary formatter + tests
+
+**Files:**
+- Create: `shared/settingsSummary.js`
+- Create: `shared/settingsSummary.test.js`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `shared/settingsSummary.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { formatSettingsSummary } from './settingsSummary.js'
+
+describe('formatSettingsSummary', () => {
+  it('renders leasters, partner shown, DOB on', () => {
+    expect(formatSettingsSummary({
+      no_pick_variant: 'leasters',
+      reveal_partner: true,
+      double_on_bump: true,
+    })).toBe('Leasters · Partner: shown · DOB: on')
+  })
+
+  it('renders doublers, partner hidden, DOB off', () => {
+    expect(formatSettingsSummary({
+      no_pick_variant: 'doublers',
+      reveal_partner: false,
+      double_on_bump: false,
+    })).toBe('Doublers · Partner: hidden · DOB: off')
+  })
+
+  it('renders schwanzers, partner shown, DOB off', () => {
+    expect(formatSettingsSummary({
+      no_pick_variant: 'schwanzers',
+      reveal_partner: true,
+      double_on_bump: false,
+    })).toBe('Schwanzers · Partner: shown · DOB: off')
+  })
+
+  it('always shows DOB state (not conditional)', () => {
+    const off = formatSettingsSummary({
+      no_pick_variant: 'leasters',
+      reveal_partner: true,
+      double_on_bump: false,
+    })
+    expect(off).toContain('DOB: off')
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run shared/settingsSummary.test.js`
+Expected: FAIL — `Failed to resolve import "./settingsSummary.js"` (module does not exist).
+
+- [ ] **Step 3: Create `shared/settingsSummary.js`**
+
+```js
+const VARIANT_LABELS = {
+  leasters: 'Leasters',
+  doublers: 'Doublers',
+  schwanzers: 'Schwanzers',
+}
+
+/**
+ * Returns a single-line summary of the game settings, used both in the
+ * play-history log line and as the on-screen settings summary. Every
+ * setting is always rendered — callers rely on the body being a full
+ * snapshot, not a diff.
+ *
+ * Example: "Leasters · Partner: shown · DOB: on"
+ */
+export function formatSettingsSummary(settings) {
+  const variant = VARIANT_LABELS[settings.no_pick_variant] ?? settings.no_pick_variant
+  const partner = settings.reveal_partner ? 'shown' : 'hidden'
+  const dob = settings.double_on_bump ? 'on' : 'off'
+  return `${variant} · Partner: ${partner} · DOB: ${dob}`
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run shared/settingsSummary.test.js`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/settingsSummary.js shared/settingsSummary.test.js
+git commit -m "feat(shared): add formatSettingsSummary helper"
+```
+
+---
+
+## Task 2: Server endpoint — accept `log_change` and append log line
+
+**Files:**
+- Modify: `functions/api/games/[id]/settings.js`
+
+- [ ] **Step 1: Read the current endpoint**
+
+Open `functions/api/games/[id]/settings.js` to confirm existing structure (validators for `no_pick_variant`, `reveal_partner`, `double_on_bump`; `json_set` update; re-read of `settings_json`).
+
+- [ ] **Step 2: Update imports and validation**
+
+At the top of `functions/api/games/[id]/settings.js`, add the formatter import below the existing helpers import:
+
+```js
+import { json, err, requireUser, AuthError } from '../../_helpers.js'
+import { formatSettingsSummary } from '../../../../shared/settingsSummary.js'
+```
+
+In the validation block (around line 17-27), add a validator for `log_change`. Change:
+
+```js
+const { no_pick_variant, reveal_partner, double_on_bump } = body ?? {}
+```
+
+to:
+
+```js
+const { no_pick_variant, reveal_partner, double_on_bump, log_change } = body ?? {}
+```
+
+Add after the `double_on_bump` validator:
+
+```js
+if (log_change !== undefined && typeof log_change !== 'boolean') {
+  return err('log_change must be a boolean.')
+}
+```
+
+- [ ] **Step 3: Relax the "no settings to update" guard**
+
+The current endpoint errors with `No settings to update.` when no setting fields are provided. This must change so a caller may send `{ log_change: true }` with no setting fields (supports mobile clients and matches the spec's noted shape). Replace:
+
+```js
+if (bindings.length === 0) return err('No settings to update.')
+
+bindings.push(gameId)
+await env.DB.prepare(
+  `UPDATE games SET settings_json = ${jsonSetExpr}, updated_at = datetime('now') WHERE id = ?`
+).bind(...bindings).run()
+```
+
+with:
+
+```js
+if (bindings.length === 0 && log_change !== true) {
+  return err('No settings to update.')
+}
+
+if (bindings.length > 0) {
+  bindings.push(gameId)
+  await env.DB.prepare(
+    `UPDATE games SET settings_json = ${jsonSetExpr}, updated_at = datetime('now') WHERE id = ?`
+  ).bind(...bindings).run()
+}
+```
+
+- [ ] **Step 4: Append log line when `log_change` is true**
+
+After the existing re-read block (which computes `settings`) and before `return json({ ok: true, settings })`, add:
+
+```js
+if (log_change === true) {
+  const stateRow = await env.DB.prepare(
+    'SELECT state_json FROM game_state WHERE game_id = ?'
+  ).bind(gameId).first()
+  if (stateRow) {
+    const state = JSON.parse(stateRow.state_json)
+    const line = `Next Hand: ${formatSettingsSummary(settings)}`
+    state.log = [...(state.log ?? []), line]
+    await env.DB.prepare(
+      "UPDATE game_state SET state_json = ?, updated_at = datetime('now') WHERE game_id = ?"
+    ).bind(JSON.stringify(state), gameId).run()
+  }
+}
+```
+
+Rationale: the `stateRow` null-check naturally covers waiting-status games (no `game_state` row yet). Game status `'complete'` is already rejected earlier in the handler (line 11). Only active games with a live game_state receive the log line.
+
+- [ ] **Step 5: Sanity-check by reading the full file**
+
+Read `functions/api/games/[id]/settings.js` top-to-bottom and confirm: imports present, validator added, guard relaxed, log-append block inserted in the right place (after `settings` is computed, before the JSON response).
+
+- [ ] **Step 6: Run the full test suite to confirm nothing broke**
+
+Run: `npm test`
+Expected: All existing tests pass. (There are no integration tests for the settings endpoint in this codebase; manual verification covers the endpoint in Task 5.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add functions/api/games/\[id\]/settings.js
+git commit -m "feat(api): PATCH settings accepts log_change flag and appends Next Hand log line"
+```
+
+---
+
+## Task 3: Extract `<SettingsSummary>` and render for all players
+
+**Files:**
+- Create: `frontend/src/components/SettingsSummary.jsx`
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Create `<SettingsSummary>` component**
+
+Create `frontend/src/components/SettingsSummary.jsx`:
+
+```jsx
+import { formatSettingsSummary } from '@shared/settingsSummary.js'
+
+/**
+ * Renders the single-line settings summary body. Plain span — the
+ * caller controls surrounding layout, labels, and any adjacent
+ * controls (e.g. the admin Edit button).
+ */
+export default function SettingsSummary({ settings, style }) {
+  if (!settings) return null
+  return (
+    <span style={style}>{formatSettingsSummary(settings)}</span>
+  )
+}
+```
+
+(Uses the existing `@shared` Vite alias from `frontend/vite.config.js`.)
+
+- [ ] **Step 2: Update `GamePage.jsx` imports**
+
+At the top of `frontend/src/pages/GamePage.jsx`, add:
+
+```jsx
+import SettingsSummary from '../components/SettingsSummary.jsx'
+```
+
+You may also remove `const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }` if no other reference to `VARIANT_LABELS` remains after this task. Search the file first: `VARIANT_LABELS` — if the only references are in the summary blocks you're replacing and the non-admin `No-pick variant: …` line, remove the constant. Otherwise leave it.
+
+- [ ] **Step 3: Build a small `currentSettings` helper inside `GamePage.jsx`**
+
+The file currently spreads settings across props + local state (`currentVariant`, `revealPartner`, `dobEnabled`, `noPickVariant`, `gameData.settings`). Add a single derived object inside the component, near the other derived values (e.g. next to where `noPickVariant` is computed):
+
+```jsx
+const currentSettings = {
+  no_pick_variant: currentVariant ?? noPickVariant,
+  reveal_partner:  revealPartner  ?? gameData.settings?.reveal_partner  ?? true,
+  double_on_bump:  dobEnabled     ?? gameData.settings?.double_on_bump  ?? true,
+}
+```
+
+This is used by both the admin and non-admin renders below.
+
+- [ ] **Step 4: Replace the waiting-screen admin summary (line ~426)**
+
+Locate the `isGameAdmin ?` waiting-screen block. Replace:
+
+```jsx
+<span style={{ color: '#ccc', fontSize: '0.85rem' }}>
+  {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+  Partner: {(revealPartner ?? gameData.settings?.reveal_partner ?? true) ? 'shown' : 'hidden'}
+  {(dobEnabled ?? gameData.settings?.double_on_bump ?? true) ? ' · DOB' : ''}
+</span>
+```
+
+with:
+
+```jsx
+<SettingsSummary
+  settings={currentSettings}
+  style={{ color: '#ccc', fontSize: '0.85rem' }}
+/>
+```
+
+- [ ] **Step 5: Replace the waiting-screen non-admin line (line ~450)**
+
+Replace:
+
+```jsx
+<p style={{ color: '#aaa', fontSize: '0.85rem', marginTop: 8 }}>
+  No-pick variant: <strong>{VARIANT_LABELS[noPickVariant]}</strong>
+</p>
+```
+
+with:
+
+```jsx
+<div style={{ marginTop: 8 }}>
+  <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
+  <SettingsSummary
+    settings={currentSettings}
+    style={{ color: '#aaa', fontSize: '0.85rem' }}
+  />
+</div>
+```
+
+This matches the label (`Game options`) the admin view uses, so both player types see a consistent layout.
+
+- [ ] **Step 6: Replace the active-play admin summary (line ~622)**
+
+In the `last-trick-area` block, replace:
+
+```jsx
+<span style={{ color: '#aaa', fontSize: '0.78rem' }}>
+  {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
+  Partner: {(revealPartner ?? gameData.settings?.reveal_partner ?? true) ? 'shown' : 'hidden'}
+  {(dobEnabled ?? gameData.settings?.double_on_bump ?? true) ? ' · DOB' : ''}
+</span>
+```
+
+with:
+
+```jsx
+<SettingsSummary
+  settings={currentSettings}
+  style={{ color: '#aaa', fontSize: '0.78rem' }}
+/>
+```
+
+- [ ] **Step 7: Add non-admin summary to the active-play right panel**
+
+In the same `last-trick-area` block, the `{isGameAdmin && ( … )}` wrapper currently hides the entire summary section from non-admins. Replace the admin-only block with an if/else that renders either the admin version (summary + Edit button + modal) or the non-admin version (summary only):
+
+Find this section:
+
+```jsx
+{isGameAdmin && (
+  <div style={{ width: '100%', borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 8 }}>
+    <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
+    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+      <SettingsSummary
+        settings={currentSettings}
+        style={{ color: '#aaa', fontSize: '0.78rem' }}
+      />
+      <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+        onClick={() => setShowOptions(true)}>
+        ⚙ Edit
+      </button>
+    </div>
+    <GameOptionsPanel
+      mode="update"
+      gameId={gameId}
+      open={showOptions}
+      values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.settings?.reveal_partner ?? true, double_on_bump: dobEnabled ?? gameData.settings?.double_on_bump ?? true }}
+      onUpdated={handleSettingsUpdate}
+      onClose={() => setShowOptions(false)}
+    />
+  </div>
+)}
+```
+
+And replace with:
+
+```jsx
+<div style={{ width: '100%', borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 8 }}>
+  <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
+  {isGameAdmin ? (
+    <>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <SettingsSummary
+          settings={currentSettings}
+          style={{ color: '#aaa', fontSize: '0.78rem' }}
+        />
+        <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+          onClick={() => setShowOptions(true)}>
+          ⚙ Edit
+        </button>
+      </div>
+      <GameOptionsPanel
+        mode="update"
+        gameId={gameId}
+        open={showOptions}
+        values={currentSettings}
+        onUpdated={handleSettingsUpdate}
+        onClose={() => setShowOptions(false)}
+      />
+    </>
+  ) : (
+    <SettingsSummary
+      settings={currentSettings}
+      style={{ color: '#aaa', fontSize: '0.78rem' }}
+    />
+  )}
+</div>
+```
+
+Note: this also switches the `values` prop of the existing admin `GameOptionsPanel` to use `currentSettings` — a readability cleanup that doesn't change behavior.
+
+- [ ] **Step 8: Do the same `values` prop cleanup on the waiting-screen GameOptionsPanel**
+
+Find the waiting-screen `<GameOptionsPanel … />` (around line 439-446) and change:
+
+```jsx
+values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.settings?.reveal_partner ?? true, double_on_bump: dobEnabled ?? gameData.settings?.double_on_bump ?? true }}
+```
+
+to:
+
+```jsx
+values={currentSettings}
+```
+
+- [ ] **Step 9: Start the dev server and verify visually**
+
+Run: `npm run dev`
+
+Navigate to a game in two browser tabs (one admin, one non-admin). Confirm:
+- Waiting screen: both users see the same `<variant> · Partner: <shown|hidden> · DOB: <on|off>` line. Admin has the Edit button; non-admin does not.
+- Active play: both users see the same summary in the last-trick-area right panel. Admin has the Edit button; non-admin does not.
+
+If something is off, adjust styling/layout inline, then recheck.
+
+Stop the dev server when finished.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/components/SettingsSummary.jsx frontend/src/pages/GamePage.jsx
+git commit -m "feat(ui): show settings summary to non-admin players via shared SettingsSummary"
+```
+
+---
+
+## Task 4: Rework `GameOptionsPanel` update mode to deferred save
+
+**Files:**
+- Modify: `frontend/src/components/GameOptionsPanel.jsx`
+
+- [ ] **Step 1: Read the current file**
+
+Open `frontend/src/components/GameOptionsPanel.jsx`. Current behavior: `update` mode calls `save(patch)` on every toggle, which does `api.games.updateSettings(gameId, patch)` and sets Saving/Saved flags. `create` mode uses `onChange` only — do NOT change `create`.
+
+- [ ] **Step 2: Replace the component body**
+
+Replace the entire contents of `frontend/src/components/GameOptionsPanel.jsx` with the following. Rationale: the changes touch nearly every part of the component (state, handlers, close path, render); an inline rewrite is cleaner than a sequence of edits.
+
+```jsx
+import { useState, useEffect, useRef } from 'react'
+import { api } from '../lib/api.js'
+
+const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
+
+/**
+ * Reusable game options modal.
+ *
+ * mode="create"  — no API calls; calls onChange({ no_pick_variant, reveal_partner, double_on_bump }) on each change.
+ * mode="update"  — deferred save: local state only until the admin presses Done, which sends
+ *                  one PATCH carrying the changed fields plus log_change: true. Escape or
+ *                  backdrop click cancels and discards local edits.
+ *
+ * The parent controls open/close via the `open` prop and `onClose` callback.
+ */
+export default function GameOptionsPanel({ mode, gameId, open, values, onChange, onUpdated, onClose }) {
+  const dialogRef = useRef(null)
+  // True when the in-flight close was initiated by the Done button. Lets us
+  // distinguish a commit (Done) from a cancel (Escape/backdrop), since the
+  // native <dialog> onClose event fires for both.
+  const committedRef = useRef(false)
+  // Snapshot of the settings at the moment the modal opened. Used in update
+  // mode to decide which fields actually changed when Done is pressed.
+  const initialRef = useRef(null)
+
+  const [variant, setVariant] = useState(values?.no_pick_variant ?? 'doublers')
+  const [reveal,  setReveal]  = useState(values?.reveal_partner  ?? false)
+  const [dob,     setDob]     = useState(values?.double_on_bump  ?? true)
+  const [saving,  setSaving]  = useState(false)
+  const [error,   setError]   = useState(null)
+
+  // Re-sync form from parent values each time the panel opens, and capture
+  // the initial snapshot.
+  useEffect(() => {
+    if (open) {
+      const v = values?.no_pick_variant ?? 'leasters'
+      const r = values?.reveal_partner  ?? true
+      const d = values?.double_on_bump  ?? true
+      setVariant(v)
+      setReveal(r)
+      setDob(d)
+      setError(null)
+      committedRef.current = false
+      initialRef.current = { no_pick_variant: v, reveal_partner: r, double_on_bump: d }
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  // Drive the native <dialog> open/close
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    if (open) {
+      if (!dialog.open) dialog.showModal()
+    } else {
+      if (dialog.open) dialog.close()
+    }
+  }, [open])
+
+  function handleVariantChange(v) {
+    setVariant(v)
+    if (mode === 'create') {
+      onChange?.({ no_pick_variant: v, reveal_partner: reveal, double_on_bump: dob })
+    }
+  }
+
+  function handleRevealChange(v) {
+    setReveal(v)
+    if (mode === 'create') {
+      onChange?.({ no_pick_variant: variant, reveal_partner: v, double_on_bump: dob })
+    }
+  }
+
+  function handleDobChange(v) {
+    setDob(v)
+    if (mode === 'create') {
+      onChange?.({ no_pick_variant: variant, reveal_partner: reveal, double_on_bump: v })
+    }
+  }
+
+  async function handleDone() {
+    if (mode !== 'update') {
+      onClose?.()
+      return
+    }
+    const initial = initialRef.current
+    const changed = {}
+    if (variant !== initial.no_pick_variant) changed.no_pick_variant = variant
+    if (reveal  !== initial.reveal_partner)  changed.reveal_partner  = reveal
+    if (dob     !== initial.double_on_bump)  changed.double_on_bump  = dob
+
+    if (Object.keys(changed).length === 0) {
+      // Nothing changed — close without any network call.
+      committedRef.current = true
+      onClose?.()
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await api.games.updateSettings(gameId, { ...changed, log_change: true })
+      onUpdated?.(result)
+      committedRef.current = true
+      onClose?.()
+    } catch (e) {
+      setError(e?.message ?? 'Failed to save.')
+      // Stay open so the admin can retry. Local state is preserved.
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // Fires for any dialog close — Done, Escape, backdrop click. We only
+  // propagate to the parent here; the commit path is in handleDone.
+  function handleDialogClose() {
+    if (!committedRef.current) {
+      // Cancel path: discard local edits by simply closing. The next open
+      // will reseed from `values` (parent state).
+    }
+    committedRef.current = false
+    onClose?.()
+  }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="game-options-dialog"
+      onClose={handleDialogClose}
+    >
+      <strong style={{ fontSize: '0.95rem' }}>⚙ Game options</strong>
+      {mode === 'update' && (
+        <small style={{ color: '#aaa', display: 'block', marginBottom: 12, marginTop: 2 }}>
+          Changes take effect next hand
+        </small>
+      )}
+      {mode === 'create' && (
+        <div style={{ marginBottom: 12 }} />
+      )}
+
+      {/* No-pick variant */}
+      <div style={{ marginBottom: 12 }}>
+        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant</div>
+        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          {['doublers', 'leasters', 'schwanzers'].map(v => (
+            <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+              <input
+                type="radio"
+                name={`variant-${gameId ?? 'create'}`}
+                value={v}
+                checked={variant === v}
+                onChange={() => handleVariantChange(v)}
+                disabled={saving}
+              />
+              {VARIANT_LABELS[v]}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Identify partner */}
+      <div style={{ marginBottom: 16 }}>
+        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>
+          Partner Visibility
+        </div>
+        <div style={{ display: 'flex', gap: 12 }}>
+          {[false, true].map(v => (
+            <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+              <input
+                type="radio"
+                name={`reveal-${gameId ?? 'create'}`}
+                value={String(v)}
+                checked={reveal === v}
+                onChange={() => handleRevealChange(v)}
+                disabled={saving}
+              />
+              {v ? 'Shown' : 'Hidden'}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Double on the Bump */}
+      <div style={{ marginBottom: 16 }}>
+        <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem' }}>
+          Double on the Bump?
+          <input
+            type="checkbox"
+            checked={dob}
+            onChange={e => handleDobChange(e.target.checked)}
+            disabled={saving}
+          />
+        </label>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ fontSize: '0.82rem' }}>
+          {mode === 'update' && saving && <span style={{ color: '#aaa' }}>Saving…</span>}
+          {mode === 'update' && error  && <span style={{ color: '#f87171' }}>{error}</span>}
+        </div>
+        <button
+          type="button"
+          onClick={handleDone}
+          disabled={saving}
+          style={{ fontSize: '0.85rem', padding: '4px 16px' }}
+        >
+          Done
+        </button>
+      </div>
+    </dialog>
+  )
+}
+```
+
+- [ ] **Step 3: Verify the dev server still builds**
+
+Run: `npm run dev`
+Expected: Vite compiles successfully with no errors about `GameOptionsPanel`.
+
+- [ ] **Step 4: Manual verification — happy path commit**
+
+With the dev server running, open two browser tabs on the same game (one admin, one non-admin).
+
+Admin tab:
+1. Press ⚙ Edit — modal opens.
+2. Change the no-pick variant to a different value.
+3. Toggle DOB off.
+4. Press Done.
+
+Expected:
+- Modal closes.
+- Admin's on-screen summary updates to reflect the new values.
+- Non-admin tab (after the next poll) sees the same updated summary and one new `Next Hand: …` line in the Play History.
+
+- [ ] **Step 5: Manual verification — cancel path**
+
+Admin tab:
+1. Press ⚙ Edit — modal opens.
+2. Change any setting.
+3. Press Escape (or click outside the modal).
+
+Expected:
+- Modal closes.
+- Admin's summary is unchanged.
+- No new line in Play History.
+- Reopening the modal shows the previously-saved values (local edits were discarded).
+
+- [ ] **Step 6: Manual verification — no-op press Done**
+
+Admin tab:
+1. Press ⚙ Edit — modal opens.
+2. Don't change anything.
+3. Press Done.
+
+Expected:
+- Modal closes.
+- No network PATCH fires (check DevTools Network panel).
+- No new line in Play History.
+
+- [ ] **Step 7: Manual verification — net-zero change**
+
+Admin tab:
+1. Press ⚙ Edit — modal opens.
+2. Toggle DOB off.
+3. Toggle DOB on (back to original).
+4. Press Done.
+
+Expected:
+- No network PATCH fires.
+- No new line in Play History.
+
+- [ ] **Step 8: Manual verification — error handling**
+
+Temporarily break the endpoint (e.g., stop Wrangler or set a bad URL) and try Done. The modal should stay open with a red error message visible. Restore the endpoint, press Done again, and it should succeed.
+
+- [ ] **Step 9: Stop the dev server and run the test suite**
+
+Run: `npm test`
+Expected: All tests pass.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/src/components/GameOptionsPanel.jsx
+git commit -m "feat(ui): GameOptionsPanel update mode uses deferred save with cancel on Escape"
+```
+
+---
+
+## Task 5: Final manual verification + PR-readiness check
+
+**Files:** none modified.
+
+- [ ] **Step 1: Run the full test suite one more time**
+
+Run: `npm test`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run the build to catch production-only issues**
+
+Run: `npm run build`
+Expected: Build succeeds with no errors or warnings about missing imports.
+
+- [ ] **Step 3: Full end-to-end manual verification**
+
+Run: `npm run dev`, then run through this checklist in two browser tabs (admin + non-admin):
+
+- [ ] Waiting screen, non-admin: sees `<variant> · Partner: <shown|hidden> · DOB: <on|off>` with the `Game options` label, no Edit button.
+- [ ] Waiting screen, admin: sees the same summary plus ⚙ Edit.
+- [ ] Active play, non-admin: sees the same summary in the last-trick-area right panel, no Edit button.
+- [ ] Active play, admin: sees the same summary plus ⚙ Edit.
+- [ ] Admin edits settings + Done → one `Next Hand: …` line appears in Play History for both tabs.
+- [ ] Admin opens modal + Done without changing → no log line.
+- [ ] Admin changes and reverts → no log line.
+- [ ] Admin presses Escape → no save, no log line.
+- [ ] Admin clicks outside modal → no save, no log line.
+- [ ] Game behavior remains correct: settings still take effect on the next hand (play one hand after a change, confirm new variant rules applied).
+
+Stop the dev server when done.
+
+- [ ] **Step 4: Review diff against the spec**
+
+Run: `git diff main...HEAD --stat`
+Review the changed files against the spec's "Components & Files" section. There should be no unexpected files touched.
+
+- [ ] **Step 5: No commit for this task** — it's purely verification. If any issue is found in steps 1–4, fix it inline and commit under the appropriate previous task's topic.
+
+---
+
+## Out of scope reminders
+
+- No changes to `shared/gameEngine.js` (no rule changes).
+- No updates to `docs/RULES.md` or `docs/BOTS.md` (neither rules nor bot strategy changes).
+- `create` mode of `GameOptionsPanel` is unchanged — it already defers via `onChange`.
+- No new push notifications, toasts, or banners.

--- a/docs/superpowers/specs/2026-04-18-game-mode-visibility-PMspec.md
+++ b/docs/superpowers/specs/2026-04-18-game-mode-visibility-PMspec.md
@@ -23,13 +23,15 @@ Every setting is listed, whether it changed or not. The "Next Hand" prefix makes
 
 ## How it behaves
 
-**One log line per editing session, not per click.** The admin might flip two or three settings in a row inside the modal. Rather than spamming the play history with a line per toggle, a single summary line appears when the admin closes the modal.
+**Nothing saves until the admin presses Done.** The settings modal becomes a staging area. The admin can toggle options freely; nothing is persisted and no other player sees anything until they commit with Done. This is a change from today's behavior, where each individual toggle saved immediately.
 
-**No log line if nothing actually changed.** If the admin opens the settings modal, looks around, and closes it without changing anything, no log entry is created. If they change a setting and then revert it to the original before closing, also no log entry. The log only speaks up when the resulting settings differ from what the admin started with.
+**Done commits, Escape cancels.** Pressing Done saves all the admin's changes in one go and emits the log line. Pressing Escape, or clicking outside the modal, discards the edits entirely — no save, no log line, no visible change to anyone else. The modal behaves like most modern "edit" dialogs: you commit or you cancel.
+
+**One log line per editing session.** Whatever mix of changes the admin made inside the modal, committing them produces exactly one log line summarizing the resulting settings. No spam, no line per toggle.
+
+**No log line if nothing actually changed.** If the admin opens the modal, presses Done without changing anything — or changes a setting and reverts it to the original before pressing Done — no log entry is created. The log only speaks up when the committed settings differ from what the admin started with.
 
 **Waiting screen is quiet.** The log isn't visible before a game starts, so no log line is emitted during the waiting screen phase. Non-admin players still see the summary display there — that's how they learn the starting settings.
-
-**Any way of closing the modal counts.** The log line is emitted whether the admin clicks the Done button, presses Escape, or clicks outside the modal. From the player's perspective, the admin "finished editing," and the announcement goes out.
 
 ## Why this design is forward-compatible
 
@@ -37,7 +39,7 @@ The app will grow over time — new game settings will be added, and a mobile ap
 
 **New settings are cheap to add.** The summary line is built in one place on the server from the current settings. When a new setting is added, updating that one formatter automatically updates: the in-game display for all players, the log line wording, and the wording on both the waiting screen and active-play views.
 
-**Mobile-friendly.** The backend exposes a simple signal the client can send — effectively "the admin just finished editing, announce it" — rather than locking in a particular UX flow. The web app uses a pattern where each toggle saves immediately and the announcement is sent at modal close. A mobile app could just as easily save everything in one go and attach the announcement to that single save. Either style works without backend changes.
+**Mobile-friendly.** Web and any future mobile app share the same flow: edit freely in the modal, commit all changes in one go on Done, cancel on Escape/backdrop. The backend accepts a single save per editing session with an "announce it" flag attached, which keeps the implementation identical across platforms.
 
 ## Out of scope
 

--- a/docs/superpowers/specs/2026-04-18-game-mode-visibility-PMspec.md
+++ b/docs/superpowers/specs/2026-04-18-game-mode-visibility-PMspec.md
@@ -1,0 +1,53 @@
+# Game Mode Visibility & Change Logging — PM Spec
+
+**Date:** 2026-04-18
+**Issue:** https://github.com/andynumber2/sheepshead/issues/114
+
+## What we're building
+
+Two small, related improvements so every player at the table — not just the game admin — can see and keep up with the active game settings.
+
+### 1. Everyone can see the current game settings
+
+Today, only the admin who created the game sees the current settings summary (no-pick variant, whether the partner is shown, double-on-the-bump). Other players have no way to know what variant is active once the game begins.
+
+After this change, all players see the same compact summary line in the two places it already lives: the pre-game waiting screen and the right-side panel during active play. Non-admin players see it read-only — no edit button.
+
+### 2. When the admin changes settings, everyone is told
+
+Today, the admin can toggle settings mid-game and no one else knows until the next hand begins with surprising new rules. After this change, when the admin finishes editing settings, a single line appears in the Play History chat for everyone:
+
+> **Next Hand:** Leasters · Partner: shown · DOB
+
+Every setting is listed, whether it changed or not. The "Next Hand" prefix makes clear to everyone that the rules aren't shifting mid-hand — they take effect at the start of the next hand.
+
+## How it behaves
+
+**One log line per editing session, not per click.** The admin might flip two or three settings in a row inside the modal. Rather than spamming the play history with a line per toggle, a single summary line appears when the admin closes the modal.
+
+**No log line if nothing actually changed.** If the admin opens the settings modal, looks around, and closes it without changing anything, no log entry is created. If they change a setting and then revert it to the original before closing, also no log entry. The log only speaks up when the resulting settings differ from what the admin started with.
+
+**Waiting screen is quiet.** The log isn't visible before a game starts, so no log line is emitted during the waiting screen phase. Non-admin players still see the summary display there — that's how they learn the starting settings.
+
+**Any way of closing the modal counts.** The log line is emitted whether the admin clicks the Done button, presses Escape, or clicks outside the modal. From the player's perspective, the admin "finished editing," and the announcement goes out.
+
+## Why this design is forward-compatible
+
+The app will grow over time — new game settings will be added, and a mobile app is likely. The design anticipates both.
+
+**New settings are cheap to add.** The summary line is built in one place on the server from the current settings. When a new setting is added, updating that one formatter automatically updates: the in-game display for all players, the log line wording, and the wording on both the waiting screen and active-play views.
+
+**Mobile-friendly.** The backend exposes a simple signal the client can send — effectively "the admin just finished editing, announce it" — rather than locking in a particular UX flow. The web app uses a pattern where each toggle saves immediately and the announcement is sent at modal close. A mobile app could just as easily save everything in one go and attach the announcement to that single save. Either style works without backend changes.
+
+## Out of scope
+
+- **When settings apply.** Settings still take effect at the start of the next hand — unchanged from today.
+- **What settings exist.** No new settings are being added in this work. This is about making existing settings visible.
+- **Other notification channels.** No push notifications, toasts, or banners — just the existing play-history log and the existing on-screen summary panel.
+
+## Success criteria
+
+- A non-admin player can open a game and, at any point, know what variant is being played and what the other current settings are.
+- When the admin changes settings, every player — admin and non-admin — sees a single clear line in the play history indicating what the settings will be for the next hand.
+- No log noise: opening and closing the settings modal without making a change has no visible effect.
+- The design supports adding a fourth or fifth setting later without revisiting the feature.

--- a/docs/superpowers/specs/2026-04-18-game-mode-visibility-design.md
+++ b/docs/superpowers/specs/2026-04-18-game-mode-visibility-design.md
@@ -1,0 +1,150 @@
+# Game Mode Visibility & Change Logging — Design
+
+**Date:** 2026-04-18
+**Issue:** https://github.com/andynumber2/sheepshead/issues/114
+
+## Goal
+
+Non-admin players currently have no visibility into the active game settings (no-pick variant, partner visibility, double-on-bump) once a game starts, and when the admin changes settings mid-game no other player is notified. This spec covers two deliverables:
+
+1. Display the current settings summary to non-admin players in the same places admins already see it.
+2. Append one line to the game's play-history log each time the admin closes the settings modal after making changes, showing the full post-change settings.
+
+Both features must be forward-compatible with additional game settings added later and work for any client (web today, mobile eventually).
+
+## Scope
+
+In scope:
+
+- The three existing settings: `no_pick_variant` (Leasters/Doublers/Schwanzers), `reveal_partner`, `double_on_bump`.
+- Any future settings — the design must extend to them without rework.
+- Display in the waiting screen and the active-play right panel.
+- Log emission only during active play.
+
+Out of scope:
+
+- Changing when settings take effect (they still apply next hand).
+- Changing which settings exist.
+- Any log content beyond the settings summary line.
+- Notification mechanisms other than the play-history log.
+
+## Architecture
+
+### Server: single extended endpoint
+
+`PATCH /api/games/:id/settings` gains one optional boolean field: `log_change`.
+
+- When `log_change: true`, after applying any setting updates in the same request, the endpoint reads `game_state.state_json`, appends one line to `state.log`, and writes it back.
+- The line is built server-side from the current (post-patch) settings via a shared formatter. Clients never construct the string.
+- When `log_change` is absent or false, the endpoint behaves exactly as today.
+- If the game is in `waiting` status, the log append is skipped (no `game_state` row exists). Setting updates still persist normally.
+- Validation: `log_change` must be a boolean if provided.
+
+This shape works equally well for:
+
+- Web auto-save-per-toggle, where a final `{ log_change: true }` PATCH with no setting fields flushes the log line.
+- Mobile batch-save, where a single PATCH carries all settings plus `log_change: true`.
+
+### Settings summary formatter
+
+A single function — `formatSettingsSummary(settings)` — is the sole source of truth for the settings summary string. It returns the body only, without any prefix:
+
+```
+Leasters · Partner: shown · DOB
+```
+
+Consumers add their own context:
+
+- **Log line** (server): prepends `Next Hand: ` → `Next Hand: Leasters · Partner: shown · DOB`
+- **On-screen summary** (client, admin + non-admin): uses the body verbatim.
+
+Every setting is rendered whether it changed or not. When a new setting is added, this formatter is the one place updated to include it.
+
+The formatter lives in `shared/` (e.g., `shared/settingsSummary.js`) so both the server endpoint and the frontend import it. This guarantees admin view, non-admin view, and log line all stay in lockstep.
+
+### Client: modal close-time flush
+
+`GameOptionsPanel` (update mode only) tracks the settings snapshot taken when the modal opens. On close — whether via the Done button, Escape key, or backdrop click, all of which route through `onClose` — the panel compares the snapshot to the current values. If any differ, it issues one final call:
+
+```js
+api.games.updateSettings(gameId, { log_change: true })
+```
+
+No setting fields are included; the server uses the already-persisted values. If the snapshot matches current values, no call is made.
+
+### Client: non-admin display
+
+Extract the existing admin-only summary block into a small presentational helper:
+
+```jsx
+<SettingsSummary settings={…} />
+```
+
+Internally it calls `formatSettingsSummary(settings)` from `shared/` and renders the resulting body string, so admin view, non-admin view, and server-generated log line all stay in lockstep. Render it:
+
+- In the waiting screen, in place of the current `No-pick variant: <X>` line, for non-admins.
+- In the active-play right panel, below `LastTrickArea`, for non-admins.
+
+The admin branch keeps its ⚙ Edit button alongside the same summary component.
+
+## Components & Files
+
+| File | Change |
+|---|---|
+| `functions/api/games/[id]/settings.js` | Accept `log_change` field; after persisting settings, if `log_change === true` and game status is `active`, append `Next Hand: <summary>` to `state.log` and write back. |
+| `shared/settingsSummary.js` (new) | `formatSettingsSummary(settings)` — single source of truth for the summary body, imported by both server and frontend. |
+| `frontend/src/components/GameOptionsPanel.jsx` | On modal open, capture `initialValues`. In `onClose` path, if current values differ from `initialValues` and `mode === 'update'`, send a final `updateSettings(gameId, { log_change: true })`. |
+| `frontend/src/pages/GamePage.jsx` | Replace the two inline admin summary blocks with a small shared `<SettingsSummary>` component/helper; render it for non-admin players in both waiting and active-play views without the Edit button. |
+
+`frontend/src/lib/api.js` needs no signature change — `updateSettings` already forwards the JSON body.
+
+## Data Flow — admin editing session
+
+1. Admin clicks ⚙ Edit → modal opens; snapshot `{ variant, reveal, dob }` saved.
+2. Admin toggles `no_pick_variant` → `PATCH { no_pick_variant: 'leasters' }` → server persists, no log.
+3. Admin toggles `double_on_bump` → `PATCH { double_on_bump: false }` → server persists, no log.
+4. Admin clicks Done → modal `onClose` fires → snapshot differs → client sends `PATCH { log_change: true }` → server appends `Next Hand: Leasters · Partner: shown` to `state.log`.
+5. All clients see the log update on their next poll.
+
+## Edge Cases
+
+- **No-op guard — nothing changed.** Admin opens modal, presses Done → snapshots match → no flush PATCH sent → no log entry.
+- **Net-zero change.** Admin toggles a setting and reverts it to the original before closing → snapshots match → no log entry. (Intermediate PATCHes already persisted to the DB, but the final value equals the original so nothing to announce.)
+- **Modal closes via Escape or backdrop.** Same `onClose` path, same behavior as Done.
+- **Mid-hand change.** Settings still take effect next hand (unchanged from today). The `Next Hand:` prefix communicates this to all players.
+- **Waiting screen.** Log append is skipped server-side even if the client sends `log_change: true`, because no `game_state` row exists yet. Setting persistence still works. Non-admins still see the summary on the waiting screen via the new shared component; log entries are irrelevant there since the log isn't rendered.
+- **Multiple admins rapid-firing.** Only one admin can hold the modal open at a time per session, but if two admin sessions overlap, each emits its own log line on close. This matches the natural semantics.
+
+## Testing
+
+### Unit tests
+
+- `formatSettingsSummary(settings)` — exhaustive combinations: each variant × reveal on/off × DOB on/off. Anchors the string format so regressions surface immediately.
+
+### Integration / state-construction tests
+
+Extend existing settings endpoint tests (or add new ones if none exist):
+
+- PATCH with `log_change: true` during active game → `state.log` gets the `Next Hand: …` line.
+- PATCH with `log_change: true` during waiting game → no log change; setting updates still persist.
+- PATCH with `log_change: false` or absent → no log change even if settings change.
+- PATCH with `log_change: true` and no setting fields → still emits the log line using the current persisted settings.
+- PATCH with invalid `log_change` type → 400 with appropriate error.
+
+### Manual verification
+
+- Non-admin sees the summary on the waiting screen and the active-play right panel; no Edit button.
+- Admin edits settings + presses Done → one `Next Hand: …` line appears in Play History for all players.
+- Admin opens modal + presses Done without changing → no line appears.
+- Admin changes and reverts before Done → no line appears.
+- Admin presses Escape — same behavior as Done.
+
+## Future Settings
+
+When a new game setting is added, three places need updating:
+
+1. Settings persistence (already the pattern: `settings.js` validator + `json_set` path).
+2. `formatSettingsSummary` — add the new field to the rendered string.
+3. `GameOptionsPanel` — add the control.
+
+The log line format and non-admin display both update automatically because they consume the same formatter.

--- a/docs/superpowers/specs/2026-04-18-game-mode-visibility-design.md
+++ b/docs/superpowers/specs/2026-04-18-game-mode-visibility-design.md
@@ -40,10 +40,7 @@ Out of scope:
 - If the game is in `waiting` status, the log append is skipped (no `game_state` row exists). Setting updates still persist normally.
 - Validation: `log_change` must be a boolean if provided.
 
-This shape works equally well for:
-
-- Web auto-save-per-toggle, where a final `{ log_change: true }` PATCH with no setting fields flushes the log line.
-- Mobile batch-save, where a single PATCH carries all settings plus `log_change: true`.
+All clients — web and mobile — commit changes on modal-close as a single batched PATCH carrying whatever fields changed plus `log_change: true`.
 
 ### Settings summary formatter
 
@@ -62,15 +59,18 @@ Every setting is rendered whether it changed or not. When a new setting is added
 
 The formatter lives in `shared/` (e.g., `shared/settingsSummary.js`) so both the server endpoint and the frontend import it. This guarantees admin view, non-admin view, and log line all stay in lockstep.
 
-### Client: modal close-time flush
+### Client: deferred save on Done
 
-`GameOptionsPanel` (update mode only) tracks the settings snapshot taken when the modal opens. On close — whether via the Done button, Escape key, or backdrop click, all of which route through `onClose` — the panel compares the snapshot to the current values. If any differ, it issues one final call:
+`GameOptionsPanel` (update mode) uses a deferred-save flow — no network I/O happens as the admin toggles controls. Local state only.
 
-```js
-api.games.updateSettings(gameId, { log_change: true })
-```
+- **On open:** capture `initialValues` (snapshot of settings at the moment the modal opens). Local form state is seeded from props.
+- **As admin toggles:** local state updates; nothing is persisted.
+- **On Done:** if the current local values differ from `initialValues`, issue one PATCH carrying the changed fields plus `log_change: true`, e.g. `PATCH { no_pick_variant: 'leasters', double_on_bump: false, log_change: true }`. If no values changed, no PATCH is sent.
+- **On Escape or backdrop click (cancel):** the modal closes without persisting anything. No PATCH is sent. Local state is discarded.
 
-No setting fields are included; the server uses the already-persisted values. If the snapshot matches current values, no call is made.
+Done and Cancel must be separate code paths. The native `<dialog>` `close` event fires for both; the implementation distinguishes them by tracking whether the close was initiated by the Done button or by Escape/backdrop (e.g., a `committedRef` set by the Done handler before closing).
+
+This replaces the current per-toggle auto-save behavior. No "Saving…" / "✓ Saved" indicators are needed on individual controls; a single save indicator (or error state) applies to the Done action as a whole.
 
 ### Client: non-admin display
 
@@ -93,27 +93,32 @@ The admin branch keeps its ⚙ Edit button alongside the same summary component.
 |---|---|
 | `functions/api/games/[id]/settings.js` | Accept `log_change` field; after persisting settings, if `log_change === true` and game status is `active`, append `Next Hand: <summary>` to `state.log` and write back. |
 | `shared/settingsSummary.js` (new) | `formatSettingsSummary(settings)` — single source of truth for the summary body, imported by both server and frontend. |
-| `frontend/src/components/GameOptionsPanel.jsx` | On modal open, capture `initialValues`. In `onClose` path, if current values differ from `initialValues` and `mode === 'update'`, send a final `updateSettings(gameId, { log_change: true })`. |
+| `frontend/src/components/GameOptionsPanel.jsx` | Rework `update` mode to defer saves. Capture `initialValues` on open. Done button: if local values differ, PATCH changed fields plus `log_change: true`. Escape/backdrop: close without saving. Remove per-toggle auto-save and per-toggle Saving/Saved indicators. |
 | `frontend/src/pages/GamePage.jsx` | Replace the two inline admin summary blocks with a small shared `<SettingsSummary>` component/helper; render it for non-admin players in both waiting and active-play views without the Edit button. |
 
 `frontend/src/lib/api.js` needs no signature change — `updateSettings` already forwards the JSON body.
 
 ## Data Flow — admin editing session
 
-1. Admin clicks ⚙ Edit → modal opens; snapshot `{ variant, reveal, dob }` saved.
-2. Admin toggles `no_pick_variant` → `PATCH { no_pick_variant: 'leasters' }` → server persists, no log.
-3. Admin toggles `double_on_bump` → `PATCH { double_on_bump: false }` → server persists, no log.
-4. Admin clicks Done → modal `onClose` fires → snapshot differs → client sends `PATCH { log_change: true }` → server appends `Next Hand: Leasters · Partner: shown` to `state.log`.
-5. All clients see the log update on their next poll.
+1. Admin clicks ⚙ Edit → modal opens; `initialValues` captured; local form state seeded.
+2. Admin toggles `no_pick_variant` → local state updates; no network.
+3. Admin toggles `double_on_bump` → local state updates; no network.
+4. Admin clicks Done → values differ from `initialValues` → client sends one `PATCH { no_pick_variant: 'leasters', double_on_bump: false, log_change: true }` → server persists and appends `Next Hand: Leasters · Partner: shown` to `state.log`.
+5. All clients see the settings + log update on their next poll.
+
+Alternative path — cancel:
+
+- Admin clicks ⚙ Edit, toggles some settings, presses Escape (or clicks the backdrop) → modal closes, no PATCH, no persistence, no log. Next time the admin opens the modal, it reflects the last-saved server state.
 
 ## Edge Cases
 
-- **No-op guard — nothing changed.** Admin opens modal, presses Done → snapshots match → no flush PATCH sent → no log entry.
-- **Net-zero change.** Admin toggles a setting and reverts it to the original before closing → snapshots match → no log entry. (Intermediate PATCHes already persisted to the DB, but the final value equals the original so nothing to announce.)
-- **Modal closes via Escape or backdrop.** Same `onClose` path, same behavior as Done.
+- **No-op guard — nothing changed.** Admin opens modal, presses Done → values match `initialValues` → no PATCH sent → no log entry.
+- **Net-zero change.** Admin toggles a setting and reverts it to the original before pressing Done → values match `initialValues` → no PATCH sent. (Nothing was ever persisted, so no revert logic is needed.)
+- **Escape or backdrop click (cancel).** Modal closes; no PATCH; no log entry. Any local edits are discarded.
 - **Mid-hand change.** Settings still take effect next hand (unchanged from today). The `Next Hand:` prefix communicates this to all players.
 - **Waiting screen.** Log append is skipped server-side even if the client sends `log_change: true`, because no `game_state` row exists yet. Setting persistence still works. Non-admins still see the summary on the waiting screen via the new shared component; log entries are irrelevant there since the log isn't rendered.
-- **Multiple admins rapid-firing.** Only one admin can hold the modal open at a time per session, but if two admin sessions overlap, each emits its own log line on close. This matches the natural semantics.
+- **Save error on Done.** If the PATCH fails, the modal should surface the error and stay open so the admin can retry. Local state is not discarded on failure.
+- **Multiple admins.** If two admin sessions overlap, each emits its own log line when its admin presses Done. Whichever PATCH lands second wins (last-write-wins, matches today).
 
 ## Testing
 
@@ -125,19 +130,19 @@ The admin branch keeps its ⚙ Edit button alongside the same summary component.
 
 Extend existing settings endpoint tests (or add new ones if none exist):
 
-- PATCH with `log_change: true` during active game → `state.log` gets the `Next Hand: …` line.
+- PATCH with settings fields + `log_change: true` during active game → settings persist and `state.log` gets the `Next Hand: …` line.
 - PATCH with `log_change: true` during waiting game → no log change; setting updates still persist.
 - PATCH with `log_change: false` or absent → no log change even if settings change.
-- PATCH with `log_change: true` and no setting fields → still emits the log line using the current persisted settings.
+- PATCH with only `log_change: true` (no setting fields) → still emits the log line using the current persisted settings (supports mobile clients that may choose this shape).
 - PATCH with invalid `log_change` type → 400 with appropriate error.
 
 ### Manual verification
 
 - Non-admin sees the summary on the waiting screen and the active-play right panel; no Edit button.
-- Admin edits settings + presses Done → one `Next Hand: …` line appears in Play History for all players.
-- Admin opens modal + presses Done without changing → no line appears.
-- Admin changes and reverts before Done → no line appears.
-- Admin presses Escape — same behavior as Done.
+- Admin edits settings + presses Done → one `Next Hand: …` line appears in Play History for all players; settings take effect on the next hand.
+- Admin opens modal + presses Done without changing → no line appears; no network call.
+- Admin changes and reverts before Done → no line appears; no network call.
+- Admin edits settings + presses Escape (or clicks backdrop) → nothing saved; no log line; reopening the modal shows the previously-saved values.
 
 ## Future Settings
 

--- a/frontend/src/components/GameOptionsPanel.jsx
+++ b/frontend/src/components/GameOptionsPanel.jsx
@@ -33,8 +33,8 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
   // the initial snapshot.
   useEffect(() => {
     if (open) {
-      const v = values?.no_pick_variant ?? 'leasters'
-      const r = values?.reveal_partner  ?? true
+      const v = values?.no_pick_variant ?? 'doublers'
+      const r = values?.reveal_partner  ?? false
       const d = values?.double_on_bump  ?? true
       setVariant(v)
       setReveal(r)

--- a/frontend/src/components/GameOptionsPanel.jsx
+++ b/frontend/src/components/GameOptionsPanel.jsx
@@ -6,25 +6,42 @@ const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers:
 /**
  * Reusable game options modal.
  *
- * mode="create"  — no API calls; calls onChange({ no_pick_variant, reveal_partner }) on each change.
- * mode="update"  — auto-saves via PATCH /api/games/:gameId/settings on each change; calls onUpdated(result).
+ * mode="create"  — no API calls; calls onChange({ no_pick_variant, reveal_partner, double_on_bump }) on each change.
+ * mode="update"  — deferred save: local state only until the admin presses Done, which sends
+ *                  one PATCH carrying the changed fields plus log_change: true. Escape or
+ *                  backdrop click cancels and discards local edits.
  *
  * The parent controls open/close via the `open` prop and `onClose` callback.
  */
 export default function GameOptionsPanel({ mode, gameId, open, values, onChange, onUpdated, onClose }) {
-  const dialogRef  = useRef(null)
+  const dialogRef = useRef(null)
+  // True when the in-flight close was initiated by the Done button. Lets us
+  // distinguish a commit (Done) from a cancel (Escape/backdrop), since the
+  // native <dialog> onClose event fires for both.
+  const committedRef = useRef(false)
+  // Snapshot of the settings at the moment the modal opened. Used in update
+  // mode to decide which fields actually changed when Done is pressed.
+  const initialRef = useRef(null)
+
   const [variant, setVariant] = useState(values?.no_pick_variant ?? 'doublers')
   const [reveal,  setReveal]  = useState(values?.reveal_partner  ?? false)
   const [dob,     setDob]     = useState(values?.double_on_bump  ?? true)
   const [saving,  setSaving]  = useState(false)
-  const [saved,   setSaved]   = useState(false)
+  const [error,   setError]   = useState(null)
 
-  // Re-sync form from parent values each time the panel opens
+  // Re-sync form from parent values each time the panel opens, and capture
+  // the initial snapshot.
   useEffect(() => {
     if (open) {
-      setVariant(values?.no_pick_variant ?? 'leasters')
-      setReveal(values?.reveal_partner  ?? true)
-      setDob(values?.double_on_bump ?? true)
+      const v = values?.no_pick_variant ?? 'leasters'
+      const r = values?.reveal_partner  ?? true
+      const d = values?.double_on_bump  ?? true
+      setVariant(v)
+      setReveal(r)
+      setDob(d)
+      setError(null)
+      committedRef.current = false
+      initialRef.current = { no_pick_variant: v, reveal_partner: r, double_on_bump: d }
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
@@ -40,50 +57,76 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
     }
   }, [open])
 
-  async function handleVariantChange(v) {
+  function handleVariantChange(v) {
     setVariant(v)
     if (mode === 'create') {
       onChange?.({ no_pick_variant: v, reveal_partner: reveal, double_on_bump: dob })
-    } else {
-      await save({ no_pick_variant: v })
     }
   }
 
-  async function handleRevealChange(v) {
+  function handleRevealChange(v) {
     setReveal(v)
     if (mode === 'create') {
       onChange?.({ no_pick_variant: variant, reveal_partner: v, double_on_bump: dob })
-    } else {
-      await save({ reveal_partner: v })
     }
   }
 
-  async function handleDobChange(v) {
+  function handleDobChange(v) {
     setDob(v)
     if (mode === 'create') {
       onChange?.({ no_pick_variant: variant, reveal_partner: reveal, double_on_bump: v })
-    } else {
-      await save({ double_on_bump: v })
     }
   }
 
-  async function save(patch) {
+  async function handleDone() {
+    if (mode !== 'update') {
+      onClose?.()
+      return
+    }
+    const initial = initialRef.current
+    const changed = {}
+    if (variant !== initial.no_pick_variant) changed.no_pick_variant = variant
+    if (reveal  !== initial.reveal_partner)  changed.reveal_partner  = reveal
+    if (dob     !== initial.double_on_bump)  changed.double_on_bump  = dob
+
+    if (Object.keys(changed).length === 0) {
+      // Nothing changed — close without any network call.
+      committedRef.current = true
+      onClose?.()
+      return
+    }
+
     setSaving(true)
-    setSaved(false)
+    setError(null)
     try {
-      const result = await api.games.updateSettings(gameId, patch)
-      setSaved(true)
+      const result = await api.games.updateSettings(gameId, { ...changed, log_change: true })
       onUpdated?.(result)
-      setTimeout(() => setSaved(false), 2000)
-    } catch { /* revert handled by parent re-poll */ }
-    finally { setSaving(false) }
+      committedRef.current = true
+      onClose?.()
+    } catch (e) {
+      setError(e?.message ?? 'Failed to save.')
+      // Stay open so the admin can retry. Local state is preserved.
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  // Fires for any dialog close — Done, Escape, backdrop click. We only
+  // propagate to the parent here; the commit path is in handleDone.
+  function handleDialogClose() {
+    if (!committedRef.current) {
+      // Cancel path: discard local edits by simply closing. The next open
+      // will reseed from `values` (parent state).
+    }
+    committedRef.current = false
+    onClose?.()
   }
 
   return (
     <dialog
       ref={dialogRef}
       className="game-options-dialog"
-      onClose={onClose}
+      onClose={handleDialogClose}
     >
       <strong style={{ fontSize: '0.95rem' }}>⚙ Game options</strong>
       {mode === 'update' && (
@@ -153,11 +196,12 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ fontSize: '0.82rem' }}>
           {mode === 'update' && saving && <span style={{ color: '#aaa' }}>Saving…</span>}
-          {mode === 'update' && saved  && <span style={{ color: '#4ade80' }}>✓ Saved</span>}
+          {mode === 'update' && error  && <span style={{ color: '#f87171' }}>{error}</span>}
         </div>
         <button
           type="button"
-          onClick={onClose}
+          onClick={handleDone}
+          disabled={saving}
           style={{ fontSize: '0.85rem', padding: '4px 16px' }}
         >
           Done

--- a/frontend/src/components/SettingsSummary.jsx
+++ b/frontend/src/components/SettingsSummary.jsx
@@ -1,0 +1,13 @@
+import { formatSettingsSummary } from '@shared/settingsSummary.js'
+
+/**
+ * Renders the single-line settings summary body. Plain span — the
+ * caller controls surrounding layout, labels, and any adjacent
+ * controls (e.g. the admin Edit button).
+ */
+export default function SettingsSummary({ settings, style }) {
+  if (!settings) return null
+  return (
+    <span style={style}>{formatSettingsSummary(settings)}</span>
+  )
+}

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -7,9 +7,9 @@ import ActionPanel from '../components/ActionPanel.jsx'
 import GameLog from '../components/GameLog.jsx'
 import ScoreBoard from '../components/ScoreBoard.jsx'
 import GameOptionsPanel from '../components/GameOptionsPanel.jsx'
+import SettingsSummary from '../components/SettingsSummary.jsx'
 
-const SUIT_SYMBOLS   = { C: '♣', D: '♦', H: '♥', S: '♠' }
-const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers: 'Schwanzers' }
+const SUIT_SYMBOLS = { C: '♣', D: '♦', H: '♥', S: '♠' }
 
 // ── Seat layout (you at bottom, 4 opponents around the arc) ──────────────────
 // 5-seat positions: bottom, left, top-left, top-right, right
@@ -392,6 +392,12 @@ export default function GamePage({ gameId, user, onNavigate }) {
     } = {},
   } = gameData
 
+  const currentSettings = {
+    no_pick_variant: currentVariant ?? noPickVariant,
+    reveal_partner:  revealPartner  ?? gameData.settings?.reveal_partner  ?? true,
+    double_on_bump:  dobEnabled     ?? gameData.settings?.double_on_bump  ?? true,
+  }
+
   // ── Game ended ──────────────────────────────────────────────────────────────
   if (status === 'complete') {
     return (
@@ -425,11 +431,10 @@ export default function GamePage({ gameId, user, onNavigate }) {
             <div style={{ marginTop: 8 }}>
               <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
-                <span style={{ color: '#ccc', fontSize: '0.85rem' }}>
-                  {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
-                  Partner: {(revealPartner ?? gameData.settings?.reveal_partner ?? true) ? 'shown' : 'hidden'}
-                  {(dobEnabled ?? gameData.settings?.double_on_bump ?? true) ? ' · DOB' : ''}
-                </span>
+                <SettingsSummary
+                  settings={currentSettings}
+                  style={{ color: '#ccc', fontSize: '0.85rem' }}
+                />
                 <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
                   onClick={() => setShowOptions(true)}>
                   ⚙ Edit
@@ -440,15 +445,19 @@ export default function GamePage({ gameId, user, onNavigate }) {
               mode="update"
               gameId={gameId}
               open={showOptions}
-              values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.settings?.reveal_partner ?? true, double_on_bump: dobEnabled ?? gameData.settings?.double_on_bump ?? true }}
+              values={currentSettings}
               onUpdated={handleSettingsUpdate}
               onClose={() => setShowOptions(false)}
             />
           </>
         ) : (
-          <p style={{ color: '#aaa', fontSize: '0.85rem', marginTop: 8 }}>
-            No-pick variant: <strong>{VARIANT_LABELS[noPickVariant]}</strong>
-          </p>
+          <div style={{ marginTop: 8 }}>
+            <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
+            <SettingsSummary
+              settings={currentSettings}
+              style={{ color: '#aaa', fontSize: '0.85rem' }}
+            />
+          </div>
         )}
 
         <p style={{ marginTop: 16 }}>Waiting for players… ({players.length}/5)</p>
@@ -614,30 +623,36 @@ export default function GamePage({ gameId, user, onNavigate }) {
       {/* ── Right panel: last trick + game options + leave game ── */}
       <div className="last-trick-area">
         <LastTrickArea lastTrick={lastTrick} seats={seats} />
-        {isGameAdmin && (
-          <div style={{ width: '100%', borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 8 }}>
-            <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
-            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-              <span style={{ color: '#aaa', fontSize: '0.78rem' }}>
-                {VARIANT_LABELS[currentVariant ?? noPickVariant]} ·{' '}
-                Partner: {(revealPartner ?? gameData.settings?.reveal_partner ?? true) ? 'shown' : 'hidden'}
-                {(dobEnabled ?? gameData.settings?.double_on_bump ?? true) ? ' · DOB' : ''}
-              </span>
-              <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
-                onClick={() => setShowOptions(true)}>
-                ⚙ Edit
-              </button>
-            </div>
-            <GameOptionsPanel
-              mode="update"
-              gameId={gameId}
-              open={showOptions}
-              values={{ no_pick_variant: currentVariant ?? noPickVariant, reveal_partner: revealPartner ?? gameData.settings?.reveal_partner ?? true, double_on_bump: dobEnabled ?? gameData.settings?.double_on_bump ?? true }}
-              onUpdated={handleSettingsUpdate}
-              onClose={() => setShowOptions(false)}
+        <div style={{ width: '100%', borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 8 }}>
+          <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
+          {isGameAdmin ? (
+            <>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                <SettingsSummary
+                  settings={currentSettings}
+                  style={{ color: '#aaa', fontSize: '0.78rem' }}
+                />
+                <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+                  onClick={() => setShowOptions(true)}>
+                  ⚙ Edit
+                </button>
+              </div>
+              <GameOptionsPanel
+                mode="update"
+                gameId={gameId}
+                open={showOptions}
+                values={currentSettings}
+                onUpdated={handleSettingsUpdate}
+                onClose={() => setShowOptions(false)}
+              />
+            </>
+          ) : (
+            <SettingsSummary
+              settings={currentSettings}
+              style={{ color: '#aaa', fontSize: '0.78rem' }}
             />
-          </div>
-        )}
+          )}
+        </div>
         <div style={{ marginTop: 'auto', width: '100%', display: 'flex', justifyContent: 'flex-end', paddingTop: 8 }}>
           <button className="outline contrast" style={{ fontSize: '0.8rem' }}
             onClick={handleLeave} aria-busy={leaving} disabled={leaving}>

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -394,7 +394,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
   const currentSettings = {
     no_pick_variant: currentVariant ?? noPickVariant,
-    reveal_partner:  revealPartner  ?? gameData.settings?.reveal_partner  ?? true,
+    reveal_partner:  revealPartner  ?? gameData.settings?.reveal_partner  ?? false,
     double_on_bump:  dobEnabled     ?? gameData.settings?.double_on_bump  ?? true,
   }
 
@@ -502,11 +502,11 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
   const dealerUserId  = state.pickOrder ? state.pickOrder[4] : null
   const pickerUserId  = state.picker
-  const partnerUserId  = (state.partnerRevealed && (state.reveal_partner ?? true)) ? state.partner : null
+  const partnerUserId  = (state.partnerRevealed && (state.reveal_partner ?? false)) ? state.partner : null
 
   // Called ace display
   const calledAce       = state.calledAce
-  const showPartnerName = state.partnerRevealed && (state.reveal_partner ?? true)
+  const showPartnerName = state.partnerRevealed && (state.reveal_partner ?? false)
   const partnerPlayer   = showPartnerName && state.partner
     ? players.find(p => String(p.user_id) === String(state.partner))
     : null

--- a/functions/api/games/[id]/settings.js
+++ b/functions/api/games/[id]/settings.js
@@ -1,4 +1,5 @@
 import { json, err, requireUser, AuthError } from '../../_helpers.js'
+import { formatSettingsSummary } from '../../../../shared/settingsSummary.js'
 
 export async function onRequestPatch({ request, env, params }) {
   try {
@@ -14,7 +15,7 @@ export async function onRequestPatch({ request, env, params }) {
     let body
     try { body = await request.json() } catch { return err('Invalid JSON.') }
 
-    const { no_pick_variant, reveal_partner, double_on_bump } = body ?? {}
+    const { no_pick_variant, reveal_partner, double_on_bump, log_change } = body ?? {}
 
     if (no_pick_variant !== undefined && !['leasters', 'doublers', 'schwanzers'].includes(no_pick_variant)) {
       return err('no_pick_variant must be "leasters", "doublers", or "schwanzers".')
@@ -24,6 +25,9 @@ export async function onRequestPatch({ request, env, params }) {
     }
     if (double_on_bump !== undefined && typeof double_on_bump !== 'boolean') {
       return err('double_on_bump must be a boolean.')
+    }
+    if (log_change !== undefined && typeof log_change !== 'boolean') {
+      return err('log_change must be a boolean.')
     }
 
     // Build json_set args for the fields that were provided
@@ -44,16 +48,34 @@ export async function onRequestPatch({ request, env, params }) {
       bindings.push(double_on_bump ? 'true' : 'false')
     }
 
-    if (bindings.length === 0) return err('No settings to update.')
+    if (bindings.length === 0 && log_change !== true) {
+      return err('No settings to update.')
+    }
 
-    bindings.push(gameId)
-    await env.DB.prepare(
-      `UPDATE games SET settings_json = ${jsonSetExpr}, updated_at = datetime('now') WHERE id = ?`
-    ).bind(...bindings).run()
+    if (bindings.length > 0) {
+      bindings.push(gameId)
+      await env.DB.prepare(
+        `UPDATE games SET settings_json = ${jsonSetExpr}, updated_at = datetime('now') WHERE id = ?`
+      ).bind(...bindings).run()
+    }
 
     const updated = await env.DB.prepare('SELECT settings_json FROM games WHERE id = ?').bind(gameId).first()
     const raw = JSON.parse(updated.settings_json)
     const settings = { ...raw, reveal_partner: !!raw.reveal_partner, double_on_bump: !!raw.double_on_bump, is_test_mode: !!raw.is_test_mode }
+
+    if (log_change === true) {
+      const stateRow = await env.DB.prepare(
+        'SELECT state_json FROM game_state WHERE game_id = ?'
+      ).bind(gameId).first()
+      if (stateRow) {
+        const state = JSON.parse(stateRow.state_json)
+        const line = `Next Hand: ${formatSettingsSummary(settings)}`
+        state.log = [...(state.log ?? []), line]
+        await env.DB.prepare(
+          "UPDATE game_state SET state_json = ?, updated_at = datetime('now') WHERE game_id = ?"
+        ).bind(JSON.stringify(state), gameId).run()
+      }
+    }
 
     return json({ ok: true, settings })
   } catch (e) {

--- a/shared/gameEngine.js
+++ b/shared/gameEngine.js
@@ -906,7 +906,7 @@ export function getPlayerView(state, userId) {
   // Hide partner identity from bystanders when:
   // 1. The ace hasn't been played yet (partnerRevealed is false), OR
   // 2. The "identify partner" game option is disabled (reveal_partner is false)
-  const partnerVisible = view.partnerRevealed && (view.reveal_partner ?? true)
+  const partnerVisible = view.partnerRevealed && (view.reveal_partner ?? false)
   if (!partnerVisible && view.partner && view.partner !== userId && view.picker !== userId) {
     view.partner = null
   }

--- a/shared/settingsSummary.js
+++ b/shared/settingsSummary.js
@@ -1,0 +1,20 @@
+const VARIANT_LABELS = {
+  leasters: 'Leasters',
+  doublers: 'Doublers',
+  schwanzers: 'Schwanzers',
+}
+
+/**
+ * Returns a single-line summary of the game settings, used both in the
+ * play-history log line and as the on-screen settings summary. Every
+ * setting is always rendered — callers rely on the body being a full
+ * snapshot, not a diff.
+ *
+ * Example: "Leasters · Partner: shown · DOB: on"
+ */
+export function formatSettingsSummary(settings) {
+  const variant = VARIANT_LABELS[settings.no_pick_variant] ?? settings.no_pick_variant
+  const partner = settings.reveal_partner ? 'shown' : 'hidden'
+  const dob = settings.double_on_bump ? 'on' : 'off'
+  return `${variant} · Partner: ${partner} · DOB: ${dob}`
+}

--- a/shared/settingsSummary.test.js
+++ b/shared/settingsSummary.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { formatSettingsSummary } from './settingsSummary.js'
+
+describe('formatSettingsSummary', () => {
+  it('renders leasters, partner shown, DOB on', () => {
+    expect(formatSettingsSummary({
+      no_pick_variant: 'leasters',
+      reveal_partner: true,
+      double_on_bump: true,
+    })).toBe('Leasters · Partner: shown · DOB: on')
+  })
+
+  it('renders doublers, partner hidden, DOB off', () => {
+    expect(formatSettingsSummary({
+      no_pick_variant: 'doublers',
+      reveal_partner: false,
+      double_on_bump: false,
+    })).toBe('Doublers · Partner: hidden · DOB: off')
+  })
+
+  it('renders schwanzers, partner shown, DOB off', () => {
+    expect(formatSettingsSummary({
+      no_pick_variant: 'schwanzers',
+      reveal_partner: true,
+      double_on_bump: false,
+    })).toBe('Schwanzers · Partner: shown · DOB: off')
+  })
+
+  it('always shows DOB state (not conditional)', () => {
+    const off = formatSettingsSummary({
+      no_pick_variant: 'leasters',
+      reveal_partner: true,
+      double_on_bump: false,
+    })
+    expect(off).toContain('DOB: off')
+  })
+})


### PR DESCRIPTION
## Summary
- Non-admin players now see the current settings summary (`<variant> · Partner: <shown|hidden> · DOB: <on|off>`) in the waiting screen and active-play right panel.
- Admin edits to game settings now defer until Done: pressing Done commits all changes in one PATCH and appends a single `Next Hand: …` line to the play-history log. Escape/backdrop cancels and discards edits.
- A shared `formatSettingsSummary()` helper in `shared/` is the single source of truth for the summary string — server log line and both UI summaries stay in lockstep.

Closes https://github.com/andynumber2/sheepshead/issues/114

## Test plan
- [x] `npm test` — 214/214 passing
- [x] `npm run build` — succeeds
- [x] Manual browser verification in two tabs (admin + non-admin):
  - [x] Waiting screen: non-admin sees summary with no Edit button
  - [x] Active play: non-admin sees summary with no Edit button
  - [x] Admin edits + Done → one `Next Hand: …` line appears in Play History for both tabs
  - [x] Admin opens modal + Done without changes → no log line, no network call
  - [x] Admin changes and reverts before Done → no log line
  - [ ] Admin presses Escape → no save, no log line
  - [ ] Admin clicks outside modal → no save, no log line
  - [ ] Admin triggers a save error → modal stays open, edits preserved, retry works
  - [ ] Settings still take effect on the next hand (unchanged behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)