### PR TITLE
feat(ui): bot suggestion highlight + non-admin Options modal (#123)

### DIFF
--- a/docs/superpowers/plans/2026-04-19-bot-suggestion-highlight.md
+++ b/docs/superpowers/plans/2026-04-19-bot-suggestion-highlight.md
@@ -1,0 +1,1074 @@
+# Bot Suggestion Highlight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an opt-in per-player red-outline highlight on the card/action the bot strategy would choose, with the toggle housed in a refactored Options modal that non-admins can now open in read-only mode.
+
+**Architecture:** Thin client-only feature. A pure helper (`shared/botSuggestion.js`) dispatches on `state.phase` to the existing `shared/botStrategy.js` decision functions. `GamePage` calls it in a gated `useMemo`; the result is threaded as `suggestedIds`/`suggestedAction` props into `Hand` and `ActionPanel`. The toggle persists in `localStorage`. `GameOptionsPanel` gains a `role` prop: admin keeps the form; player gets a read-only key-value list plus a new "Your preferences" section with the one toggle. No server, DB, or API changes.
+
+**Tech Stack:** React 18 + Vite (frontend), Vitest (tests), plain CSS.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-bot-suggestion-highlight-design.md`
+**Issue:** https://github.com/andynumber2/sheepshead/issues/123
+**Blocks:** https://github.com/andynumber2/sheepshead/issues/140
+
+---
+
+## File Map
+
+- **Create:**
+  - `shared/botSuggestion.js` — pure `computeBotSuggestion(view, userId)` helper dispatching on phase
+  - `shared/botSuggestion.test.js` — vitest tests for the helper
+- **Modify:**
+  - `frontend/src/index.css` — add `.card-suggested`, `.btn-suggested` rules
+  - `frontend/src/components/Card.jsx` — accept optional `suggested` prop, add `card-suggested` class
+  - `frontend/src/components/Hand.jsx` — accept optional `suggestedIds` prop, forward to `Card`
+  - `frontend/src/components/ActionPanel.jsx` — accept optional `suggestedAction` prop, apply `btn-suggested` class to the matching button; in the `ace_under` sub-view, forward `suggestedIds` to the inner `Hand`
+  - `frontend/src/components/GameOptionsPanel.jsx` — add `role` prop, `botSuggestionEnabled` + `onBotSuggestionChange` props; render read-only list for `role === 'player'`; add "Your preferences" section; hide section when `mode === 'create'`; rename dialog title / behavior unchanged
+  - `frontend/src/pages/GamePage.jsx` — drop admin-only gating of the Options button in both waiting-state and in-game; read/write `sheepshead:showBotSuggestion` in `localStorage`; compute `botSuggestion` via `useMemo` (wrapped in try/catch); pass `suggestedIds`/`suggestedAction` through to `Hand`/`ActionPanel`; pass `role`, `botSuggestionEnabled`, `onBotSuggestionChange` to `GameOptionsPanel`; rename button text to "⚙ Options"
+  - `frontend/src/pages/LobbyPage.jsx` — rename create-form button text to "⚙ Options"
+- **Tests:** `shared/botSuggestion.test.js` covers phase dispatch. No new frontend harness — manual verification per spec. Existing `npm test` suite must still pass.
+
+---
+
+## Task 1: Add CSS classes for the highlight
+
+**Files:**
+- Modify: `frontend/src/index.css`
+
+- [ ] **Step 1: Append `.card-suggested` and `.btn-suggested` rules**
+
+Add the following at the end of `frontend/src/index.css`:
+
+```css
+/* Bot suggestion highlight — issue #123 */
+.card-suggested {
+  outline: 3px solid #ef4444;
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+.btn-suggested {
+  box-shadow: 0 0 0 2px #ef4444;
+}
+```
+
+- [ ] **Step 2: Run the build to confirm no CSS errors**
+
+```
+npm run build
+```
+
+Expected: build succeeds (the existing "✓ built in …" line appears).
+
+- [ ] **Step 3: Commit**
+
+```
+git add frontend/src/index.css
+git commit -m "feat(ui): add .card-suggested / .btn-suggested CSS for bot hint (#123)"
+```
+
+---
+
+## Task 2: Add pure helper `computeBotSuggestion` with tests
+
+**Files:**
+- Create: `shared/botSuggestion.js`
+- Create: `shared/botSuggestion.test.js`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `shared/botSuggestion.test.js`:
+
+```js
+import { describe, it, expect, vi } from 'vitest'
+import { computeBotSuggestion } from './botSuggestion.js'
+
+// Stub view factories — minimal shapes sufficient for dispatch.
+// Real decision correctness is covered by the botStrategy test suite.
+function playingView({ hands, currentTrick = [] }) {
+  return {
+    phase: 'playing',
+    hands,
+    currentTrick,
+    tricks: [],
+    picker: 'u1',
+    partner: 'u2',
+    calledSuit: 'H',
+    partnerRevealed: false,
+    lastTrick: [],
+    isLeaster: false,
+    reveal_partner: false,
+  }
+}
+
+describe('computeBotSuggestion', () => {
+  it('returns { kind: "play", ids: [cardId] } in playing phase', () => {
+    const view = playingView({ hands: { u1: [{ id: 'QC', suit: 'C', rank: 'Q' }] } })
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('play')
+    expect(result.ids).toEqual(['QC'])
+    expect(result.actionLabel).toBeUndefined()
+  })
+
+  it('returns { kind: "bury", ids: [a, b] } in burying phase', () => {
+    const view = {
+      phase: 'burying',
+      hands: {
+        u1: [
+          { id: 'AC', suit: 'C', rank: 'A' }, { id: 'KC', suit: 'C', rank: 'K' },
+          { id: '9C', suit: 'C', rank: '9' }, { id: '8C', suit: 'C', rank: '8' },
+          { id: '7C', suit: 'C', rank: '7' }, { id: 'AS', suit: 'S', rank: 'A' },
+          { id: 'KS', suit: 'S', rank: 'K' }, { id: '9S', suit: 'S', rank: '9' },
+        ],
+      },
+      picker: 'u1',
+      blind: [],
+      calledSuit: null,
+    }
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('bury')
+    expect(result.ids).toHaveLength(2)
+  })
+
+  it('returns { kind: "pick", actionLabel: "pick"|"pass" } in picking phase', () => {
+    const view = {
+      phase: 'picking',
+      hands: { u1: [
+        { id: 'QC', suit: 'C', rank: 'Q' }, { id: 'QS', suit: 'S', rank: 'Q' },
+        { id: 'QH', suit: 'H', rank: 'Q' }, { id: 'JC', suit: 'C', rank: 'J' },
+        { id: 'AD', suit: 'D', rank: 'A' }, { id: '10D', suit: 'D', rank: '10' },
+      ]},
+      potentialBlitzes: [],
+      pickOrder: ['u1'], pickIndex: 0,
+    }
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('pick')
+    expect(['pick', 'pass', 'blitz']).toContain(result.actionLabel)
+    expect(result.ids).toEqual([])
+  })
+
+  it('returns { kind: "call", actionLabel: "ace:X"|"ten:X"|"king:X"|"go_alone" } in calling phase', () => {
+    const view = {
+      phase: 'calling',
+      hands: { u1: [
+        { id: 'QC', suit: 'C', rank: 'Q' }, { id: 'QS', suit: 'S', rank: 'Q' },
+        { id: 'JC', suit: 'C', rank: 'J' }, { id: 'AD', suit: 'D', rank: 'A' },
+        { id: '9S', suit: 'S', rank: '9' }, { id: '9H', suit: 'H', rank: '9' },
+      ]},
+      picker: 'u1',
+      buried: [],
+    }
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('call')
+    expect(result.actionLabel).toMatch(/^(ace:[CHS]|ten:[CHS]|king:[CHS]|go_alone)$/)
+  })
+
+  it('throws on unknown phase', () => {
+    expect(() => computeBotSuggestion({ phase: 'scoring', hands: { u1: [] } }, 'u1'))
+      .toThrow(/unknown phase/i)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test file and confirm failure**
+
+```
+npm test -- shared/botSuggestion.test.js
+```
+
+Expected: FAIL with "Cannot find module './botSuggestion.js'" or equivalent.
+
+- [ ] **Step 3: Implement `shared/botSuggestion.js`**
+
+Create `shared/botSuggestion.js`:
+
+```js
+// Dispatches on state.phase to the matching bot-strategy decision function.
+// Pure — no side effects, no I/O. Caller is responsible for deciding *when*
+// to call (toggle on, my turn). Errors are thrown; the caller wraps in try/catch.
+import {
+  decidePick, decideBlitz, decideBury, decideCall, decidePlay,
+} from './botStrategy.js'
+
+export function computeBotSuggestion(view, userId) {
+  switch (view.phase) {
+    case 'picking': {
+      const potentialBlitz = (view.potentialBlitzes ?? []).find(b => b.userId === userId)
+      if (potentialBlitz && decideBlitz(view, userId)) {
+        return { kind: 'pick', ids: [], actionLabel: 'blitz' }
+      }
+      const shouldPick = decidePick(view, userId)
+      return { kind: 'pick', ids: [], actionLabel: shouldPick ? 'pick' : 'pass' }
+    }
+
+    case 'burying': {
+      const ids = decideBury(view, userId)
+      return { kind: 'bury', ids }
+    }
+
+    case 'calling': {
+      const decision = decideCall(view, userId)
+      let actionLabel
+      switch (decision.type) {
+        case 'ace':
+        case 'ace_under':
+          actionLabel = `ace:${decision.suit}`
+          break
+        case 'ten':
+          actionLabel = `ten:${decision.suit}`
+          break
+        case 'king':
+          actionLabel = `king:${decision.suit}`
+          break
+        default:
+          actionLabel = 'go_alone'
+      }
+      const ids = decision.type === 'ace_under' && decision.underCardId
+        ? [decision.underCardId]
+        : []
+      return { kind: 'call', ids, actionLabel }
+    }
+
+    case 'playing': {
+      const cardId = decidePlay(view, userId)
+      return { kind: 'play', ids: [cardId] }
+    }
+
+    default:
+      throw new Error(`Unknown phase: ${view.phase}`)
+  }
+}
+```
+
+- [ ] **Step 4: Re-run tests to confirm they pass**
+
+```
+npm test -- shared/botSuggestion.test.js
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Run the full suite to confirm no regressions**
+
+```
+npm test
+```
+
+Expected: all existing tests still pass (210 pre-existing + 5 new = 215, approximately).
+
+- [ ] **Step 6: Commit**
+
+```
+git add shared/botSuggestion.js shared/botSuggestion.test.js
+git commit -m "feat(bot): add computeBotSuggestion phase-dispatch helper (#123)"
+```
+
+---
+
+## Task 3: `Card` — accept `suggested` prop and apply class
+
+**Files:**
+- Modify: `frontend/src/components/Card.jsx`
+
+- [ ] **Step 1: Add the `suggested` prop and compose into class list**
+
+Replace the entire function body of `Card` (lines 9-49) with:
+
+```js
+export default function Card({ card, playable = false, selected = false, suggested = false, onClick }) {
+  if (!card || card.hidden) {
+    const hiddenClasses = [
+      'card', 'card-img', 'hidden',
+      playable  ? 'playable'       : '',
+      selected  ? 'selected'       : '',
+      suggested ? 'card-suggested' : '',
+    ].filter(Boolean).join(' ')
+    return (
+      <div
+        className={hiddenClasses}
+        aria-label={card?.isUnderCard ? 'Under card' : 'Hidden card'}
+        title={card?.isUnderCard ? 'Under card' : undefined}
+        onClick={playable ? onClick : undefined}
+        role={playable ? 'button' : undefined}
+      >
+        <img src={CARD_BACK_SRC} alt="Card back" className="card-image" />
+      </div>
+    )
+  }
+
+  const trump = isTrump(card)
+
+  const classes = [
+    'card',
+    'card-img',
+    trump     ? 'trump'          : '',
+    playable  ? 'playable'       : '',
+    selected  ? 'selected'       : '',
+    suggested ? 'card-suggested' : '',
+  ].filter(Boolean).join(' ')
+
+  return (
+    <div
+      className={classes}
+      onClick={playable ? onClick : undefined}
+      title={trump ? `${card.id} (trump)` : card.id}
+      role={playable ? 'button' : undefined}
+    >
+      <img src={cardImageSrc(card.id)} alt={card.id} className="card-image" />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```
+git add frontend/src/components/Card.jsx
+git commit -m "feat(ui): add suggested prop to Card for bot-hint highlight (#123)"
+```
+
+---
+
+## Task 4: `Hand` — accept `suggestedIds` prop and forward
+
+**Files:**
+- Modify: `frontend/src/components/Hand.jsx`
+
+- [ ] **Step 1: Add `suggestedIds` prop and forward to each `Card`**
+
+Replace the Hand component (lines 21-41) with:
+
+```js
+export default function Hand({ cards = [], playableIds = null, selectedIds = [], suggestedIds = null, onCardClick }) {
+  const sorted = sortHand(cards)
+
+  return (
+    <div className="hand">
+      {sorted.map(card => {
+        const playable  = playableIds === null ? false : playableIds.includes(card.id)
+        const selected  = selectedIds.includes(card.id)
+        const suggested = suggestedIds !== null && suggestedIds.includes(card.id)
+        return (
+          <Card
+            key={card.id}
+            card={card}
+            playable={playable}
+            selected={selected}
+            suggested={suggested}
+            onClick={() => onCardClick?.(card)}
+          />
+        )
+      })}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```
+git add frontend/src/components/Hand.jsx
+git commit -m "feat(ui): thread suggestedIds through Hand to Card (#123)"
+```
+
+---
+
+## Task 5: `ActionPanel` — accept `suggestedAction`, apply to matching buttons
+
+**Files:**
+- Modify: `frontend/src/components/ActionPanel.jsx`
+
+- [ ] **Step 1: Add `suggestedAction` and `suggestedIds` props to the function signature**
+
+Replace line 6 (the `export default function ActionPanel(...)` signature) with:
+
+```js
+export default function ActionPanel({ state, myUserId, myHand, onAction, loading, actingForName, suggestedAction = null, suggestedIds = null }) {
+```
+
+- [ ] **Step 2: Define a small className helper just below the signature**
+
+Insert after line 6 (inside the function body, near the top, before `const botStyle`):
+
+```js
+  const suggestedClass = (label) => (suggestedAction === label ? 'btn-suggested' : '')
+```
+
+- [ ] **Step 3: Apply to the picking-phase buttons**
+
+In the picking block (lines 86-93), update the three action buttons:
+
+```js
+          {playerBlitz?.type === 'black' && (
+            <button className={suggestedClass('blitz')} onClick={() => act('blitz')} disabled={loading}>Black Blitz?</button>
+          )}
+          {playerBlitz?.type === 'red' && (
+            <button className={suggestedClass('blitz')} onClick={() => act('blitz')} disabled={loading}>Red Blitz?</button>
+          )}
+          <button className={suggestedClass('pick')} onClick={() => act('pick')} disabled={loading}>Pick the Blind?</button>
+          <button className={`secondary ${suggestedClass('pass')}`} onClick={() => act('pass')} disabled={loading}>Pass</button>
+```
+
+- [ ] **Step 4: Apply to the burying-phase Hand**
+
+In the burying block (lines 112-131), forward `suggestedIds` to the `<Hand>`:
+
+```js
+        <Hand
+          cards={myHand}
+          playableIds={myHand.map(c => c.id)}
+          selectedIds={selectedBuried.map(c => c.id)}
+          suggestedIds={suggestedIds}
+          onCardClick={toggleBury}
+        />
+```
+
+- [ ] **Step 5: Apply to calling-phase suit buttons (king, ten, ace, ace-under)**
+
+For each of the three `callMode` blocks (king, ten, ace), compose `suggestedClass('king:${suit}')` / `suggestedClass('ten:${suit}')` / `suggestedClass('ace:${suit}')` into the button's `className`. Example for king (lines 158-167):
+
+```js
+            {callableSuits.map(suit => (
+              <button
+                key={suit}
+                className={`suit-btn ${suit === 'H' ? 'red' : 'black'} ${suggestedClass(`king:${suit}`)}`}
+                onClick={() => act('call_king', { suit })}
+                disabled={loading}
+                title={`Call K${suit}`}
+              >
+                K{SUIT_SYMBOLS[suit]}
+              </button>
+            ))}
+```
+
+Repeat the same pattern for ten mode (replace `king:` with `ten:`) and ace mode (replace with `ace:`). The under-call buttons in ace mode should also use `ace:${suit}` — the bot's `ace_under` decision maps to the same `actionLabel`, so the same button highlights.
+
+- [ ] **Step 6: Apply to the Go Alone button**
+
+Replace the `goAloneSection` (lines 17-50). The only change is the button inside the non-confirming branch (line 41-48):
+
+```js
+        <button
+          className={`secondary ${suggestedClass('go_alone')}`}
+          onClick={() => setConfirmingAlone(true)}
+          disabled={loading}
+        >
+          Go Alone
+        </button>
+```
+
+- [ ] **Step 7: Forward `suggestedIds` to the under-card-selection sub-view `<Hand>`**
+
+In the Situation B sub-view (lines 213-247), update the inner `<Hand>` call (lines 222-227):
+
+```js
+          <Hand
+            cards={myHand}
+            playableIds={myHand.map(c => c.id)}
+            selectedIds={selectedUnderCard ? [selectedUnderCard] : []}
+            suggestedIds={suggestedIds}
+            onCardClick={(card) => setSelectedUnderCard(card.id)}
+          />
+```
+
+- [ ] **Step 8: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 9: Commit**
+
+```
+git add frontend/src/components/ActionPanel.jsx
+git commit -m "feat(ui): thread suggestedAction/suggestedIds through ActionPanel (#123)"
+```
+
+---
+
+## Task 6: `GameOptionsPanel` — add `role` prop and read-only layout
+
+**Files:**
+- Modify: `frontend/src/components/GameOptionsPanel.jsx`
+
+- [ ] **Step 1: Add new props to the signature**
+
+Replace line 16 with:
+
+```js
+export default function GameOptionsPanel({
+  mode, gameId, open, values, onChange, onUpdated, onClose,
+  role = 'admin',
+  botSuggestionEnabled = false,
+  onBotSuggestionChange = null,
+}) {
+```
+
+- [ ] **Step 2: Replace the three form-option sections with a role-aware render**
+
+Replace the entire JSX block from the opening `<dialog>` (line 126) through the closing `</dialog>` (line 210) with the following. Preserve the existing `dialogRef`, `onClose`, and header semantics.
+
+```jsx
+  const isReadOnly = role === 'player'
+  const VARIANT_DISPLAY = { doublers: 'Doublers', leasters: 'Leasters', schwanzers: 'Schwanzers' }
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className="game-options-dialog"
+      onClose={handleDialogClose}
+    >
+      <strong style={{ fontSize: '0.95rem' }}>⚙ Game options</strong>
+      {mode === 'update' && !isReadOnly && (
+        <small style={{ color: '#aaa', display: 'block', marginBottom: 12, marginTop: 2 }}>
+          Changes take effect next hand
+        </small>
+      )}
+      {isReadOnly && (
+        <small style={{ color: '#aaa', display: 'block', marginBottom: 12, marginTop: 2 }}>
+          Only the game admin can change these
+        </small>
+      )}
+      {mode === 'create' && (
+        <div style={{ marginBottom: 12 }} />
+      )}
+
+      {isReadOnly ? (
+        <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', rowGap: 6, columnGap: 16, marginBottom: 16, fontSize: '0.85rem' }}>
+          <span style={{ color: '#aaa' }}>No-pick variant</span>
+          <span>{VARIANT_DISPLAY[variant] ?? variant}</span>
+          <span style={{ color: '#aaa' }}>Partner visibility</span>
+          <span>{reveal ? 'Shown' : 'Hidden'}</span>
+          <span style={{ color: '#aaa' }}>Double on bump</span>
+          <span>{dob ? 'On' : 'Off'}</span>
+        </div>
+      ) : (
+        <>
+          {/* No-pick variant */}
+          <div style={{ marginBottom: 12 }}>
+            <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant</div>
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              {['doublers', 'leasters', 'schwanzers'].map(v => (
+                <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+                  <input
+                    type="radio"
+                    name={`variant-${gameId ?? 'create'}`}
+                    value={v}
+                    checked={variant === v}
+                    onChange={() => handleVariantChange(v)}
+                    disabled={saving}
+                  />
+                  {VARIANT_LABELS[v]}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Identify partner */}
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>
+              Partner Visibility
+            </div>
+            <div style={{ display: 'flex', gap: 12 }}>
+              {[false, true].map(v => (
+                <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+                  <input
+                    type="radio"
+                    name={`reveal-${gameId ?? 'create'}`}
+                    value={String(v)}
+                    checked={reveal === v}
+                    onChange={() => handleRevealChange(v)}
+                    disabled={saving}
+                  />
+                  {v ? 'Shown' : 'Hidden'}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Double on the Bump */}
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem' }}>
+              Double on the Bump?
+              <input
+                type="checkbox"
+                checked={dob}
+                onChange={e => handleDobChange(e.target.checked)}
+                disabled={saving}
+              />
+            </label>
+          </div>
+        </>
+      )}
+
+      {/* Your preferences — hidden in create mode (no game yet) */}
+      {mode !== 'create' && onBotSuggestionChange && (
+        <div style={{ marginTop: 4, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,0.15)', marginBottom: 16 }}>
+          <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 6 }}>Your preferences</div>
+          <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, cursor: 'pointer', fontSize: '0.85rem' }}>
+            <input
+              type="checkbox"
+              checked={botSuggestionEnabled}
+              onChange={e => onBotSuggestionChange(e.target.checked)}
+              disabled={saving}
+              style={{ marginTop: 3 }}
+            />
+            <span>
+              Show Bot Suggestion
+              <small style={{ display: 'block', color: '#888', marginTop: 2 }}>
+                Highlights the card the bot would play on your turn. Purely advisory — useful for learning the game or comparing against the bot's strategy.
+              </small>
+            </span>
+          </label>
+        </div>
+      )}
+
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ fontSize: '0.82rem' }}>
+          {mode === 'update' && saving && <span style={{ color: '#aaa' }}>Saving…</span>}
+          {mode === 'update' && error  && <span style={{ color: '#f87171' }}>{error}</span>}
+        </div>
+        <button
+          type="button"
+          onClick={handleDone}
+          disabled={saving}
+          style={{ fontSize: '0.85rem', padding: '4px 16px' }}
+        >
+          Done
+        </button>
+      </div>
+    </dialog>
+  )
+```
+
+- [ ] **Step 3: Guard the Done-handler against player-role writes**
+
+Replace `handleDone` (lines 81-112) so a player role never PATCHes, regardless of whether the UI would let it:
+
+```js
+  async function handleDone() {
+    if (mode !== 'update' || role === 'player') {
+      committedRef.current = true
+      onClose?.()
+      return
+    }
+    const initial = initialRef.current
+    const changed = {}
+    if (variant !== initial.no_pick_variant) changed.no_pick_variant = variant
+    if (reveal  !== initial.reveal_partner)  changed.reveal_partner  = reveal
+    if (dob     !== initial.double_on_bump)  changed.double_on_bump  = dob
+
+    if (Object.keys(changed).length === 0) {
+      committedRef.current = true
+      onClose?.()
+      return
+    }
+
+    setSaving(true)
+    setError(null)
+    try {
+      const result = await api.games.updateSettings(gameId, { ...changed, log_change: true })
+      onUpdated?.(result)
+      committedRef.current = true
+      onClose?.()
+    } catch (e) {
+      setError(e?.message ?? 'Failed to save.')
+    } finally {
+      setSaving(false)
+    }
+  }
+```
+
+- [ ] **Step 4: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```
+git add frontend/src/components/GameOptionsPanel.jsx
+git commit -m "feat(ui): add role + botSuggestion props to GameOptionsPanel (#123)"
+```
+
+---
+
+## Task 7: `LobbyPage` — rename Edit → Options on create form
+
+**Files:**
+- Modify: `frontend/src/pages/LobbyPage.jsx`
+
+- [ ] **Step 1: Rename the button label**
+
+On `frontend/src/pages/LobbyPage.jsx` line 156, change `⚙ Edit` to `⚙ Options`. The button is the one inside the `{showCreate && …}` create-game form.
+
+- [ ] **Step 2: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```
+git add frontend/src/pages/LobbyPage.jsx
+git commit -m "feat(ui): rename create-form game options button to Options (#123)"
+```
+
+---
+
+## Task 8: `GamePage` — localStorage-backed `showBotSuggestion` state
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Add the state and change handler**
+
+Near the top of the component, alongside the other `useState` declarations (e.g. next to `setCurrentVariant`), insert:
+
+```js
+  const [showBotSuggestion, setShowBotSuggestion] = useState(() => {
+    try {
+      return localStorage.getItem('sheepshead:showBotSuggestion') === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  const handleBotSuggestionChange = (next) => {
+    setShowBotSuggestion(next)
+    try {
+      localStorage.setItem('sheepshead:showBotSuggestion', next ? 'true' : 'false')
+    } catch {
+      // localStorage unavailable — in-memory state still updates.
+    }
+  }
+```
+
+- [ ] **Step 2: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```
+git add frontend/src/pages/GamePage.jsx
+git commit -m "feat(ui): persist showBotSuggestion in localStorage (#123)"
+```
+
+---
+
+## Task 9: `GamePage` — import botSuggestion helper and compute in `useMemo`
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Add the import at the top of the file**
+
+Near the existing `@shared/` imports in `GamePage.jsx`, add:
+
+```js
+// NOTE: Importing the bot strategy here bundles its full logic into the
+// shipped JS. The logic is already documented in docs/BOTS.md, so this
+// exposure is acceptable. See issue #123.
+import { computeBotSuggestion } from '@shared/botSuggestion.js'
+```
+
+- [ ] **Step 2: Add the `useMemo` after `effectiveUserId` / `turnUserId` are defined**
+
+Immediately after the existing `isMyPlayingTurn` / `legalIds` computation (around line 604-605), add:
+
+```js
+  const botSuggestion = useMemo(() => {
+    if (!showBotSuggestion) return null
+    if (!turnUserId || turnUserId !== effectiveUserId) return null
+    try {
+      return computeBotSuggestion(state, effectiveUserId)
+    } catch (err) {
+      console.warn('[botSuggestion] computation failed:', err)
+      return null
+    }
+  }, [showBotSuggestion, turnUserId, effectiveUserId, state])
+```
+
+Add `useMemo` to the `import { useState, useEffect } from 'react'` line if it's not already imported.
+
+- [ ] **Step 3: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Commit**
+
+```
+git add frontend/src/pages/GamePage.jsx
+git commit -m "feat(ui): compute botSuggestion in GamePage via useMemo (#123)"
+```
+
+---
+
+## Task 10: `GamePage` — thread props into `Hand`/`ActionPanel` and open Options to non-admins (waiting state)
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Replace the waiting-state admin/non-admin branch with a unified Options button**
+
+In the `if (status === 'waiting')` block (roughly lines 414-462), replace the `{isGameAdmin ? (...) : (...)}` branch with a single unified render. The goal: both admin and non-admin see an Options button; the modal's `role` prop branches.
+
+```jsx
+        <div style={{ marginTop: 8 }}>
+          <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
+            <SettingsSummary
+              settings={currentSettings}
+              style={{ color: '#ccc', fontSize: '0.85rem' }}
+            />
+            <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+              onClick={() => setShowOptions(true)}>
+              ⚙ Options
+            </button>
+          </div>
+        </div>
+        <GameOptionsPanel
+          mode="update"
+          gameId={gameId}
+          open={showOptions}
+          values={currentSettings}
+          onUpdated={handleSettingsUpdate}
+          onClose={() => setShowOptions(false)}
+          role={isGameAdmin ? 'admin' : 'player'}
+          botSuggestionEnabled={showBotSuggestion}
+          onBotSuggestionChange={handleBotSuggestionChange}
+        />
+```
+
+- [ ] **Step 2: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```
+git add frontend/src/pages/GamePage.jsx
+git commit -m "feat(ui): open Options to non-admin players in waiting state (#123)"
+```
+
+---
+
+## Task 11: `GamePage` — in-game Options button + suggestion props wired to `Hand`/`ActionPanel`
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+- [ ] **Step 1: Replace the in-game admin/non-admin branch in the right-panel**
+
+In the right-panel options block (roughly lines 635-663), replace the `{isGameAdmin ? (...) : (...)}` branch with:
+
+```jsx
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+            <SettingsSummary
+              settings={currentSettings}
+              style={{ color: '#aaa', fontSize: '0.78rem' }}
+            />
+            <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+              onClick={() => setShowOptions(true)}>
+              ⚙ Options
+            </button>
+          </div>
+          <GameOptionsPanel
+            mode="update"
+            gameId={gameId}
+            open={showOptions}
+            values={currentSettings}
+            onUpdated={handleSettingsUpdate}
+            onClose={() => setShowOptions(false)}
+            role={isGameAdmin ? 'admin' : 'player'}
+            botSuggestionEnabled={showBotSuggestion}
+            onBotSuggestionChange={handleBotSuggestionChange}
+          />
+```
+
+- [ ] **Step 2: Derive `suggestedIdsForHand` and `suggestedActionForPanel` near the bottom of the component**
+
+Just before the `return` statement that renders the game table, add:
+
+```js
+  const suggestedIdsForHand = botSuggestion &&
+    (botSuggestion.kind === 'play' || botSuggestion.kind === 'bury')
+      ? botSuggestion.ids
+      : null
+
+  // Pass ids through in the call phase too (for the ace_under sub-view's inner Hand).
+  const suggestedIdsForActionPanel = botSuggestion &&
+    (botSuggestion.kind === 'call' || botSuggestion.kind === 'bury')
+      ? botSuggestion.ids
+      : null
+
+  const suggestedActionForPanel = botSuggestion?.actionLabel ?? null
+```
+
+- [ ] **Step 3: Thread `suggestedIds` into the player's bottom-seat `<Hand>` render**
+
+Locate the `<Hand cards={activeHand} ... />` render in the bottom seat (inside `seat-bottom`). Add the `suggestedIds` prop:
+
+```jsx
+              <Hand
+                cards={activeHand}
+                playableIds={state.phase === 'playing' && isMyPlayingTurn ? legalIds : null}
+                selectedIds={[]}
+                suggestedIds={suggestedIdsForHand}
+                onCardClick={handlePlayCard}
+              />
+```
+
+(The exact surrounding props may differ — keep all existing props, add `suggestedIds={suggestedIdsForHand}`.)
+
+- [ ] **Step 4: Thread `suggestedAction` and `suggestedIds` into `<ActionPanel>`**
+
+Locate the `<ActionPanel ... />` render. Add:
+
+```jsx
+          <ActionPanel
+            state={state}
+            myUserId={effectiveUserId}
+            myHand={activeHand}
+            onAction={...existing}
+            loading={...existing}
+            actingForName={actingForPlayer?.username}
+            suggestedAction={suggestedActionForPanel}
+            suggestedIds={suggestedIdsForActionPanel}
+          />
+```
+
+- [ ] **Step 5: Confirm build still succeeds**
+
+```
+npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 6: Run the full test suite**
+
+```
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```
+git add frontend/src/pages/GamePage.jsx
+git commit -m "feat(ui): open Options to non-admin in-game; thread bot hint props (#123)"
+```
+
+---
+
+## Task 12: Manual verification walkthrough
+
+**Files:** none — this is a verification pass.
+
+- [ ] **Step 1: Start the dev environment**
+
+```
+npm run dev
+```
+
+Open http://localhost:3000 in a browser.
+
+- [ ] **Step 2: Verify lobby create form**
+
+- Open New Game. Click ⚙ Options (renamed). Confirm the modal opens with game-option form inputs and NO "Your preferences" section (create mode hides it).
+- Close, create a game with bots.
+
+- [ ] **Step 3: Verify non-admin read-only Options**
+
+- In a second browser (or incognito window), sign in as a different user, join the game.
+- In that second browser, click ⚙ Options.
+- Confirm: a key-value list (no form controls) showing the current settings, plus a "Your preferences" section with the Show Bot Suggestion checkbox.
+- Toggle the checkbox on. Close the modal.
+
+- [ ] **Step 4: Verify highlight appears on your turn (play phase)**
+
+- In the second browser, wait for the hand to reach the playing phase and for your turn.
+- Confirm exactly one card in your hand has a red outline (the bot's recommended play).
+- Confirm the outline does NOT change while you hover other cards.
+
+- [ ] **Step 5: Verify highlight on pick/pass/blitz, bury, and call phases**
+
+- Start a new hand. On a turn where you are the first picker, confirm Pick or Pass is outlined (or Blitz if you hold Q♣ and qualify).
+- When you pick, confirm the bury screen shows exactly two red-outlined cards.
+- When you call, confirm the recommended suit button is outlined (or Go Alone).
+
+- [ ] **Step 6: Verify toggle off hides the highlight**
+
+- Open ⚙ Options, uncheck Show Bot Suggestion, close.
+- Confirm no red outlines appear on any turn.
+
+- [ ] **Step 7: Verify persistence across reload**
+
+- Enable the toggle, reload the page.
+- Confirm the toggle is still on and the hint reappears on your next turn.
+
+- [ ] **Step 8: Verify admin view is unchanged**
+
+- In the first browser (the admin), click ⚙ Options. Confirm the form controls are editable as before, and the "Your preferences" section is present at the bottom.
+- Change a game option and click Done. Confirm the change persists (this exercises that the player-role guard does not interfere with admin writes).
+
+- [ ] **Step 9: Confirm production build**
+
+```
+npm run build
+```
+
+Expected: build succeeds with no new warnings.
+
+- [ ] **Step 10: Commit a tag-only verification note (optional)**
+
+If a manual-verification note in the PR description is desired, record it there rather than in code. No further commit needed from this task.
+
+---
+
+## Out of scope (tracked separately)
+
+- Reasoning tooltip on the highlighted element → https://github.com/andynumber2/sheepshead/issues/140
+- Cross-device sync of the preference — not planned
+- Spectator highlights — blocked on spectator mode (https://github.com/andynumber2/sheepshead/issues/75)
+- Alternative candidate plays — not requested

--- a/docs/superpowers/specs/2026-04-19-bot-suggestion-highlight-design-for-PMs.md
+++ b/docs/superpowers/specs/2026-04-19-bot-suggestion-highlight-design-for-PMs.md
@@ -1,0 +1,89 @@
+# Bot Suggestion Highlight — For PMs
+
+Tracks https://github.com/andynumber2/sheepshead/issues/123.
+
+## What we're building
+
+A new, optional visual cue that shows each human player what the game's bot would choose on their turn. When the cue is turned on, the recommended card (or action button) is outlined in red in the player's own view. The player is still free to do whatever they want — the red outline is a hint, nothing more.
+
+Alongside this, the in-game "Options" panel is being reworked so every player — not just the game's admin — can open it. Non-admins see the active game rules as read-only information, and they get one personal toggle: **Show Bot Suggestion**.
+
+## Why we're building it
+
+The feature serves two audiences at once:
+
+- **Developers and testers debugging the bot.** We're actively iterating on the bot's strategy, and today the only way to notice a bad bot decision is to watch a bot play and catch the moment. With this feature, the bot's recommendation is on-screen during every human turn — so any human player (the developer, a tester, an opinionated friend) can immediately compare it against what they think the right play is. Misplays that used to require a post-game replay to find can be spotted live.
+- **Newer or less experienced human players.** Sheepshead has a steep learning curve — pick/pass decisions, partner calls, and trump management are hard to reason about at first. The same highlight that helps us find bot bugs doubles as a learning scaffold: a player who turns it on sees a plausible, competent play every turn and can learn the game by comparing their intuition against the bot's recommendation. The bot is not always optimal, but it is consistently reasonable, which is exactly what a new player benefits from.
+
+This dual framing is intentional. The implementation is the same either way; we just get to serve two audiences with one feature.
+
+**Where this could eventually go.** The hint in this feature is voluntary and static. A natural extension is a proper **tutorial mode**: guided play, forced decisions, explanatory text, scenarios designed to illustrate specific concepts (e.g. "when to pass a marginal hand," "how to call on a short partner"). That would build on top of the same underlying machinery introduced here — the ability to surface what a competent player would do at any decision point. The tutorial mode is explicitly out of scope for this issue, but nothing in this design forecloses it.
+
+The Options-panel rework is necessary plumbing: the toggle needs a home, and the natural home is the existing settings modal. Giving non-admins read-only visibility into game options is a nice side effect — it closes an information gap from the prior iteration where non-admins couldn't see things like the Double-on-Bump or Partner-visibility rules without asking the admin.
+
+## How it behaves
+
+- **Scope of the hint.** The hint covers all four decision points a player hits during a hand:
+  - **Pick, pass, or blitz** (during the picking phase, including the optional "Black/Red Blitz" action when the player qualifies)
+  - **Bury** (once the picker has taken the blind and must tuck away two cards)
+  - **Call** (the picker's choice of which partner card to call)
+  - **Play** (every normal trick-taking decision)
+- **Visual treatment.** A red outline on the recommended card in the player's hand, or a red outline on the recommended button. The outline is always additive — a card can still show its normal "legal to play" highlight, and the bot hint layers on top. Red was chosen to be visually distinct from the existing green "playable" highlight.
+- **When it appears.** Only when it is the player's turn and the player has the toggle switched on. Other players' turns show nothing — the hint is purely a personal view.
+- **Who sees it.** Any seated human player. Spectators (a feature not yet built) are not covered. In admin test mode, where the admin can act on behalf of a bot, the hint works too — which is actually the most useful debugging scenario.
+
+## How the Options panel changes
+
+- Today, only the game's admin sees an "Edit" button on the options panel. The button is renamed "⚙ Options" and shown to all players.
+- When an admin opens it, nothing changes — they still have full control of the game settings.
+- When a non-admin opens it, the three game settings (no-pick variant, partner visibility, double-on-bump) appear as a plain read-only list. We deliberately avoided showing disabled form controls — seeing grayed-out radio buttons is confusing and suggests a broken UI.
+- Regardless of role, a new "Your preferences" section appears at the bottom of the modal, separated from the game settings. For this feature it contains one checkbox: **Show Bot Suggestion**. The section is a natural home for future personal toggles (theme, sound, etc.), though none are planned right now.
+
+## Where the preference is stored
+
+The Show Bot Suggestion toggle is stored in the browser locally — **not on the server**. This means:
+
+- Turning it on persists across page reloads on the same browser.
+- Opening the app on a different device (phone, laptop) starts with the toggle off until you turn it on there.
+- The server does not know or care what the toggle's value is — it is a pure client-side visual aid.
+
+This was an intentional choice. The toggle is a personal debugging preference, nobody else needs to know about it, and keeping it out of the database avoids a schema migration and new API endpoints for what is essentially an optional UI setting. If we later decide to store a meaningful set of per-user preferences (e.g., theme, notification settings), we'd move this toggle to that system then.
+
+## Critical logic the spec captures
+
+### Where the bot recommendation comes from
+
+The bot's decision code already exists in the project as a shared module — it is the same code the server runs when a bot takes its turn. This feature imports that module into the browser and calls it directly against the game state the player already sees. There is no new server endpoint, no API round-trip per turn, and no risk of the client and server disagreeing about what the bot would choose (because it's literally the same code).
+
+One consequence to flag: importing the bot strategy in the browser means the full strategy logic gets shipped to every player's browser as part of the app bundle. A curious player could read it in their browser's developer tools. We accept this exposure because the strategy is already publicly documented in the project's `BOTS.md` file — nothing is being revealed that wasn't already readable from the repo.
+
+### When the hint is computed
+
+The hint recomputes automatically whenever the game state changes or the toggle is flipped. The computation is lazy and memoized, so it doesn't run repeatedly in the background — only when something relevant has actually changed. If an unexpected error ever occurs inside the bot code, the hint silently disappears for that turn (and a developer-only warning goes into the browser console). The game itself is never affected by a bad hint.
+
+### No impact on authoritative gameplay
+
+Nothing about this feature changes what actions are legal, what the server accepts, what other players see, or how scoring works. A player who disables the hint sees exactly the same game as they do today. A player who enables it and follows the bot's advice plays the same cards they would have been allowed to play anyway — the server validates every action independently.
+
+## Success criteria
+
+We'll consider this shipped successfully when:
+
+1. With the toggle on, a human player sees red outlines on their screen identifying exactly what the bot would do — across all four phases of a hand.
+2. Toggling the preference takes effect on the current turn and persists across reloads on the same browser.
+3. Any player can open the Options modal. Admins still fully control the game settings; non-admins see those settings as read-only and have their personal toggle.
+4. No server-side code, database schema, or API endpoints need to change.
+5. The existing bot test suite continues to pass with no modifications — a small set of targeted frontend tests covers the new wiring without duplicating strategy coverage.
+
+## Out of scope / deferred
+
+- **Showing *why* the bot chose a given card.** Hovering the highlighted card could show an explanation like "leading highest trump as picker team." This was identified as valuable but deferred to a separate issue (https://github.com/andynumber2/sheepshead/issues/140) because it requires refactoring the entire bot-decision code to emit reason tags alongside each decision. Delivering the visual highlight first means that follow-up work has somewhere to attach.
+- **Cross-device sync of the toggle.** If you enable the hint on your laptop, it stays off on your phone until you enable it there too.
+- **Showing hints to spectators.** Spectator mode isn't fully implemented in the product today; it is tracked separately at https://github.com/andynumber2/sheepshead/issues/75 and will be considered then.
+- **Showing alternative candidate plays the bot considered.** Not requested; would add significant complexity for marginal debug value.
+- **A tooltip/callout explaining the bot's belief state** (what it thinks the partner might hold, trump count remaining, etc.). Tracked as part of the recap/replay feature at https://github.com/andynumber2/sheepshead/issues/125 — that feature is a historical/post-hoc view; this feature is a live view.
+
+## Relationships
+
+- **Blocks** https://github.com/andynumber2/sheepshead/issues/140 (live bot-reasoning tooltip), which attaches to the highlight this feature introduces.
+- **Builds on** https://github.com/andynumber2/sheepshead/issues/114 (game-mode visibility for non-admins), which is extended here from a one-line summary into a full read-only Options view.

--- a/docs/superpowers/specs/2026-04-19-bot-suggestion-highlight-design.md
+++ b/docs/superpowers/specs/2026-04-19-bot-suggestion-highlight-design.md
@@ -1,0 +1,157 @@
+# Bot Suggestion Highlight — Design
+
+Tracks https://github.com/andynumber2/sheepshead/issues/123.
+
+## Summary
+
+Add an opt-in, per-player visual indicator that highlights what the bot strategy would choose on the human player's turn. The indicator is a red outline on the relevant card(s) or action button(s). The toggle lives inside the game Options modal, which is simultaneously refactored so non-admin players can open it (read-only game settings + personal preferences).
+
+## Motivation
+
+Two overlapping uses:
+
+1. **Bot debugging.** Seeing what the bot *would* do on every human turn makes misplays easy to spot during normal play, without waiting for a bot to act.
+2. **Gameplay / learning aid.** New or inexperienced Sheepshead players can use the highlight to learn conventional play patterns. The same mechanism that helps us find bot bugs also helps a human understand *what a competent player does in this situation* — the bot encodes a reasonable strategy, and surfacing it turns every turn into a small lesson.
+
+This dual use is deliberate and costs us nothing — the same code and UI serves both audiences. It also sets up a natural extension path: a future **tutorial mode** could use the same highlight machinery plus guided prompts and forced decisions to teach the game end-to-end. That is out of scope here, but the design does not foreclose it.
+
+## Scope
+
+- Highlight the bot's choice on all four player decisions: pick/pass, bury, call, and play.
+- Let any player open the Options modal. Non-admins see game settings as read-only; their only editable field is the personal "Show Bot Suggestion" toggle.
+- Store the toggle client-side (localStorage), per browser.
+
+**Out of scope** (see "Deferred" below): reasoning tooltips, cross-device sync, spectator highlights, alternative-candidate display.
+
+## Architecture
+
+The change is entirely in the frontend. No server or DB changes.
+
+### Components touched
+
+| File                                          | Change                                                                                                        |
+|-----------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| `frontend/src/components/GameOptionsPanel.jsx` | Add `role` prop; render game settings as read-only list for `role='player'`; add "Your preferences" section. |
+| `frontend/src/pages/GamePage.jsx`             | Drop admin-only gating of Options button; compute `botSuggestion` via `useMemo`; pass down props.             |
+| `frontend/src/pages/LobbyPage.jsx`            | Rename button "Edit" → "Options". Preferences section hidden in create mode.                                   |
+| `frontend/src/components/Hand.jsx`            | New `suggestedIds` prop; apply `card-suggested` class.                                                        |
+| `frontend/src/components/ActionPanel.jsx`     | New `suggestedAction` prop; apply `btn-suggested` class to the matching button.                               |
+| `frontend/src/components/Card.jsx`            | No prop change; the `card-suggested` class is applied by `Hand` via the wrapper.                              |
+| CSS (existing stylesheet)                     | Add `.card-suggested` and `.btn-suggested` rules.                                                             |
+
+### Options modal refactor
+
+`GameOptionsPanel` gains a `role: 'admin' | 'player'` prop (default `'admin'` for backward compatibility):
+
+- **`role === 'admin'`** — current behaviour preserved: radios and checkboxes editable, Done button commits changed fields via `PATCH /api/games/:id/settings`.
+- **`role === 'player'`** — game-option inputs are *not rendered* at all. Instead, a compact key-value block shows each option's current value:
+  ```
+  No-pick variant     Doublers
+  Partner visibility  Hidden
+  Double on bump      On
+  ```
+  No disabled form controls. This avoids implying interactivity where there is none.
+
+A new **"Your preferences"** section is added at the bottom of the modal, separated by a thin top border. For v1 it contains exactly one control: a checkbox labelled **"Show Bot Suggestion"** with sub-copy "Highlights the card the bot would play on your turn. Purely advisory — useful for learning the game or comparing against the bot's strategy."
+
+The preference's value is owned by the parent (`GamePage`). `GameOptionsPanel` receives `botSuggestionEnabled: boolean` and `onBotSuggestionChange(next: boolean): void` props. The panel itself never touches localStorage.
+
+The "Your preferences" section is **hidden** when `mode === 'create'` — there is no active game yet, so the toggle has no effect.
+
+Button label in all three call sites (LobbyPage create-form, GamePage waiting, GamePage in-game) renames from "⚙ Edit" to "⚙ Options".
+
+### Bot suggestion computation
+
+`GamePage.jsx` computes the suggestion in a `useMemo` hook that depends on `state`, `effectiveUserId`, `turnUserId`, and `showBotSuggestion`:
+
+- Returns `null` when the toggle is off or when it is not the effective player's turn.
+- Dispatches on `state.phase` to the matching decision function from `shared/botStrategy.js`.
+- Wrapped in `try/catch`: on any thrown error, returns `null` and logs `console.warn`. A broken bot suggestion must never break the game UI.
+
+Return shape:
+
+```
+{ kind: 'pick' | 'bury' | 'call' | 'play',
+  ids: string[],              // card IDs to highlight (empty for non-card decisions)
+  actionLabel?: string }       // e.g. 'pick', 'pass', 'go_alone', 'ace:H'
+```
+
+| phase    | decision function(s)                   | `kind`  | `ids`                   | `actionLabel`                                                         |
+|----------|----------------------------------------|---------|-------------------------|-----------------------------------------------------------------------|
+| picking  | `decideBlitz` → `decidePick`           | `pick`  | `[]`                    | `'blitz'` / `'pick'` / `'pass'`                                       |
+| burying  | `decideBury`                           | `bury`  | `[cardId, cardId]`      | `undefined`                                                           |
+| calling  | `decideCall`                           | `call`  | `[]`                    | `'ace:<suit>'` / `'ten:<suit>'` / `'king:<suit>'` / `'go_alone'`       |
+| playing  | `decidePlay`                           | `play`  | `[cardId]`              | `undefined`                                                           |
+
+**Picking-phase dispatch mirrors the server's bot flow** (`functions/api/_botHelpers.js`). If the player has a `potentialBlitzes` entry *and* `decideBlitz` returns true → `actionLabel: 'blitz'`. Otherwise fall through to `decidePick`: true → `'pick'`, false → `'pass'`. `ActionPanel` highlights the matching button.
+
+**Call decision — `ace_under` (Situation B).** When `decideCall` returns `{ type: 'ace_under', suit, underCardId }`, the `actionLabel` is `'ace:<suit>'` so the suit button is highlighted on the initial call screen (same as a normal `'ace'` call). When the user subsequently enters the under-card-selection sub-view, the recommended under card is additionally passed into that `<Hand>` as `suggestedIds: [underCardId]`. This is the only phase where the suggestion spans two UI screens.
+
+**Bury-phase UX.** Both recommended cards glow red simultaneously and statically. Clicking one to select it does not alter the highlight on the other — the hint is purely advisory and stays visible until the Bury action is committed.
+
+`decidePlay` can return the sentinel `'UNDER_CARD'` when the picker should play their under card. The under card is already represented in `hand` as `{ id: 'UNDER_CARD', isUnderCard: true, faceDown: true }`, so the same highlight mechanism applies uniformly — no special case.
+
+### Client-side import note
+
+The client now imports `shared/botStrategy.js`, which ships the full strategy logic to the browser. This is acceptable because the strategy is already publicly documented in `docs/BOTS.md`. A brief comment is added at the import site in `GamePage.jsx` to record this reasoning.
+
+### Prop wiring
+
+- `Hand` gains `suggestedIds: string[] | null`. For each card, adds `card-suggested` to the wrapper class when `suggestedIds?.includes(card.id)`.
+- `ActionPanel` gains `suggestedAction: string | null`. Matches against its internal button identifiers and applies `btn-suggested` to the matching element. The matching is direct string equality; no parsing.
+
+### localStorage
+
+- **Key:** `sheepshead:showBotSuggestion`
+- **Value:** `"true"` or `"false"` (missing = off).
+- **Read:** lazy initializer in `useState` in `GamePage`.
+- **Write:** the `onBotSuggestionChange` handler writes through to localStorage and React state in the same function.
+- **No cross-tab sync.** Two tabs hold independent values until toggled. Adding a `storage` event listener is overkill for a debug preference.
+
+### CSS
+
+```
+.card-suggested {
+  outline: 3px solid #ef4444;  /* red-500 */
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+.btn-suggested {
+  box-shadow: 0 0 0 2px #ef4444;
+}
+```
+
+Using `outline` rather than `border` avoids layout shift. `.card-suggested` composes additively with the existing `playable` class — a card can be both.
+
+## Testing
+
+- No new tests in `shared/`. The bot strategy suite already covers decision correctness.
+- Add a small suite around `GamePage`'s suggestion wiring, exercising the four phase branches end-to-end with fixture state:
+  - Toggle off → no suggestion.
+  - Toggle on but not our turn → no suggestion.
+  - Toggle on and `phase === 'playing'` → `{ kind: 'play', ids: [expected] }`.
+  - Happy path per other phase (`burying`, `picking`, `calling`).
+
+UI rendering assertions are incidental — we verify the hook output, not the class names.
+
+## Success criteria
+
+1. When "Show Bot Suggestion" is on, a non-bot player on their own turn sees red outlines on the cards / action buttons the bot would choose.
+2. Highlighting works in all four phases (picking, burying, calling, playing).
+3. The preference persists across reloads on the same browser and does not sync cross-device.
+4. Non-admins can open the Options modal, see all three game options as read-only, and toggle only their personal Bot Suggestion.
+5. Admins retain full control of the three game options and additionally have their own personal Bot Suggestion toggle.
+6. No server or DB changes; no new endpoints.
+
+## Deferred
+
+- **Reasoning tooltip.** Tracked at https://github.com/andynumber2/sheepshead/issues/140. Requires `decide*` functions to return reason tags; out of scope for v1.
+- **Cross-device sync of the preference.** Not planned.
+- **Spectator highlights.** Spectator mode is not implemented; see https://github.com/andynumber2/sheepshead/issues/75.
+- **Alternative candidate plays.** Not requested.
+
+## Relationships
+
+- **Blocks** https://github.com/andynumber2/sheepshead/issues/140 — the reasoning tooltip hangs off this feature's highlight.
+- **Builds on** https://github.com/andynumber2/sheepshead/issues/114 — game-mode visibility for non-admins is extended here into a full read-only Options view.

--- a/frontend/src/components/ActionPanel.jsx
+++ b/frontend/src/components/ActionPanel.jsx
@@ -3,7 +3,8 @@ import Hand from './Hand.jsx'
 
 const SUIT_SYMBOLS = { C: '♣', H: '♥', S: '♠' }
 
-export default function ActionPanel({ state, myUserId, myHand, onAction, loading, actingForName }) {
+export default function ActionPanel({ state, myUserId, myHand, onAction, loading, actingForName, suggestedAction = null, suggestedIds = null }) {
+  const suggestedClass = (label) => (suggestedAction === label ? 'btn-suggested' : '')
   const botStyle = actingForName
     ? { background: 'rgba(124,58,237,0.3)', border: '1px solid rgba(124,58,237,0.5)' }
     : {}
@@ -39,7 +40,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
         </>
       ) : (
         <button
-          className="secondary"
+          className={`secondary ${suggestedClass('go_alone')}`}
           onClick={() => setConfirmingAlone(true)}
           disabled={loading}
         >
@@ -84,13 +85,13 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
         {doublerMultiplier > 1 && <p style={{ color: '#f59e0b' }}>⚠ Stakes are ×{doublerMultiplier}</p>}
         <div style={{ display: 'flex', gap: 12, justifyContent: 'center', marginTop: 8 }}>
           {playerBlitz?.type === 'black' && (
-            <button onClick={() => act('blitz')} disabled={loading}>Black Blitz?</button>
+            <button className={suggestedClass('blitz')} onClick={() => act('blitz')} disabled={loading}>Black Blitz?</button>
           )}
           {playerBlitz?.type === 'red' && (
-            <button onClick={() => act('blitz')} disabled={loading}>Red Blitz?</button>
+            <button className={suggestedClass('blitz')} onClick={() => act('blitz')} disabled={loading}>Red Blitz?</button>
           )}
-          <button onClick={() => act('pick')} disabled={loading}>Pick the Blind?</button>
-          <button className="secondary" onClick={() => act('pass')} disabled={loading}>Pass</button>
+          <button className={suggestedClass('pick')} onClick={() => act('pick')} disabled={loading}>Pick the Blind?</button>
+          <button className={`secondary ${suggestedClass('pass')}`} onClick={() => act('pass')} disabled={loading}>Pass</button>
         </div>
         {error && <p style={{ color: '#f87171', marginTop: 6 }}>{error}</p>}
       </div>
@@ -117,6 +118,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
           cards={myHand}
           playableIds={myHand.map(c => c.id)}
           selectedIds={selectedBuried.map(c => c.id)}
+          suggestedIds={suggestedIds}
           onCardClick={toggleBury}
         />
         <button
@@ -158,7 +160,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
             {callableSuits.map(suit => (
               <button
                 key={suit}
-                className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
+                className={`suit-btn ${suit === 'H' ? 'red' : 'black'} ${suggestedClass(`king:${suit}`)}`}
                 onClick={() => act('call_king', { suit })}
                 disabled={loading}
                 title={`Call K${suit}`}
@@ -188,7 +190,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
             {callableSuits.map(suit => (
               <button
                 key={suit}
-                className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
+                className={`suit-btn ${suit === 'H' ? 'red' : 'black'} ${suggestedClass(`ten:${suit}`)}`}
                 onClick={() => act('call_ten', { suit })}
                 disabled={loading}
                 title={`Call 10${suit}`}
@@ -223,6 +225,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
             cards={myHand}
             playableIds={myHand.map(c => c.id)}
             selectedIds={selectedUnderCard ? [selectedUnderCard] : []}
+            suggestedIds={suggestedIds}
             onCardClick={(card) => setSelectedUnderCard(card.id)}
           />
           <div style={{ display: 'flex', gap: 8, justifyContent: 'center', marginTop: 8 }}>
@@ -254,7 +257,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
           {normalSuits.map(suit => (
             <button
               key={suit}
-              className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
+              className={`suit-btn ${suit === 'H' ? 'red' : 'black'} ${suggestedClass(`ace:${suit}`)}`}
               onClick={() => act('call_ace', { suit })}
               disabled={loading}
               title={`Call A${suit}`}
@@ -273,7 +276,7 @@ export default function ActionPanel({ state, myUserId, myHand, onAction, loading
               {underSuits.map(suit => (
                 <button
                   key={suit}
-                  className={`suit-btn ${suit === 'H' ? 'red' : 'black'}`}
+                  className={`suit-btn ${suit === 'H' ? 'red' : 'black'} ${suggestedClass(`ace:${suit}`)}`}
                   onClick={() => setUnderSelectedSuit(suit)}
                   disabled={loading}
                   title={`Call A${suit} Under`}

--- a/frontend/src/components/Card.jsx
+++ b/frontend/src/components/Card.jsx
@@ -6,12 +6,13 @@ function cardImageSrc(cardId) {
   return `/cards/${cardId}.png`
 }
 
-export default function Card({ card, playable = false, selected = false, onClick }) {
+export default function Card({ card, playable = false, selected = false, suggested = false, onClick }) {
   if (!card || card.hidden) {
     const hiddenClasses = [
       'card', 'card-img', 'hidden',
-      playable ? 'playable' : '',
-      selected ? 'selected' : '',
+      playable  ? 'playable'       : '',
+      selected  ? 'selected'       : '',
+      suggested ? 'card-suggested' : '',
     ].filter(Boolean).join(' ')
     return (
       <div
@@ -31,9 +32,10 @@ export default function Card({ card, playable = false, selected = false, onClick
   const classes = [
     'card',
     'card-img',
-    trump    ? 'trump'    : '',
-    playable ? 'playable' : '',
-    selected ? 'selected' : '',
+    trump     ? 'trump'          : '',
+    playable  ? 'playable'       : '',
+    selected  ? 'selected'       : '',
+    suggested ? 'card-suggested' : '',
   ].filter(Boolean).join(' ')
 
   return (

--- a/frontend/src/components/GameOptionsPanel.jsx
+++ b/frontend/src/components/GameOptionsPanel.jsx
@@ -13,7 +13,12 @@ const VARIANT_LABELS = { leasters: 'Leasters', doublers: 'Doublers', schwanzers:
  *
  * The parent controls open/close via the `open` prop and `onClose` callback.
  */
-export default function GameOptionsPanel({ mode, gameId, open, values, onChange, onUpdated, onClose }) {
+export default function GameOptionsPanel({
+  mode, gameId, open, values, onChange, onUpdated, onClose,
+  role = 'admin',
+  botSuggestionEnabled = false,
+  onBotSuggestionChange = null,
+}) {
   const dialogRef = useRef(null)
   // True when the in-flight close was initiated by the Done button. Lets us
   // distinguish a commit (Done) from a cancel (Escape/backdrop), since the
@@ -79,7 +84,8 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
   }
 
   async function handleDone() {
-    if (mode !== 'update') {
+    if (mode !== 'update' || role === 'player') {
+      committedRef.current = true
       onClose?.()
       return
     }
@@ -90,7 +96,6 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
     if (dob     !== initial.double_on_bump)  changed.double_on_bump  = dob
 
     if (Object.keys(changed).length === 0) {
-      // Nothing changed — close without any network call.
       committedRef.current = true
       onClose?.()
       return
@@ -105,7 +110,6 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
       onClose?.()
     } catch (e) {
       setError(e?.message ?? 'Failed to save.')
-      // Stay open so the admin can retry. Local state is preserved.
     } finally {
       setSaving(false)
     }
@@ -122,6 +126,9 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
     onClose?.()
   }
 
+  const isReadOnly = role === 'player'
+  const VARIANT_DISPLAY = { doublers: 'Doublers', leasters: 'Leasters', schwanzers: 'Schwanzers' }
+
   return (
     <dialog
       ref={dialogRef}
@@ -129,69 +136,109 @@ export default function GameOptionsPanel({ mode, gameId, open, values, onChange,
       onClose={handleDialogClose}
     >
       <strong style={{ fontSize: '0.95rem' }}>⚙ Game options</strong>
-      {mode === 'update' && (
+      {mode === 'update' && !isReadOnly && (
         <small style={{ color: '#aaa', display: 'block', marginBottom: 12, marginTop: 2 }}>
           Changes take effect next hand
+        </small>
+      )}
+      {isReadOnly && (
+        <small style={{ color: '#aaa', display: 'block', marginBottom: 12, marginTop: 2 }}>
+          Only the game admin can change these
         </small>
       )}
       {mode === 'create' && (
         <div style={{ marginBottom: 12 }} />
       )}
 
-      {/* No-pick variant */}
-      <div style={{ marginBottom: 12 }}>
-        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant</div>
-        <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-          {['doublers', 'leasters', 'schwanzers'].map(v => (
-            <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+      {isReadOnly ? (
+        <div style={{ display: 'grid', gridTemplateColumns: 'auto 1fr', rowGap: 6, columnGap: 16, marginBottom: 16, fontSize: '0.85rem' }}>
+          <span style={{ color: '#aaa' }}>No-pick variant</span>
+          <span>{VARIANT_DISPLAY[variant] ?? variant}</span>
+          <span style={{ color: '#aaa' }}>Partner visibility</span>
+          <span>{reveal ? 'Shown' : 'Hidden'}</span>
+          <span style={{ color: '#aaa' }}>Double on bump</span>
+          <span>{dob ? 'On' : 'Off'}</span>
+        </div>
+      ) : (
+        <>
+          {/* No-pick variant */}
+          <div style={{ marginBottom: 12 }}>
+            <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>No-pick variant</div>
+            <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+              {['doublers', 'leasters', 'schwanzers'].map(v => (
+                <label key={v} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+                  <input
+                    type="radio"
+                    name={`variant-${gameId ?? 'create'}`}
+                    value={v}
+                    checked={variant === v}
+                    onChange={() => handleVariantChange(v)}
+                    disabled={saving}
+                  />
+                  {VARIANT_LABELS[v]}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Identify partner */}
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>
+              Partner Visibility
+            </div>
+            <div style={{ display: 'flex', gap: 12 }}>
+              {[false, true].map(v => (
+                <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
+                  <input
+                    type="radio"
+                    name={`reveal-${gameId ?? 'create'}`}
+                    value={String(v)}
+                    checked={reveal === v}
+                    onChange={() => handleRevealChange(v)}
+                    disabled={saving}
+                  />
+                  {v ? 'Shown' : 'Hidden'}
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {/* Double on the Bump */}
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem' }}>
+              Double on the Bump?
               <input
-                type="radio"
-                name={`variant-${gameId ?? 'create'}`}
-                value={v}
-                checked={variant === v}
-                onChange={() => handleVariantChange(v)}
+                type="checkbox"
+                checked={dob}
+                onChange={e => handleDobChange(e.target.checked)}
                 disabled={saving}
               />
-              {VARIANT_LABELS[v]}
             </label>
-          ))}
-        </div>
-      </div>
+          </div>
+        </>
+      )}
 
-      {/* Identify partner */}
-      <div style={{ marginBottom: 16 }}>
-        <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 4 }}>
-          Partner Visibility
+      {/* Your preferences — hidden in create mode (no game yet) */}
+      {mode !== 'create' && onBotSuggestionChange && (
+        <div style={{ marginTop: 4, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,0.15)', marginBottom: 16 }}>
+          <div style={{ color: '#ccc', fontSize: '0.82rem', marginBottom: 6 }}>Your preferences</div>
+          <label style={{ display: 'flex', alignItems: 'flex-start', gap: 8, cursor: 'pointer', fontSize: '0.85rem' }}>
+            <input
+              type="checkbox"
+              checked={botSuggestionEnabled}
+              onChange={e => onBotSuggestionChange(e.target.checked)}
+              disabled={saving}
+              style={{ marginTop: 3 }}
+            />
+            <span>
+              Show Bot Suggestion
+              <small style={{ display: 'block', color: '#888', marginTop: 2 }}>
+                Highlights the card the bot would play on your turn. Purely advisory — useful for learning the game or comparing against the bot's strategy.
+              </small>
+            </span>
+          </label>
         </div>
-        <div style={{ display: 'flex', gap: 12 }}>
-          {[false, true].map(v => (
-            <label key={String(v)} style={{ display: 'flex', alignItems: 'center', gap: 4, cursor: 'pointer', fontSize: '0.85rem' }}>
-              <input
-                type="radio"
-                name={`reveal-${gameId ?? 'create'}`}
-                value={String(v)}
-                checked={reveal === v}
-                onChange={() => handleRevealChange(v)}
-                disabled={saving}
-              />
-              {v ? 'Shown' : 'Hidden'}
-            </label>
-          ))}
-        </div>
-      </div>
-
-      {/* Double on the Bump */}
-      <div style={{ marginBottom: 16 }}>
-        <label style={{ display: 'flex', alignItems: 'center', gap: 8, cursor: 'pointer', fontSize: '0.85rem' }}>
-          Double on the Bump?
-          <input
-            type="checkbox"
-            checked={dob}
-            onChange={e => handleDobChange(e.target.checked)}
-            disabled={saving}
-          />
-        </label>
-      </div>
+      )}
 
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
         <div style={{ fontSize: '0.82rem' }}>

--- a/frontend/src/components/Hand.jsx
+++ b/frontend/src/components/Hand.jsx
@@ -18,20 +18,22 @@ export function sortHand(cards) {
   })
 }
 
-export default function Hand({ cards = [], playableIds = null, selectedIds = [], onCardClick }) {
+export default function Hand({ cards = [], playableIds = null, selectedIds = [], suggestedIds = null, onCardClick }) {
   const sorted = sortHand(cards)
 
   return (
     <div className="hand">
       {sorted.map(card => {
-        const playable = playableIds === null ? false : playableIds.includes(card.id)
-        const selected = selectedIds.includes(card.id)
+        const playable  = playableIds === null ? false : playableIds.includes(card.id)
+        const selected  = selectedIds.includes(card.id)
+        const suggested = suggestedIds !== null && suggestedIds.includes(card.id)
         return (
           <Card
             key={card.id}
             card={card}
             playable={playable}
             selected={selected}
+            suggested={suggested}
             onClick={() => onCardClick?.(card)}
           />
         )

--- a/frontend/src/components/PlayerSeat.jsx
+++ b/frontend/src/components/PlayerSeat.jsx
@@ -17,6 +17,7 @@ export default function PlayerSeat({
   hand,
   showFaceUp,
   playableIds,
+  suggestedIds,
   onCardClick,
   noOverlap,
   onCrack,
@@ -65,12 +66,13 @@ export default function PlayerSeat({
           {sortHand(hand.filter(c => !c.hidden)).concat(hand.filter(c => c.hidden)).map((card, i) => {
             const faceUp = showFaceUp && !card.hidden
             const playable = playableIds?.includes(card.id)
+            const suggested = suggestedIds?.includes(card.id)
             return (
               <img
                 key={i}
                 src={faceUp ? `/cards/${card.id}.png` : CARD_BACK_SRC}
                 alt={faceUp ? card.id : 'card'}
-                className={`mini-card${playable ? ' mini-card-playable' : ''}`}
+                className={`mini-card${playable ? ' mini-card-playable' : ''}${suggested ? ' card-suggested' : ''}`}
                 onClick={playable ? () => onCardClick?.(card) : undefined}
               />
             )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -469,3 +469,14 @@ dialog.game-options-dialog[open] {
 dialog.game-options-dialog::backdrop {
   background: rgba(0, 0, 0, 0.6);
 }
+
+/* Bot suggestion highlight — issue #123 */
+.card-suggested {
+  outline: 3px solid #ef4444;
+  outline-offset: 2px;
+  border-radius: inherit;
+}
+
+.btn-suggested {
+  box-shadow: 0 0 0 2px #ef4444;
+}

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -389,23 +389,23 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
   // Must live above any early returns to preserve Rules of Hooks — hook count
   // must be identical across loading, waiting, and active renders.
+  const memoState = gameData?.state ?? null
+  const memoIsTestMode = !!gameData?.settings?.is_test_mode
   const botSuggestion = useMemo(() => {
     if (!showBotSuggestion) return null
-    const st = gameData?.state
-    if (!st) return null
-    const turnUid = currentTurnPlayer(st)
+    if (!memoState) return null
+    const turnUid = currentTurnPlayer(memoState)
     if (!turnUid) return null
-    const isTestMode = !!gameData.settings?.is_test_mode
-    const isActingForBot = isTestMode && user.is_admin && String(turnUid) !== String(user.id)
+    const isActingForBot = memoIsTestMode && user.is_admin && String(turnUid) !== String(user.id)
     const effectiveUid = isActingForBot ? String(turnUid) : String(user.id)
     if (String(turnUid) !== effectiveUid) return null
     try {
-      return computeBotSuggestion(st, effectiveUid)
+      return computeBotSuggestion(memoState, effectiveUid)
     } catch (err) {
       console.warn('[botSuggestion] computation failed:', err)
       return null
     }
-  }, [showBotSuggestion, gameData, user.id, user.is_admin])
+  }, [showBotSuggestion, memoState, memoIsTestMode, user.id, user.is_admin])
 
   // ── Loading / error ─────────────────────────────────────────────────────────
   if (error) return (

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -387,6 +387,26 @@ export default function GamePage({ gameId, user, onNavigate }) {
     }
   }
 
+  // Must live above any early returns to preserve Rules of Hooks — hook count
+  // must be identical across loading, waiting, and active renders.
+  const botSuggestion = useMemo(() => {
+    if (!showBotSuggestion) return null
+    const st = gameData?.state
+    if (!st) return null
+    const turnUid = currentTurnPlayer(st)
+    if (!turnUid) return null
+    const isTestMode = !!gameData.settings?.is_test_mode
+    const isActingForBot = isTestMode && user.is_admin && String(turnUid) !== String(user.id)
+    const effectiveUid = isActingForBot ? String(turnUid) : String(user.id)
+    if (String(turnUid) !== effectiveUid) return null
+    try {
+      return computeBotSuggestion(st, effectiveUid)
+    } catch (err) {
+      console.warn('[botSuggestion] computation failed:', err)
+      return null
+    }
+  }, [showBotSuggestion, gameData, user.id, user.is_admin])
+
   // ── Loading / error ─────────────────────────────────────────────────────────
   if (error) return (
     <div style={{ padding: 32, color: '#fff' }}>
@@ -611,17 +631,6 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const isMyPlayingTurn = state.phase === 'playing' && turnUserId === effectiveUserId
   const legalIds = isMyPlayingTurn ? getLegalCardIds(state, effectiveUserId, activeHand) : []
   const isPickerOverlay = (state.phase === 'burying' || state.phase === 'calling') && state.picker === effectiveUserId
-
-  const botSuggestion = useMemo(() => {
-    if (!showBotSuggestion) return null
-    if (!turnUserId || turnUserId !== effectiveUserId) return null
-    try {
-      return computeBotSuggestion(state, effectiveUserId)
-    } catch (err) {
-      console.warn('[botSuggestion] computation failed:', err)
-      return null
-    }
-  }, [showBotSuggestion, turnUserId, effectiveUserId, state])
 
   const suggestedIdsForHand = botSuggestion &&
     (botSuggestion.kind === 'play' || botSuggestion.kind === 'bury')

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { effectiveSuit } from '@shared/gameEngine.js'
+import { computeBotSuggestion } from '@shared/botSuggestion.js'
 import { api } from '../lib/api.js'
 import PlayerSeat from '../components/PlayerSeat.jsx'
 import TrickArea, { LastTrickArea } from '../components/TrickArea.jsx'
@@ -620,6 +621,17 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const isMyPlayingTurn = state.phase === 'playing' && turnUserId === effectiveUserId
   const legalIds = isMyPlayingTurn ? getLegalCardIds(state, effectiveUserId, activeHand) : []
   const isPickerOverlay = (state.phase === 'burying' || state.phase === 'calling') && state.picker === effectiveUserId
+
+  const botSuggestion = useMemo(() => {
+    if (!showBotSuggestion) return null
+    if (!turnUserId || turnUserId !== effectiveUserId) return null
+    try {
+      return computeBotSuggestion(state, effectiveUserId)
+    } catch (err) {
+      console.warn('[botSuggestion] computation failed:', err)
+      return null
+    }
+  }, [showBotSuggestion, turnUserId, effectiveUserId, state])
 
   return (
     <div className="game-table">

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -153,6 +153,22 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const [revealPartner, setRevealPartner]   = useState(null)
   const [dobEnabled, setDobEnabled]         = useState(null)
   const [showOptions, setShowOptions]       = useState(false)
+  const [showBotSuggestion, setShowBotSuggestion] = useState(() => {
+    try {
+      return localStorage.getItem('sheepshead:showBotSuggestion') === 'true'
+    } catch {
+      return false
+    }
+  })
+
+  const handleBotSuggestionChange = (next) => {
+    setShowBotSuggestion(next)
+    try {
+      localStorage.setItem('sheepshead:showBotSuggestion', next ? 'true' : 'false')
+    } catch {
+      // localStorage unavailable — in-memory state still updates.
+    }
+  }
   const pollingRef = useRef(null)
   // Tracks the auto-play timer for the last trick. We key by
   // `${turnUserId}:${trickLen}` so each "pending play" only schedules once,

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -632,10 +632,9 @@ export default function GamePage({ gameId, user, onNavigate }) {
   const legalIds = isMyPlayingTurn ? getLegalCardIds(state, effectiveUserId, activeHand) : []
   const isPickerOverlay = (state.phase === 'burying' || state.phase === 'calling') && state.picker === effectiveUserId
 
-  const suggestedIdsForHand = botSuggestion &&
-    (botSuggestion.kind === 'play' || botSuggestion.kind === 'bury')
-      ? botSuggestion.ids
-      : null
+  const suggestedIdsForHand = botSuggestion && botSuggestion.kind === 'play'
+    ? botSuggestion.ids
+    : null
 
   const suggestedIdsForActionPanel = botSuggestion &&
     (botSuggestion.kind === 'call' || botSuggestion.kind === 'bury')

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -443,40 +443,30 @@ export default function GamePage({ gameId, user, onNavigate }) {
           )}
         </div>
 
-        {/* Game creator controls settings */}
-        {isGameAdmin ? (
-          <>
-            <div style={{ marginTop: 8 }}>
-              <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
-                <SettingsSummary
-                  settings={currentSettings}
-                  style={{ color: '#ccc', fontSize: '0.85rem' }}
-                />
-                <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
-                  onClick={() => setShowOptions(true)}>
-                  ⚙ Edit
-                </button>
-              </div>
-            </div>
-            <GameOptionsPanel
-              mode="update"
-              gameId={gameId}
-              open={showOptions}
-              values={currentSettings}
-              onUpdated={handleSettingsUpdate}
-              onClose={() => setShowOptions(false)}
-            />
-          </>
-        ) : (
-          <div style={{ marginTop: 8 }}>
-            <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
+        <div style={{ marginTop: 8 }}>
+          <div style={{ fontSize: '0.72rem', color: '#888', marginBottom: 3 }}>Game options</div>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10 }}>
             <SettingsSummary
               settings={currentSettings}
-              style={{ color: '#aaa', fontSize: '0.85rem' }}
+              style={{ color: '#ccc', fontSize: '0.85rem' }}
             />
+            <button className="outline" style={{ fontSize: '0.8rem', padding: '2px 10px' }}
+              onClick={() => setShowOptions(true)}>
+              ⚙ Options
+            </button>
           </div>
-        )}
+        </div>
+        <GameOptionsPanel
+          mode="update"
+          gameId={gameId}
+          open={showOptions}
+          values={currentSettings}
+          onUpdated={handleSettingsUpdate}
+          onClose={() => setShowOptions(false)}
+          role={isGameAdmin ? 'admin' : 'player'}
+          botSuggestionEnabled={showBotSuggestion}
+          onBotSuggestionChange={handleBotSuggestionChange}
+        />
 
         <p style={{ marginTop: 16 }}>Waiting for players… ({players.length}/5)</p>
         <ul>{players.map(p => (

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -623,6 +623,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
     }
   }, [showBotSuggestion, turnUserId, effectiveUserId, state])
 
+  const suggestedIdsForHand = botSuggestion &&
+    (botSuggestion.kind === 'play' || botSuggestion.kind === 'bury')
+      ? botSuggestion.ids
+      : null
+
+  const suggestedIdsForActionPanel = botSuggestion &&
+    (botSuggestion.kind === 'call' || botSuggestion.kind === 'bury')
+      ? botSuggestion.ids
+      : null
+
+  const suggestedActionForPanel = botSuggestion?.actionLabel ?? null
+
   return (
     <div className="game-table">
 
@@ -652,33 +664,27 @@ export default function GamePage({ gameId, user, onNavigate }) {
         <LastTrickArea lastTrick={lastTrick} seats={seats} />
         <div style={{ width: '100%', borderTop: '1px solid rgba(255,255,255,0.1)', paddingTop: 8 }}>
           <div style={{ fontSize: '0.68rem', color: '#666', textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 4 }}>Game options</div>
-          {isGameAdmin ? (
-            <>
-              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
-                <SettingsSummary
-                  settings={currentSettings}
-                  style={{ color: '#aaa', fontSize: '0.78rem' }}
-                />
-                <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
-                  onClick={() => setShowOptions(true)}>
-                  ⚙ Edit
-                </button>
-              </div>
-              <GameOptionsPanel
-                mode="update"
-                gameId={gameId}
-                open={showOptions}
-                values={currentSettings}
-                onUpdated={handleSettingsUpdate}
-                onClose={() => setShowOptions(false)}
-              />
-            </>
-          ) : (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
             <SettingsSummary
               settings={currentSettings}
               style={{ color: '#aaa', fontSize: '0.78rem' }}
             />
-          )}
+            <button className="outline" style={{ fontSize: '0.78rem', padding: '2px 8px' }}
+              onClick={() => setShowOptions(true)}>
+              ⚙ Options
+            </button>
+          </div>
+          <GameOptionsPanel
+            mode="update"
+            gameId={gameId}
+            open={showOptions}
+            values={currentSettings}
+            onUpdated={handleSettingsUpdate}
+            onClose={() => setShowOptions(false)}
+            role={isGameAdmin ? 'admin' : 'player'}
+            botSuggestionEnabled={showBotSuggestion}
+            onBotSuggestionChange={handleBotSuggestionChange}
+          />
         </div>
         <div style={{ marginTop: 'auto', width: '100%', display: 'flex', justifyContent: 'flex-end', paddingTop: 8 }}>
           <button className="outline contrast" style={{ fontSize: '0.8rem' }}
@@ -721,6 +727,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
           showFaceUp={true}
           noOverlap={true}
           playableIds={isMyPlayingTurn ? legalIds : undefined}
+          suggestedIds={suggestedIdsForHand}
           onCardClick={isMyPlayingTurn
             ? (card) => { if (legalIds.includes(card.id)) handleAction('play_card', { cardId: card.id }, isActingForBot ? turnUserId : null) }
             : undefined}
@@ -737,6 +744,8 @@ export default function GamePage({ gameId, user, onNavigate }) {
             onAction={(type, payload) => handleAction(type, payload, isActingForBot ? turnUserId : null)}
             loading={actionLoading}
             actingForName={isActingForBot ? (actingForPlayer?.username ?? turnUserId) : null}
+            suggestedAction={suggestedActionForPanel}
+            suggestedIds={suggestedIdsForActionPanel}
           />
         </div>
       )}

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -153,7 +153,7 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
                   style={{ fontSize: '0.8rem', padding: '2px 10px' }}
                   onClick={() => setShowOptions(true)}
                 >
-                  ⚙ Edit
+                  ⚙ Options
                 </button>
               </div>
             </div>

--- a/shared/botSuggestion.js
+++ b/shared/botSuggestion.js
@@ -35,8 +35,11 @@ export function computeBotSuggestion(view, userId) {
         case 'king':
           actionLabel = `king:${decision.suit}`
           break
-        default:
+        case 'alone':
           actionLabel = 'go_alone'
+          break
+        default:
+          throw new Error(`Unknown call decision type: ${decision.type}`)
       }
       const ids = decision.type === 'ace_under' && decision.underCardId
         ? [decision.underCardId]

--- a/shared/botSuggestion.js
+++ b/shared/botSuggestion.js
@@ -1,0 +1,55 @@
+// Dispatches on state.phase to the matching bot-strategy decision function.
+// Pure — no side effects, no I/O. Caller is responsible for deciding *when*
+// to call (toggle on, my turn). Errors are thrown; the caller wraps in try/catch.
+import {
+  decidePick, decideBlitz, decideBury, decideCall, decidePlay,
+} from './botStrategy.js'
+
+export function computeBotSuggestion(view, userId) {
+  switch (view.phase) {
+    case 'picking': {
+      const potentialBlitz = (view.potentialBlitzes ?? []).find(b => b.userId === userId)
+      if (potentialBlitz && decideBlitz(view, userId)) {
+        return { kind: 'pick', ids: [], actionLabel: 'blitz' }
+      }
+      const shouldPick = decidePick(view, userId)
+      return { kind: 'pick', ids: [], actionLabel: shouldPick ? 'pick' : 'pass' }
+    }
+
+    case 'burying': {
+      const ids = decideBury(view, userId)
+      return { kind: 'bury', ids }
+    }
+
+    case 'calling': {
+      const decision = decideCall(view, userId)
+      let actionLabel
+      switch (decision.type) {
+        case 'ace':
+        case 'ace_under':
+          actionLabel = `ace:${decision.suit}`
+          break
+        case 'ten':
+          actionLabel = `ten:${decision.suit}`
+          break
+        case 'king':
+          actionLabel = `king:${decision.suit}`
+          break
+        default:
+          actionLabel = 'go_alone'
+      }
+      const ids = decision.type === 'ace_under' && decision.underCardId
+        ? [decision.underCardId]
+        : []
+      return { kind: 'call', ids, actionLabel }
+    }
+
+    case 'playing': {
+      const cardId = decidePlay(view, userId)
+      return { kind: 'play', ids: [cardId] }
+    }
+
+    default:
+      throw new Error(`Unknown phase: ${view.phase}`)
+  }
+}

--- a/shared/botSuggestion.labels.test.js
+++ b/shared/botSuggestion.labels.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./botStrategy.js', () => ({
+  decidePick:  vi.fn(),
+  decideBlitz: vi.fn(),
+  decideBury:  vi.fn(),
+  decideCall:  vi.fn(),
+  decidePlay:  vi.fn(),
+}))
+
+const { decideCall } = await import('./botStrategy.js')
+const { computeBotSuggestion } = await import('./botSuggestion.js')
+
+describe('computeBotSuggestion — call label mappings', () => {
+  beforeEach(() => {
+    decideCall.mockReset()
+  })
+
+  it('maps ace_under → ids:[underCardId], actionLabel "ace:<suit>"', () => {
+    decideCall.mockReturnValueOnce({ type: 'ace_under', suit: 'H', underCardId: '9H' })
+    const result = computeBotSuggestion({ phase: 'calling' }, 'u1')
+    expect(result.kind).toBe('call')
+    expect(result.ids).toEqual(['9H'])
+    expect(result.actionLabel).toBe('ace:H')
+  })
+
+  it('maps alone → actionLabel "go_alone" with empty ids', () => {
+    decideCall.mockReturnValueOnce({ type: 'alone' })
+    const result = computeBotSuggestion({ phase: 'calling' }, 'u1')
+    expect(result.kind).toBe('call')
+    expect(result.ids).toEqual([])
+    expect(result.actionLabel).toBe('go_alone')
+  })
+
+  it('throws on unknown call decision type', () => {
+    decideCall.mockReturnValueOnce({ type: 'bogus' })
+    expect(() => computeBotSuggestion({ phase: 'calling' }, 'u1'))
+      .toThrow(/unknown call decision type/i)
+  })
+})

--- a/shared/botSuggestion.test.js
+++ b/shared/botSuggestion.test.js
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest'
+import { computeBotSuggestion } from './botSuggestion.js'
+
+// Stub view factories — minimal shapes sufficient for dispatch.
+// Real decision correctness is covered by the botStrategy test suite.
+function playingView({ hands, currentTrick = [] }) {
+  return {
+    phase: 'playing',
+    hands,
+    currentTrick,
+    tricks: [],
+    picker: 'u1',
+    partner: 'u2',
+    calledSuit: 'H',
+    partnerRevealed: false,
+    lastTrick: [],
+    isLeaster: false,
+    reveal_partner: false,
+  }
+}
+
+describe('computeBotSuggestion', () => {
+  it('returns { kind: "play", ids: [cardId] } in playing phase', () => {
+    const view = playingView({ hands: { u1: [{ id: 'QC', suit: 'C', rank: 'Q' }] } })
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('play')
+    expect(result.ids).toEqual(['QC'])
+    expect(result.actionLabel).toBeUndefined()
+  })
+
+  it('returns { kind: "bury", ids: [a, b] } in burying phase', () => {
+    const view = {
+      phase: 'burying',
+      hands: {
+        u1: [
+          { id: 'AC', suit: 'C', rank: 'A' }, { id: 'KC', suit: 'C', rank: 'K' },
+          { id: '9C', suit: 'C', rank: '9' }, { id: '8C', suit: 'C', rank: '8' },
+          { id: '7C', suit: 'C', rank: '7' }, { id: 'AS', suit: 'S', rank: 'A' },
+          { id: 'KS', suit: 'S', rank: 'K' }, { id: '9S', suit: 'S', rank: '9' },
+        ],
+      },
+      picker: 'u1',
+      blind: [],
+      calledSuit: null,
+    }
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('bury')
+    expect(result.ids).toHaveLength(2)
+  })
+
+  it('returns { kind: "pick", actionLabel: "pick"|"pass" } in picking phase', () => {
+    const view = {
+      phase: 'picking',
+      hands: { u1: [
+        { id: 'QC', suit: 'C', rank: 'Q' }, { id: 'QS', suit: 'S', rank: 'Q' },
+        { id: 'QH', suit: 'H', rank: 'Q' }, { id: 'JC', suit: 'C', rank: 'J' },
+        { id: 'AD', suit: 'D', rank: 'A' }, { id: '10D', suit: 'D', rank: '10' },
+      ]},
+      potentialBlitzes: [],
+      pickOrder: ['u1'], pickIndex: 0,
+    }
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('pick')
+    expect(['pick', 'pass', 'blitz']).toContain(result.actionLabel)
+    expect(result.ids).toEqual([])
+  })
+
+  it('returns { kind: "call", actionLabel: "ace:X"|"ten:X"|"king:X"|"go_alone" } in calling phase', () => {
+    const view = {
+      phase: 'calling',
+      hands: { u1: [
+        { id: 'QC', suit: 'C', rank: 'Q' }, { id: 'QS', suit: 'S', rank: 'Q' },
+        { id: 'JC', suit: 'C', rank: 'J' }, { id: 'AD', suit: 'D', rank: 'A' },
+        { id: '9S', suit: 'S', rank: '9' }, { id: '9H', suit: 'H', rank: '9' },
+      ]},
+      picker: 'u1',
+      buried: [],
+    }
+    const result = computeBotSuggestion(view, 'u1')
+    expect(result.kind).toBe('call')
+    expect(result.actionLabel).toMatch(/^(ace:[CHS]|ten:[CHS]|king:[CHS]|go_alone)$/)
+  })
+
+  it('throws on unknown phase', () => {
+    expect(() => computeBotSuggestion({ phase: 'scoring', hands: { u1: [] } }, 'u1'))
+      .toThrow(/unknown phase/i)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a toggleable red-outline "bot suggestion" that highlights what the bot strategy would choose on the human player's turn across all phases (pick/pass/blitz, bury, partner call including `ace_under`, play)
- Refactors the Options modal so non-admin players can open it in read-only mode and toggle the per-user "Show Bot Suggestion" preference, persisted in localStorage
- Fixes #123

## Implementation notes
- New pure helper `shared/botSuggestion.js` dispatches on phase to the existing `decidePick`/`decideBlitz`/`decideBury`/`decideCall`/`decidePlay` functions and returns `{ kind, ids, actionLabel }`
- `suggestedIds` threaded only to the bottom `PlayerSeat` (never via `seatProps`), so opponents can't receive hint ids
- `botSuggestion` `useMemo` lives above all early returns in `GamePage.jsx` (Rules of Hooks) and depends on `state` + `isTestMode` rather than the whole `gameData` object to avoid recomputing on every 2s poll
- Server settings PATCH remains admin-only; the read-only layout in `GameOptionsPanel` is purely a UI presentation

## Test plan
- [ ] Toggle "Show Bot Suggestion" in the Options modal as both admin and non-admin; verify it persists across reloads
- [ ] Verify the red outline appears on the correct card/button in picking, burying, calling, and playing phases
- [ ] Verify `ace_under` highlights both the suit button (first view) and the specific under-card (second view)
- [ ] Verify bury highlights only in the ActionPanel, not on the bottom seat's mini-stack
- [ ] Verify opponents' seats never show any highlight
- [ ] Verify non-admin Options modal is read-only (no save/edit paths)
- [ ] `npm test` → 222/222 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)