### PR TITLE
Smart polling: gate frontend requests by status + tab visibility (#145)

### DIFF
--- a/docs/superpowers/plans/2026-04-26-issue-145-request-optimization-plan.md
+++ b/docs/superpowers/plans/2026-04-26-issue-145-request-optimization-plan.md
@@ -1,0 +1,1073 @@
+# Request Optimization (Smart Polling) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut Worker requests from ~345K/week to <50K by gating frontend polling on game status and tab visibility, slowing infrequent-change cadences, and caching the `score_timezone` config singleton on the server.
+
+**Architecture:** Introduce a `useGameState(gameId)` React hook in `frontend/src/hooks/` that owns all polling logic for the game page. Replace the unconditional `setInterval(fetchGame, 2000)` in `GamePage.jsx` with the hook. Add visibility handling inline to `LobbyPage.jsx`. Memoize `score_timezone` in Worker module scope.
+
+**Tech Stack:** React 18 + Vite (frontend) · Cloudflare Pages Functions + D1 (backend) · Vitest + React Testing Library + jsdom (new test infra for the hook)
+
+**Spec:** `docs/superpowers/specs/2026-04-26-issue-145-request-optimization-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `frontend/vitest.config.js` — Vitest configuration for the frontend workspace
+- `frontend/test-setup.js` — Testing-library global setup
+- `frontend/src/hooks/useGameState.js` — The polling hook (the seam for #149)
+- `frontend/src/hooks/useGameState.test.js` — Hook unit tests
+
+**Modified files:**
+- `frontend/package.json` — Add testing-library + jsdom dev deps; add `test` script
+- `frontend/src/pages/GamePage.jsx` — Replace inline polling with `useGameState`; swap `fetchGame()` calls for `refresh()`
+- `frontend/src/pages/LobbyPage.jsx` — Add `visibilitychange` handling to the existing 5s interval
+- `functions/api/games/[id]/index.js` — Memoize the `score_timezone` config lookup in module scope
+
+---
+
+## Task 1: Set up frontend test infrastructure
+
+The repo has Vitest configured at the root (`shared/*.test.js` runs against the Node default env). The frontend has no test infra yet. We need jsdom + Testing Library to test the hook.
+
+**Files:**
+- Create: `frontend/vitest.config.js`
+- Create: `frontend/test-setup.js`
+- Modify: `frontend/package.json`
+
+- [ ] **Step 1: Add dev dependencies to the frontend workspace**
+
+```bash
+npm install --save-dev --workspace frontend \
+  vitest@^4.1.4 \
+  @testing-library/react@^16.0.1 \
+  @testing-library/jest-dom@^6.6.3 \
+  jsdom@^25.0.1
+```
+
+Pin `vitest@^4.1.4` to match the root's existing version (root `package.json` line: `"vitest": "^4.1.4"`).
+
+- [ ] **Step 2: Create `frontend/vitest.config.js`**
+
+```js
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./test-setup.js'],
+    include: ['src/**/*.test.{js,jsx}'],
+  },
+})
+```
+
+- [ ] **Step 3: Create `frontend/test-setup.js`**
+
+```js
+import '@testing-library/jest-dom/vitest'
+```
+
+- [ ] **Step 4: Add a `test` script to `frontend/package.json`**
+
+In the `scripts` block, add:
+
+```json
+"test": "vitest run"
+```
+
+- [ ] **Step 5: Verify Vitest discovers the (empty) frontend suite**
+
+Run: `npm test -w frontend`
+Expected: Vitest starts, finds no tests (passes the `--passWithNoTests` semantics by reporting "No test files found" without an error). If it errors on missing config, recheck Step 2.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/package.json frontend/vitest.config.js frontend/test-setup.js package-lock.json
+git commit -m "test: add frontend Vitest infrastructure (jsdom + testing-library)"
+```
+
+---
+
+## Task 2: Implement `useGameState` hook (TDD)
+
+Build the hook one behavior at a time. Each behavior gets a test, then a minimal implementation extension.
+
+**Files:**
+- Create: `frontend/src/hooks/useGameState.js`
+- Create: `frontend/src/hooks/useGameState.test.js`
+
+- [ ] **Step 1: Create the test file with the active-cadence test**
+
+Create `frontend/src/hooks/useGameState.test.js`:
+
+```js
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useGameState } from './useGameState.js'
+
+function mockApi(states) {
+  // states: array of game objects to return on successive calls
+  let i = 0
+  return vi.fn(async () => {
+    const next = states[Math.min(i, states.length - 1)]
+    i += 1
+    return next
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  })
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => false,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('useGameState', () => {
+  it('polls every 2000ms when game status is active', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test — verify it fails**
+
+Run: `npm test -w frontend`
+Expected: FAIL — "Cannot find module './useGameState.js'"
+
+- [ ] **Step 3: Create the minimal hook**
+
+Create `frontend/src/hooks/useGameState.js`:
+
+```js
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+export function useGameState(gameId, fetchFn) {
+  const [game, setGame]       = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError]     = useState(null)
+  const intervalRef = useRef(null)
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const data = await fetchFn(gameId)
+      setGame(data)
+      setError(null)
+      return data
+    } catch (e) {
+      setError(e)
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [gameId, fetchFn])
+
+  const refresh = useCallback(() => fetchOnce(), [fetchOnce])
+
+  useEffect(() => {
+    let cancelled = false
+    fetchOnce().then(data => {
+      if (cancelled || !data) return
+      if (data.status === 'active') {
+        intervalRef.current = setInterval(fetchOnce, 2000)
+      }
+    })
+    return () => {
+      cancelled = true
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+  }, [fetchOnce])
+
+  return { game, loading, error, refresh }
+}
+```
+
+- [ ] **Step 4: Run test — verify it passes**
+
+Run: `npm test -w frontend`
+Expected: PASS (1 test, 1 passed)
+
+- [ ] **Step 5: Add the waiting-cadence test**
+
+Append to `frontend/src/hooks/useGameState.test.js`:
+
+```js
+  it('polls every 5000ms when game status is waiting', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'waiting' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    // No tick at 2000ms (would be active cadence)
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(1)
+
+    // Tick at 5000ms total
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    // Next tick at 10000ms total
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3)
+  })
+```
+
+- [ ] **Step 6: Run test — verify it fails**
+
+Run: `npm test -w frontend`
+Expected: FAIL — second test fails because hook only handles 'active'
+
+- [ ] **Step 7: Extend hook to handle 'waiting' cadence**
+
+Replace the body of the `useEffect` block in `frontend/src/hooks/useGameState.js` with:
+
+```js
+  useEffect(() => {
+    let cancelled = false
+    const intervalForStatus = (status) => {
+      if (status === 'active')  return 2000
+      if (status === 'waiting') return 5000
+      return null
+    }
+    fetchOnce().then(data => {
+      if (cancelled || !data) return
+      const ms = intervalForStatus(data.status)
+      if (ms != null) {
+        intervalRef.current = setInterval(fetchOnce, ms)
+      }
+    })
+    return () => {
+      cancelled = true
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current)
+        intervalRef.current = null
+      }
+    }
+  }, [fetchOnce])
+```
+
+- [ ] **Step 8: Run tests — verify both pass**
+
+Run: `npm test -w frontend`
+Expected: PASS (2 tests, 2 passed)
+
+- [ ] **Step 9: Add the complete-status test**
+
+Append:
+
+```js
+  it('does not poll when game status is complete', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'complete' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(1)
+  })
+```
+
+- [ ] **Step 10: Run — verify it passes (no impl change needed)**
+
+Run: `npm test -w frontend`
+Expected: PASS (3/3) — `intervalForStatus('complete')` returns `null`, so no interval is set.
+
+- [ ] **Step 11: Add the status-transition test**
+
+The hook must react when status changes mid-poll (e.g. waiting → active when the 5th player joins, or active → complete when the game ends). Append:
+
+```js
+  it('reconfigures interval when game status changes between fetches', async () => {
+    const fetchGame = vi.fn()
+      .mockResolvedValueOnce({ id: 1, status: 'waiting' })
+      .mockResolvedValueOnce({ id: 1, status: 'active' })
+      .mockResolvedValueOnce({ id: 1, status: 'active' })
+      .mockResolvedValue({ id: 1, status: 'complete' })
+
+    renderHook(() => useGameState('1', fetchGame))
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1)) // initial waiting
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2) // second poll: now active
+
+    // Now should be on 2000ms cadence
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3) // third poll: still active
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(4) // fourth poll: now complete
+
+    // After complete, no more polls
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(4)
+  })
+```
+
+- [ ] **Step 12: Run — verify it fails**
+
+Run: `npm test -w frontend`
+Expected: FAIL — current hook only sets the interval based on the first fetch's status; never reconfigures.
+
+- [ ] **Step 13: Refactor the hook to react to status changes**
+
+The interval must be re-evaluated after each fetch, since the status (and therefore the cadence) can change between polls. Use a single named `tick` function that recomputes the desired interval and re-establishes the timer when it changes.
+
+Replace the entire contents of `frontend/src/hooks/useGameState.js` with:
+
+```js
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+function intervalForStatus(status) {
+  if (status === 'active')  return 2000
+  if (status === 'waiting') return 5000
+  return null
+}
+
+export function useGameState(gameId, fetchFn) {
+  const [game, setGame]       = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError]     = useState(null)
+  const intervalRef = useRef(null)
+
+  const clearTimer = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const data = await fetchFn(gameId)
+      setGame(data)
+      setError(null)
+      return data
+    } catch (e) {
+      setError(e)
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [gameId, fetchFn])
+
+  const refresh = useCallback(() => fetchOnce(), [fetchOnce])
+
+  // Schedule polling that reconfigures whenever the cadence-determining
+  // condition (status, eventually visibility) changes. The single source of
+  // truth for "what interval should we be on right now?" is `desiredInterval()`.
+  useEffect(() => {
+    let cancelled = false
+    let currentMs = null
+
+    const desiredInterval = (data) => intervalForStatus(data?.status)
+
+    const tick = async () => {
+      if (cancelled) return
+      const data = await fetchOnce()
+      if (cancelled || !data) return
+      const next = desiredInterval(data)
+      if (next !== currentMs) {
+        clearTimer()
+        currentMs = next
+        if (next != null) {
+          intervalRef.current = setInterval(tick, next)
+        }
+      }
+    }
+
+    tick()
+
+    return () => {
+      cancelled = true
+      clearTimer()
+    }
+  }, [fetchOnce])
+
+  return { game, loading, error, refresh }
+}
+```
+
+- [ ] **Step 14: Run tests — verify all pass**
+
+Run: `npm test -w frontend`
+Expected: PASS (4/4)
+
+- [ ] **Step 15: Add the visibility test**
+
+Append to the test file:
+
+```js
+  it('stops polling when document becomes hidden, resumes (with immediate fetch) when visible', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    // Simulate tab hidden
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'hidden' })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    // No more polls while hidden
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    // Tab visible again
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    // Immediate fetch on becoming visible
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(3))
+
+    // Cadence resumes
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(4)
+  })
+```
+
+- [ ] **Step 16: Run — verify it fails**
+
+Run: `npm test -w frontend`
+Expected: FAIL — hook does not yet listen to `visibilitychange`.
+
+- [ ] **Step 17: Add visibility handling**
+
+Replace the body of the `useEffect` in `useGameState.js` to incorporate visibility:
+
+```js
+  useEffect(() => {
+    let cancelled = false
+    let currentMs = null
+
+    const desiredInterval = (data) => {
+      if (document.hidden) return null
+      return intervalForStatus(data?.status)
+    }
+
+    const tick = async () => {
+      if (cancelled) return
+      const data = await fetchOnce()
+      if (cancelled || !data) return
+      const next = desiredInterval(data)
+      if (next !== currentMs) {
+        clearTimer()
+        currentMs = next
+        if (next != null) {
+          intervalRef.current = setInterval(tick, next)
+        }
+      }
+    }
+
+    const onVisibility = () => {
+      if (cancelled) return
+      if (document.hidden) {
+        clearTimer()
+        currentMs = null
+      } else {
+        // Re-fetch immediately and re-establish the timer.
+        tick()
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibility)
+    tick()
+
+    return () => {
+      cancelled = true
+      clearTimer()
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [fetchOnce])
+```
+
+- [ ] **Step 18: Run tests — verify all pass**
+
+Run: `npm test -w frontend`
+Expected: PASS (5/5)
+
+- [ ] **Step 19: Add the unmount-cleanup test**
+
+Append:
+
+```js
+  it('clears the interval and removes visibilitychange listener on unmount', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    const { unmount } = renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    unmount()
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+
+    // No further fetches after unmount, even with timer advances.
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(1)
+  })
+```
+
+- [ ] **Step 20: Run — verify it passes (cleanup is already implemented)**
+
+Run: `npm test -w frontend`
+Expected: PASS (6/6)
+
+- [ ] **Step 21: Add the gameId-change test**
+
+Append:
+
+```js
+  it('cancels the old interval and starts a new fetch when gameId changes', async () => {
+    const fetchGame = vi.fn(async (id) => ({ id: Number(id), status: 'active' }))
+    const { rerender } = renderHook(
+      ({ id }) => useGameState(id, fetchGame),
+      { initialProps: { id: '1' } }
+    )
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledWith('1'))
+
+    rerender({ id: '2' })
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledWith('2'))
+
+    // Ticks should be for game 2 only
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    const callsForGame2 = fetchGame.mock.calls.filter(([id]) => id === '2').length
+    expect(callsForGame2).toBeGreaterThanOrEqual(2)
+  })
+```
+
+- [ ] **Step 22: Run — verify it passes**
+
+Run: `npm test -w frontend`
+Expected: PASS (7/7) — the existing effect's `[fetchOnce]` dep, which depends on `gameId`, already triggers re-setup on id change.
+
+- [ ] **Step 23: Add the refresh() test**
+
+Append:
+
+```js
+  it('refresh() triggers an immediate fetch without disturbing cadence', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    const { result } = renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await result.current.refresh() })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    // Original 2000ms cadence still ticks
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3)
+  })
+```
+
+- [ ] **Step 24: Run — verify all 8 pass**
+
+Run: `npm test -w frontend`
+Expected: PASS (8/8)
+
+- [ ] **Step 25: Commit**
+
+```bash
+git add frontend/src/hooks/useGameState.js frontend/src/hooks/useGameState.test.js
+git commit -m "feat(frontend): add useGameState hook with status- and visibility-aware polling"
+```
+
+---
+
+## Task 3: Migrate `GamePage` to use the hook
+
+The hook accepts `fetchFn` as a parameter (so tests can inject a mock). At the call site, pass `api.games.get`. Replace `gameData`/`fetchGame` plumbing with the hook's `game`/`refresh`.
+
+**Files:**
+- Modify: `frontend/src/pages/GamePage.jsx`
+
+The current state:
+- `GamePage.jsx:173` declares `pollingRef` (no longer needed)
+- `GamePage.jsx:187-199` defines `fetchGame` (replaced by hook)
+- `GamePage.jsx:201-205` is the polling `useEffect` (deleted)
+- `GamePage.jsx:289`, `GamePage.jsx:356`, `GamePage.jsx:372` call `fetchGame()` after writes (replaced by `refresh()`)
+- `GamePage.jsx:191-194` seeds `currentVariant` / `revealPartner` / `dobEnabled` from the first fetch (must be preserved — moved to a separate effect)
+
+- [ ] **Step 1: Add the hook import**
+
+In `frontend/src/pages/GamePage.jsx`, add to the imports near the top:
+
+```js
+import { useGameState } from '../hooks/useGameState.js'
+```
+
+- [ ] **Step 2: Locate `gameData` state declaration**
+
+Find the line `const [gameData, setGameData] = useState(null)` near the top of the component. Note its exact position — it will be replaced.
+
+- [ ] **Step 3: Replace fetch plumbing with the hook**
+
+Make the following changes to `frontend/src/pages/GamePage.jsx`:
+
+1. Delete the `pollingRef` declaration (line 173 in the current file):
+
+```js
+const pollingRef = useRef(null)
+```
+
+2. Delete the `fetchGame` definition (lines 187-199 in the current file):
+
+```js
+const fetchGame = useCallback(async () => {
+  try {
+    const data = await api.games.get(gameId)
+    setGameData(data)
+    setCurrentVariant(prev => prev ?? data.settings?.no_pick_variant)
+    setRevealPartner(prev => prev ?? data.settings?.reveal_partner)
+    setDobEnabled(prev => prev ?? data.settings?.double_on_bump)
+    setError(null)
+  } catch (e) {
+    setError(e.message)
+  }
+}, [gameId])
+```
+
+3. Delete the polling effect (lines 201-205 in the current file):
+
+```js
+useEffect(() => {
+  fetchGame()
+  pollingRef.current = setInterval(fetchGame, 2000)
+  return () => clearInterval(pollingRef.current)
+}, [fetchGame])
+```
+
+4. Delete the `gameData` state declaration:
+
+```js
+const [gameData, setGameData] = useState(null)
+```
+
+5. In its place, add the hook call (immediately after the other `useState` declarations, before the `pollingRef` was located):
+
+```js
+const { game: gameData, error: hookError, refresh } = useGameState(gameId, api.games.get)
+```
+
+6. Add a separate effect that seeds the variant/reveal/DOB defaults — this preserves the "set-once" behavior the deleted `fetchGame` was doing:
+
+```js
+useEffect(() => {
+  if (!gameData) return
+  setCurrentVariant(prev => prev ?? gameData.settings?.no_pick_variant)
+  setRevealPartner(prev => prev ?? gameData.settings?.reveal_partner)
+  setDobEnabled(prev => prev ?? gameData.settings?.double_on_bump)
+}, [gameData])
+```
+
+7. Wire the hook's error into the existing `error` state. Find the existing `error` state's `setError` calls and add one effect that mirrors hook errors into local state (so the existing error UI keeps working):
+
+```js
+useEffect(() => {
+  if (hookError) setError(hookError.message)
+}, [hookError])
+```
+
+- [ ] **Step 4: Replace `await fetchGame()` calls with `refresh()`**
+
+Three sites — one in the bot-play effect, two in action handlers:
+
+**Site 1** — `GamePage.jsx` around line 289 (inside the bot-play `useEffect` callback):
+
+Find:
+```js
+try {
+  await api.games.action(gameId, 'bot_play', {})
+  await fetchGame()
+} catch {
+```
+
+Replace with:
+```js
+try {
+  await api.games.action(gameId, 'bot_play', {})
+  await refresh()
+} catch {
+```
+
+Also update this effect's dependency array (around line 295):
+
+Find:
+```js
+}, [gameData, gameId, fetchGame])
+```
+
+Replace with:
+```js
+}, [gameData, gameId, refresh])
+```
+
+**Site 2** — `handleAction` around line 356:
+
+Find:
+```js
+async function handleAction(type, payload, actAs = null) {
+  setActionLoading(true)
+  try {
+    await api.games.action(gameId, type, payload, actAs)
+    await fetchGame()
+  } finally {
+    setActionLoading(false)
+  }
+}
+```
+
+Replace with:
+```js
+async function handleAction(type, payload, actAs = null) {
+  setActionLoading(true)
+  try {
+    await api.games.action(gameId, type, payload, actAs)
+    await refresh()
+  } finally {
+    setActionLoading(false)
+  }
+}
+```
+
+**Site 3** — `handleFillWithBots` around line 372:
+
+Find:
+```js
+async function handleFillWithBots() {
+  try {
+    await api.games.fillWithBots(gameId)
+    await fetchGame()
+  } catch (e) {
+    setError(e.message)
+  }
+}
+```
+
+Replace with:
+```js
+async function handleFillWithBots() {
+  try {
+    await api.games.fillWithBots(gameId)
+    await refresh()
+  } catch (e) {
+    setError(e.message)
+  }
+}
+```
+
+- [ ] **Step 5: Verify there are no stragglers**
+
+Run: `grep -n "fetchGame\|pollingRef" frontend/src/pages/GamePage.jsx`
+Expected: no output. If anything remains, replace it (`fetchGame` → `refresh`, `pollingRef` → delete).
+
+- [ ] **Step 6: Verify the build still compiles**
+
+Run: `npm run build`
+Expected: build succeeds, no errors. (Vite's build is the closest thing to a type/lint check here.)
+
+- [ ] **Step 7: Manual smoke test**
+
+Run: `npm run dev` (in a separate terminal or background).
+Open: `http://localhost:3000` and log in.
+- Open a game. Network tab: `GET /api/games/[id]` should fire on mount, then every 2000 ms while the game is `active`.
+- Hide the tab. Polling should stop.
+- Restore the tab. One immediate fetch, then 2000 ms cadence resumes.
+- End/leave the game. Polling stops.
+
+If any of those don't behave as expected, fix before committing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/pages/GamePage.jsx
+git commit -m "feat(frontend): migrate GamePage to useGameState hook"
+```
+
+---
+
+## Task 4: Add visibility handling to `LobbyPage`
+
+`LobbyPage.jsx:34` already polls every 5000 ms. Add a `visibilitychange` listener so it pauses when hidden and does an immediate fetch + resumes when visible.
+
+**Files:**
+- Modify: `frontend/src/pages/LobbyPage.jsx`
+
+- [ ] **Step 1: Replace the polling effect**
+
+In `frontend/src/pages/LobbyPage.jsx`, find the existing effect (around line 33):
+
+```js
+useEffect(() => {
+  loadGames()
+  const interval = setInterval(loadGames, 5000)
+  return () => clearInterval(interval)
+}, [])
+```
+
+Replace with:
+
+```js
+useEffect(() => {
+  let intervalId = null
+
+  const start = () => {
+    if (intervalId != null) return
+    intervalId = setInterval(loadGames, 5000)
+  }
+  const stop = () => {
+    if (intervalId != null) {
+      clearInterval(intervalId)
+      intervalId = null
+    }
+  }
+
+  const onVisibility = () => {
+    if (document.hidden) {
+      stop()
+    } else {
+      loadGames()
+      start()
+    }
+  }
+
+  loadGames()
+  if (!document.hidden) start()
+  document.addEventListener('visibilitychange', onVisibility)
+
+  return () => {
+    stop()
+    document.removeEventListener('visibilitychange', onVisibility)
+  }
+}, [])
+```
+
+- [ ] **Step 2: Verify the build still compiles**
+
+Run: `npm run build`
+Expected: build succeeds.
+
+- [ ] **Step 3: Manual smoke test**
+
+Run: `npm run dev`.
+Open: `http://localhost:3000/#/lobby`.
+- Network tab: `GET /api/games` fires on mount, then every 5000 ms.
+- Hide the tab. Polling stops.
+- Restore the tab. One immediate fetch, then 5000 ms cadence resumes.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/pages/LobbyPage.jsx
+git commit -m "feat(frontend): pause LobbyPage polling when tab is hidden"
+```
+
+---
+
+## Task 5: Cache `score_timezone` in Worker module scope
+
+The `SELECT value FROM config WHERE key = 'score_timezone'` query runs on every `GET /api/games/[id]` request. The value never changes at runtime; cache it once per Worker isolate.
+
+**Files:**
+- Modify: `functions/api/games/[id]/index.js`
+
+- [ ] **Step 1: Check for other readers of `score_timezone`**
+
+Run: `grep -rn "score_timezone" functions/`
+Expected output: at least the line in `functions/api/games/[id]/index.js`. If the same query appears in any other handler, the cache helper should live in `functions/api/_helpers.js` instead of inline. **Note any other locations** before proceeding — Step 2 covers the inline case (one location only); Step 2-alt covers the shared-helper case.
+
+- [ ] **Step 2: Inline cache (only one reader)**
+
+If `grep` showed only one reader, edit `functions/api/games/[id]/index.js`. At the top of the file (after imports), add:
+
+```js
+let cachedScoreTimezone = null
+
+async function getScoreTimezone(db) {
+  if (cachedScoreTimezone) return cachedScoreTimezone
+  const row = await db.prepare(
+    "SELECT value FROM config WHERE key = 'score_timezone'"
+  ).first()
+  cachedScoreTimezone = row?.value ?? 'America/Chicago'
+  return cachedScoreTimezone
+}
+```
+
+Then find and replace this block inside `onRequestGet`:
+
+Find:
+```js
+const tzRow = await env.DB.prepare("SELECT value FROM config WHERE key = 'score_timezone'").first()
+const timezone = tzRow?.value ?? 'America/Chicago'
+const [dayStart, dayEnd] = getDayScoreRange(timezone)
+```
+
+Replace with:
+```js
+const timezone = await getScoreTimezone(env.DB)
+const [dayStart, dayEnd] = getDayScoreRange(timezone)
+```
+
+- [ ] **Step 2-alt: Shared helper (multiple readers)**
+
+If `grep` showed multiple readers, do this instead. Edit `functions/api/_helpers.js` and add at the bottom:
+
+```js
+let cachedScoreTimezone = null
+
+export async function getScoreTimezone(db) {
+  if (cachedScoreTimezone) return cachedScoreTimezone
+  const row = await db.prepare(
+    "SELECT value FROM config WHERE key = 'score_timezone'"
+  ).first()
+  cachedScoreTimezone = row?.value ?? 'America/Chicago'
+  return cachedScoreTimezone
+}
+```
+
+In `functions/api/games/[id]/index.js`, change the import:
+
+Find:
+```js
+import { json, err, requireUser, getDayScoreRange, AuthError } from '../../_helpers.js'
+```
+
+Replace with:
+```js
+import { json, err, requireUser, getDayScoreRange, AuthError, getScoreTimezone } from '../../_helpers.js'
+```
+
+Then replace the same `tzRow`/`timezone` block as in Step 2 with:
+```js
+const timezone = await getScoreTimezone(env.DB)
+const [dayStart, dayEnd] = getDayScoreRange(timezone)
+```
+
+Apply the same import + call-site change to every other reader you found in Step 1.
+
+- [ ] **Step 3: Manual verification**
+
+Run: `npm run dev` and load any game page.
+Inspect: the Wrangler console output. The first request after server start should log a query for `config WHERE key = 'score_timezone'`. Subsequent requests for the same game should not — only the 6 game-fetch queries.
+
+(If the Wrangler logs aren't verbose enough to see this directly, alternative: temporarily add `console.log('cache miss')` inside the `if (!cachedScoreTimezone)` block, hit the endpoint twice, confirm the log fires once. Remove the `console.log` before committing.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add functions/api/games/[id]/index.js
+# If Step 2-alt: also stage functions/api/_helpers.js
+git commit -m "perf(api): memoize score_timezone config in Worker module scope"
+```
+
+**Note on test coverage:** The spec called for a single unit test of the cache helper. The repo currently has no test infrastructure for `functions/` (no Vitest config, no Wrangler test harness). Adding it for one test was deemed not worth the scope. The cache logic is six lines and fully verifiable by reading the source plus the manual log check above. If a `functions/` test runner is added later for any reason, fold a one-test cache-hit-count test in then.
+
+---
+
+## Task 6: Final verification + PR
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm test`
+Expected: all existing tests pass + the 8 new `useGameState` tests pass.
+
+- [ ] **Step 2: Run the build**
+
+Run: `npm run build`
+Expected: clean build.
+
+- [ ] **Step 3: End-to-end manual verification (per spec Section 5d)**
+
+Run: `npm run dev`. With browser DevTools network panel open:
+
+- Lobby idle → one request every 5 s.
+- Lobby with tab hidden → no requests.
+- Lobby with tab visible again → one immediate request, then 5 s cadence.
+- Active game → one request every 2 s.
+- Active game with tab hidden → no requests.
+- Active game with tab visible again → one immediate request, then 2 s cadence.
+- Game becomes complete → polling stops.
+
+Each of these is a hard pass/fail. Do not proceed if any fail.
+
+- [ ] **Step 4: Push branch + open PR**
+
+```bash
+git push -u origin design/issue-145-request-optimization
+gh pr create --title "Smart polling: gate frontend requests by status + tab visibility (#145)" --body "$(cat <<'EOF'
+## Summary
+- Introduces `useGameState(gameId)` hook in `frontend/src/hooks/` that owns all game-page polling. Cadence is 2s for `active`, 5s for `waiting`, stopped for `complete`. Pauses when `document.hidden`, resumes with an immediate fetch when visible.
+- `GamePage.jsx` migrated to the hook. `fetchGame()` calls in action handlers and the bot-play effect swapped for `refresh()`.
+- `LobbyPage.jsx` polling now pauses when the tab is hidden.
+- `GET /api/games/[id]` caches the `score_timezone` config singleton in Worker module scope (one fewer D1 query per poll).
+- Adds Vitest + jsdom + React Testing Library to the frontend workspace; 8 unit tests cover the hook's cadence, status-transition, visibility, cleanup, gameId-change, and refresh behaviors.
+
+Spec: \`docs/superpowers/specs/2026-04-26-issue-145-request-optimization-design.md\`
+Closes #145.
+
+ETag / push-based transport deferred to #149 ([context](https://github.com/andynumber2/sheepshead/issues/149#issuecomment-4323677349)).
+
+## Test plan
+- [x] \`npm test\` — all suites pass (existing + 8 new hook tests).
+- [x] \`npm run build\` — clean build.
+- [ ] Manual: lobby idle polls every 5s; mid-game polls every 2s; both pause when tab hidden; both resume with one immediate fetch when visible; polling stops when game becomes complete.
+- [ ] Post-deploy: monitor Cloudflare dashboard for one week. Targets: <50K Worker requests/week, <100 requests/hour during idle 1-hour windows.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist
+
+After implementation, before declaring done:
+
+- [ ] All 8 hook tests pass.
+- [ ] Build succeeds.
+- [ ] Manual verification of all 7 browser behaviors (Task 6 Step 3) passes.
+- [ ] No `fetchGame` or `pollingRef` references remain in `GamePage.jsx` (verify with `grep`).
+- [ ] No `score_timezone` query duplicated elsewhere in `functions/` (verify with `grep`).
+- [ ] PR description references issue #145 and #149 with correct context.

--- a/docs/superpowers/specs/2026-04-26-issue-145-request-optimization-design-for-PMs.md
+++ b/docs/superpowers/specs/2026-04-26-issue-145-request-optimization-design-for-PMs.md
@@ -1,0 +1,60 @@
+# Request Optimization (Smart Polling) — Overview for PMs
+
+**Issue:** [#145](https://github.com/andynumber2/sheepshead/issues/145)
+**Related:** [#149](https://github.com/andynumber2/sheepshead/issues/149) (long-term replacement)
+**Date:** 2026-04-26
+
+## What we're building
+
+A small, focused change to how the web app talks to the server. Today, every game page asks the server "anything new?" twice per second — forever — even when the game is over, the player has switched browser tabs, or no one is doing anything. We're making the app smart enough to stop asking when nothing can change, and to slow down when changes are infrequent.
+
+## Why we're doing this
+
+Internal traffic monitoring (Cloudflare dashboard) shows the app generating roughly **345,000 server requests per week from a single user**. The vast majority is wasted — the app is checking for updates constantly even when there is nothing to check. This number does not scale: as we add real users, costs climb linearly with this baseline, and the picture gets dramatically worse when a mobile app enters the picture (battery and cellular data are spent on each useless check).
+
+This spec is the "stop the bleeding" pass. A separate, larger initiative (issue #149) re-architects the system to push updates instead of poll for them, eliminating the question entirely. That work is in the future; this one ships now.
+
+## What changes for the user
+
+Nothing visible. The game still feels live during play, the lobby still shows new games as they appear, and player actions (picking up the blind, playing a card, etc.) still reflect immediately on screen. The improvements are all internal — the app simply stops asking pointless questions.
+
+## What changes behind the scenes
+
+Four behavioral rules:
+
+1. **When the game is over, stop checking.** Today, even after a hand is scored and the game is marked complete, the app continues asking the server for updates. After this change, polling halts as soon as the game ends.
+2. **When the browser tab is not visible, stop checking.** If a player switches to another tab or minimizes the browser, polling pauses. When they come back to the tab, the app does one immediate refresh and resumes.
+3. **Slow down when waiting.** While a game is in the lobby state (waiting for the next hand to be dealt or for players to join), the app checks every five seconds instead of every two. Less urgency, less waste.
+4. **Skip a small repeated server lookup.** A specific configuration value — the time zone used for daily score totals — is re-fetched from the database on every single request. It never changes during operation. We cache it in memory once and reuse it. Trivial code change, but it eliminates one database query per page check.
+
+## Critical logic to be aware of
+
+The single most important property of this change is that the app must never end up with multiple polling timers running at once, and it must never leave a timer running after the page that started it has gone away. Today's bug is essentially that polling is started but never properly stopped under certain conditions; the fix encapsulates start/stop into one place that owns the rule. The unit tests verify this for every state transition (game becomes active, game ends, tab hides, tab returns, page closes, game ID changes).
+
+The change is also designed to make the future #149 migration cheap. The web app will route all of its game-state-fetching through a single, replaceable component. When #149 lands and switches the underlying mechanism from polling to a live server-push connection, only that one component needs to change — the rest of the app does not know or care which mechanism is in use.
+
+## Out of scope (deferred or covered elsewhere)
+
+- **Caching unchanged responses.** A possible optimization where the server says "nothing has changed since you last asked" without doing the full database work. This was considered, but it adds code that the larger #149 work would throw away. Logged on #149 ([comment](https://github.com/andynumber2/sheepshead/issues/149#issuecomment-4323677349)).
+- **Reducing the number of database queries per request beyond the one cache.** Same reason — #149 rewrites this code path.
+- **Push-based updates (server tells client when something changes).** This is exactly what #149 is.
+- **Mobile app implementation.** The design records considerations for mobile (notably: don't poll every two seconds on cellular) but does not implement anything mobile-specific.
+- **Lobby page becoming push-based.** Out of scope for #149's first cut, and out of scope here.
+
+## Success criteria
+
+The change is "done" when **all** of the following hold:
+
+1. Automated unit tests pass for every behavior listed above (game ends, tab hides, etc.).
+2. Manual verification in a real browser confirms: idle on lobby = one request every 5 s, mid-game = one request every 2 s, both stop when the tab is hidden, and game-over halts polling entirely.
+3. After one week of real-world traffic, the Cloudflare dashboard shows:
+   - **Total Worker requests below 50,000 per week** (down from ~345,000 — an ~85% reduction).
+   - **Idle baseline below 100 requests per hour** during any one-hour window with no active gameplay (down from ~1,800).
+   - One fewer database query per game-page check (down from 7 to 6).
+4. No user-visible regressions in gameplay, lobby, or action responsiveness.
+
+The week-long traffic check is the real gate. If smart polling alone does not close the gap to the 50K target, that is the signal to revisit the deferred caching work earlier than #149 — handled as a follow-up issue, not as a re-open of this design.
+
+## Rollout
+
+A single pull request, a single deploy, no feature flag. The changes are entirely behavior-shaping (the web app behaves more politely; the server is unchanged except for one in-memory cache). If anything goes wrong, a one-click revert removes the change cleanly with no database migration to undo.

--- a/docs/superpowers/specs/2026-04-26-issue-145-request-optimization-design.md
+++ b/docs/superpowers/specs/2026-04-26-issue-145-request-optimization-design.md
@@ -1,0 +1,193 @@
+# Request Optimization (Smart Polling) — Design
+
+**Issue:** [#145](https://github.com/andynumber2/sheepshead/issues/145)
+**Related:** [#149](https://github.com/andynumber2/sheepshead/issues/149) (Durable Objects + WebSockets — long-term replacement)
+**Date:** 2026-04-26
+**Status:** Approved
+
+## Context
+
+The Cloudflare dashboard shows ~345K Worker requests/week from a single user, driven by a sustained ~0.5 req/sec idle baseline. Audit (in #145) traced this to `frontend/src/pages/GamePage.jsx:201-205`:
+
+```js
+useEffect(() => {
+  fetchGame()
+  pollingRef.current = setInterval(fetchGame, 2000)
+  return () => clearInterval(pollingRef.current)
+}, [fetchGame])
+```
+
+This `setInterval` polls `GET /api/games/[id]` every 2s unconditionally. It runs while the game is `complete`, while `waiting` for players, and while the browser tab is hidden. Each poll triggers ~7 D1 queries on the server. `LobbyPage.jsx:34` polls `/api/games` every 5s with the same lack of gating.
+
+Issue #149 tracks the long-term fix: re-architect in-flight game state onto Durable Objects with WebSocket subscriptions, eliminating polling. This spec is the "stop the bleeding" change that lands first and stands alone.
+
+## Goals
+
+- Cut Worker requests to **< 50K / week** (from 345K).
+- Pause polling when nothing meaningful can change: tab hidden, game `complete`, no current game.
+- Slow polling when changes are infrequent: lobby (5s), waiting-for-players (5s).
+- Cache the `score_timezone` config singleton in Worker module scope.
+- Introduce a frontend abstraction (`useGameState(gameId)` hook) so the future Durable Objects transport in #149 is a one-file swap.
+
+## Non-Goals
+
+- ETag / `304 Not Modified` short-circuit on `GET /api/games/[id]` — deferred to #149 ([noted in comment](https://github.com/andynumber2/sheepshead/issues/149#issuecomment-4323677349)). Smart polling alone is projected to hit the target; any ETag plumbing built now would be deleted when push-based transport lands.
+- Reducing the 6 remaining queries on `GET /api/games/[id]` (beyond the config cache) — #149 rewrites that path.
+- Real-time push (SSE / WebSocket) — that is #149.
+- Indexes, query consolidation, payload shrinking — same reason.
+- Server-side changes to handle the new client cadence — server stays stateless and identical; only the client behaves more politely.
+
+## Architecture
+
+### Polling state machine (client-side)
+
+A single rule decides the effective polling interval at each tick:
+
+| Condition | Effective interval |
+|---|---|
+| `document.hidden` | none (interval cleared) |
+| `game.status === 'complete'` | none |
+| `game.status === 'waiting'` | 5000 ms |
+| `game.status === 'active'` | 2000 ms |
+| Lobby page (no `gameId`) | 5000 ms, also subject to visibility gate |
+
+When `document.visibilityState` flips back to `visible`, fire one immediate fetch then resume the cadence above.
+
+### Server-side cache
+
+`score_timezone` is a singleton config row currently fetched on every `GET /api/games/[id]` call. Move to a Worker module-scope memoized lookup. No invalidation logic — config is set once at deploy time, isolates eventually recycle, and a fresh deploy guarantees fresh isolates.
+
+### Seam for Durable Objects (#149)
+
+A single React hook, `useGameState(gameId)`, encapsulates all transport. Its return shape (`{ game, loading, error, refresh }`) becomes the contract that #149 will swap polling for WebSocket behind, with no consumer changes.
+
+## Components
+
+### `frontend/src/hooks/useGameState.js` (new)
+
+The seam. Encapsulates fetch + interval management + visibility handling.
+
+**Returns:** `{ game, loading, error, refresh }`
+
+**Behavior:**
+- Fetches `GET /api/games/[id]` on mount.
+- Computes effective interval from `game.status` and `document.hidden` per the table above.
+- Subscribes to `visibilitychange`: on `visible`, do an immediate fetch then resume the interval.
+- Cleans up the interval on unmount and whenever the effective interval changes (no overlapping timers).
+- Cancels the active interval and starts a new one when `gameId` changes.
+- `refresh()` triggers an immediate fetch without disturbing the interval cadence.
+
+**Critical invariant:** at most one timer alive per hook instance at any time. The bug we are fixing is "intervals accumulate or persist past their useful life" — this hook must not reproduce it.
+
+### `frontend/src/pages/GamePage.jsx` (modified)
+
+Delete the `pollingRef` / `useEffect` / `setInterval` block at lines 201–205 and the `fetchGame` plumbing. Replace with:
+
+```js
+const { game, loading, error, refresh } = useGameState(gameId)
+```
+
+Action handlers (`handlePick`, `handlePlay`, etc.) call `refresh()` after a successful POST so the UI reflects the post-action state immediately rather than waiting for the next tick.
+
+### `frontend/src/pages/LobbyPage.jsx` (modified)
+
+Inline change — no hook abstraction (lobby is explicitly out-of-scope for the WebSocket migration in #149's first cut).
+
+- Keep the existing 5000 ms cadence on `loadGames`.
+- Add a `visibilitychange` listener: pause when hidden, do an immediate fetch and resume when visible.
+- Verify the existing cleanup on unmount still holds.
+
+### `functions/api/games/[id]/index.js` (modified)
+
+Replace the per-request `SELECT value FROM config WHERE key = 'score_timezone'` query with a memoized lookup:
+
+```js
+let scoreTimezoneCache = null
+async function getScoreTimezone(db) {
+  if (scoreTimezoneCache) return scoreTimezoneCache
+  const row = await db.prepare(
+    "SELECT value FROM config WHERE key = 'score_timezone'"
+  ).first()
+  scoreTimezoneCache = row?.value ?? 'America/Chicago'
+  return scoreTimezoneCache
+}
+```
+
+If the same singleton is read from any other endpoint (quick check during implementation), promote the helper to `functions/api/_helpers.js` so all routes share the cache. Otherwise leave inline.
+
+## Data Flow
+
+1. User opens a game page → `GamePage` mounts → `useGameState(gameId)` mounts.
+2. Hook fires initial fetch → server runs the 6 game-fetch queries + (cold-isolate only) 1 config query.
+3. Hook starts a 2000 ms interval (game is `active`) or 5000 ms (game is `waiting`).
+4. On every tick, hook re-fetches; server reuses cached `score_timezone` (warm isolate).
+5. User switches tabs away → `visibilitychange` fires → hook clears the interval. Zero requests.
+6. User switches back → `visibilitychange` fires → hook does one immediate fetch and restarts the interval.
+7. Hand finishes, game state moves to `complete` → next tick reads the new status → hook clears the interval. Zero further requests.
+8. User navigates away → `GamePage` unmounts → hook cleanup clears the interval.
+
+## Error Handling
+
+- Failed fetches surface via the hook's `error` state. No retry-with-backoff in this spec — the next tick is the retry. (Adding backoff is in scope only if testing reveals tight failure loops, which the gating already mitigates.)
+- The hook never throws synchronously from the timer callback; errors are caught and stored in state.
+
+## Testing
+
+### Unit — `frontend/src/hooks/useGameState.test.js` (new)
+
+Use React Testing Library + fake timers + `vi.spyOn` on `fetch`. Cover:
+
+- Polls every 2000 ms when `game.status === 'active'`.
+- Polls every 5000 ms when `game.status === 'waiting'`.
+- Stops polling when `game.status === 'complete'`.
+- Stops polling when `document.hidden` becomes true; resumes (with an immediate fetch) when it becomes false.
+- Cleans up the interval on unmount — assert no leaked timers.
+- Switching `gameId` cancels the old interval and starts a new one.
+- `refresh()` triggers an immediate fetch without disturbing cadence.
+
+### Integration — `GamePage`
+
+Light touch. Existing GamePage tests (if any) should pass without modification — that's the seam working.
+
+### Backend — config cache
+
+Single test in the existing pattern (or add one if none exists): two consecutive calls to `getScoreTimezone` hit the DB once. Stub the D1 binding's `prepare(...).first()` and assert call count.
+
+### Manual verification (required before declaring done)
+
+Run `npm run dev` and watch the network panel:
+- Idle on `/lobby` → one request every 5 s; stops when tab hidden.
+- Mid-game → one request every 2 s; stops when tab hidden.
+- Game completes → polling stops.
+- Switch tab away and back → polling pauses then resumes with one immediate fetch.
+
+This is behavior that passes unit tests and silently regresses in production. The manual check is non-negotiable.
+
+## Mobile App Considerations
+
+CLAUDE.md flags that a mobile app is on the roadmap. Recording the implications so future mobile work has the context:
+
+- **Polling endpoint contract is unchanged** — mobile can call the same `GET /api/games/[id]` if it ships before #149.
+- **`useGameState` hook is web-only**, but the *concept* — a single subscription primitive that abstracts transport — translates directly to a mobile equivalent (Swift/Kotlin observer, React Native hook). The lesson the seam encodes is what mobile needs.
+- **Visibility handling is web-specific** (`document.visibilitychange`). Mobile has its own foreground/background lifecycle; the same gating concept applies but the trigger is the platform's app-lifecycle event. Worth wiring up explicitly on mobile so it doesn't poll continuously.
+- **2 s active cadence is aggressive on cellular.** When mobile lands before #149, use a more conservative cadence (5 s active, 10 s waiting). Better: mobile may want to wait for #149 entirely so it ships on WebSocket from day one.
+
+## Success Criteria
+
+The change is done when **all** of the following hold:
+
+1. **Unit tests pass** for `useGameState` covering every cadence/visibility transition.
+2. **Manual verification confirms** each of the four browser behaviors above.
+3. **Cloudflare dashboard, after one week of post-deploy traffic**, shows:
+   - Worker requests: **< 50K / week** (down from 345K).
+   - Idle baseline (rolling 1-hour window with no active gameplay): **< 100 requests/hour** (down from ~1,800).
+   - Per-request D1 query count on `GET /api/games/[id]`: **6** (down from 7).
+4. **No regressions** in observed gameplay — the game still feels live during play, lobby still updates, action POSTs still reflect immediately.
+
+The week-long check is the real gate. If smart polling does not close the gap to target, that is the signal to revisit deferred ETag work earlier than #149 — not by re-opening this design, but by filing a follow-up.
+
+## Rollout
+
+- Single PR, single deploy. No flag — the changes are pure client-side gating + a server-side cache that defaults to identical behavior.
+- Post-deploy: monitor the Cloudflare dashboard daily for the first week. The 1-hour idle baseline should drop within minutes of deploy as soon as the user closes the tab.
+- Rollback: standard `git revert` of the PR. No schema migration to undo.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "vite --port 3000",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@picocss/pico": "^2.1.1",
@@ -13,7 +14,11 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@vitejs/plugin-react": "^4.3.1",
-    "vite": "^5.4.10"
+    "jsdom": "^25.0.1",
+    "vite": "^5.4.10",
+    "vitest": "^4.1.5"
   }
 }

--- a/frontend/src/hooks/useGameState.js
+++ b/frontend/src/hooks/useGameState.js
@@ -1,0 +1,85 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+
+function intervalForStatus(status) {
+  if (status === 'active')  return 2000
+  if (status === 'waiting') return 5000
+  return null
+}
+
+export function useGameState(gameId, fetchFn) {
+  const [game, setGame]       = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError]     = useState(null)
+  const intervalRef = useRef(null)
+
+  const clearTimer = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current)
+      intervalRef.current = null
+    }
+  }
+
+  const fetchOnce = useCallback(async () => {
+    try {
+      const data = await fetchFn(gameId)
+      setGame(data)
+      setError(null)
+      return data
+    } catch (e) {
+      setError(e)
+      return null
+    } finally {
+      setLoading(false)
+    }
+  }, [gameId, fetchFn])
+
+  const refresh = useCallback(() => fetchOnce(), [fetchOnce])
+
+  // Schedule polling that reconfigures whenever the cadence-determining
+  // condition (status, eventually visibility) changes. The single source of
+  // truth for "what interval should we be on right now?" is `desiredInterval()`.
+  useEffect(() => {
+    let cancelled = false
+    let currentMs = null
+
+    const desiredInterval = (data) => {
+      if (document.hidden) return null
+      return intervalForStatus(data?.status)
+    }
+
+    const tick = async () => {
+      if (cancelled) return
+      const data = await fetchOnce()
+      if (cancelled || !data) return
+      const next = desiredInterval(data)
+      if (next !== currentMs) {
+        clearTimer()
+        currentMs = next
+        if (next != null) {
+          intervalRef.current = setInterval(tick, next)
+        }
+      }
+    }
+
+    const onVisibility = () => {
+      if (cancelled) return
+      if (document.hidden) {
+        clearTimer()
+        currentMs = null
+      } else {
+        tick()
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisibility)
+    tick()
+
+    return () => {
+      cancelled = true
+      clearTimer()
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
+  }, [fetchOnce])
+
+  return { game, loading, error, refresh }
+}

--- a/frontend/src/hooks/useGameState.test.js
+++ b/frontend/src/hooks/useGameState.test.js
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useGameState } from './useGameState.js'
+
+function mockApi(states) {
+  // states: array of game objects to return on successive calls
+  let i = 0
+  return vi.fn(async () => {
+    const next = states[Math.min(i, states.length - 1)]
+    i += 1
+    return next
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true })
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => 'visible',
+  })
+  Object.defineProperty(document, 'hidden', {
+    configurable: true,
+    get: () => false,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+describe('useGameState', () => {
+  it('polls every 2000ms when game status is active', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3)
+  })
+
+  it('polls every 5000ms when game status is waiting', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'waiting' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(1)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(3000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not poll when game status is complete', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'complete' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(1)
+  })
+
+  it('reconfigures interval when game status changes between fetches', async () => {
+    const fetchGame = vi.fn()
+      .mockResolvedValueOnce({ id: 1, status: 'waiting' })
+      .mockResolvedValueOnce({ id: 1, status: 'active' })
+      .mockResolvedValueOnce({ id: 1, status: 'active' })
+      .mockResolvedValue({ id: 1, status: 'complete' })
+
+    renderHook(() => useGameState('1', fetchGame))
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(5000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(4)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(4)
+  })
+
+  it('stops polling when document becomes hidden, resumes (with immediate fetch) when visible', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => true })
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'hidden' })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => false })
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' })
+    await act(async () => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(3))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(4)
+  })
+
+  it('clears the interval and removes visibilitychange listener on unmount', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    const removeSpy = vi.spyOn(document, 'removeEventListener')
+    const { unmount } = renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    unmount()
+    expect(removeSpy).toHaveBeenCalledWith('visibilitychange', expect.any(Function))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(10000) })
+    expect(fetchGame).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels the old interval and starts a new fetch when gameId changes', async () => {
+    const fetchGame = vi.fn(async (id) => ({ id: Number(id), status: 'active' }))
+    const { rerender } = renderHook(
+      ({ id }) => useGameState(id, fetchGame),
+      { initialProps: { id: '1' } }
+    )
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledWith('1'))
+
+    rerender({ id: '2' })
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledWith('2'))
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    const callsForGame2 = fetchGame.mock.calls.filter(([id]) => id === '2').length
+    expect(callsForGame2).toBeGreaterThanOrEqual(2)
+  })
+
+  it('refresh() triggers an immediate fetch without disturbing cadence', async () => {
+    const fetchGame = mockApi([{ id: 1, status: 'active' }])
+    const { result } = renderHook(() => useGameState('1', fetchGame))
+
+    await waitFor(() => expect(fetchGame).toHaveBeenCalledTimes(1))
+
+    await act(async () => { await result.current.refresh() })
+    expect(fetchGame).toHaveBeenCalledTimes(2)
+
+    await act(async () => { await vi.advanceTimersByTimeAsync(2000) })
+    expect(fetchGame).toHaveBeenCalledTimes(3)
+  })
+})

--- a/frontend/src/pages/GamePage.jsx
+++ b/frontend/src/pages/GamePage.jsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { useState, useEffect, useMemo, useRef } from 'react'
 import { effectiveSuit } from '@shared/gameEngine.js'
 import { computeBotSuggestion } from '@shared/botSuggestion.js'
 import { api } from '../lib/api.js'
+import { useGameState } from '../hooks/useGameState.js'
 import PlayerSeat from '../components/PlayerSeat.jsx'
 import TrickArea, { LastTrickArea } from '../components/TrickArea.jsx'
 import ActionPanel from '../components/ActionPanel.jsx'
@@ -146,8 +147,8 @@ function getLegalCardIds(state, userId, hand) {
 
 // ── Main GamePage ─────────────────────────────────────────────────────────────
 export default function GamePage({ gameId, user, onNavigate }) {
-  const [gameData, setGameData]             = useState(null)
   const [error, setError]                   = useState(null)
+  const { game: gameData, error: hookError, refresh } = useGameState(gameId, api.games.get)
   const [actionLoading, setActionLoading]   = useState(false)
   const [leaving, setLeaving]               = useState(false)
   const [currentVariant, setCurrentVariant] = useState(null)
@@ -170,7 +171,6 @@ export default function GamePage({ gameId, user, onNavigate }) {
       // localStorage unavailable — in-memory state still updates.
     }
   }
-  const pollingRef = useRef(null)
   // Tracks the auto-play timer for the last trick. We key by
   // `${turnUserId}:${trickLen}` so each "pending play" only schedules once,
   // even though state polling produces a new state object every 2s.
@@ -184,25 +184,18 @@ export default function GamePage({ gameId, user, onNavigate }) {
 
   const myUserId = String(user.id)
 
-  const fetchGame = useCallback(async () => {
-    try {
-      const data = await api.games.get(gameId)
-      setGameData(data)
-      // Only set once — don't clobber in-flight admin changes
-      setCurrentVariant(prev => prev ?? data.settings?.no_pick_variant)
-      setRevealPartner(prev => prev ?? data.settings?.reveal_partner)
-      setDobEnabled(prev => prev ?? data.settings?.double_on_bump)
-      setError(null)
-    } catch (e) {
-      setError(e.message)
-    }
-  }, [gameId])
-
+  // ── Seed variant/reveal/DOB defaults once from game settings ────────────────
   useEffect(() => {
-    fetchGame()
-    pollingRef.current = setInterval(fetchGame, 2000)
-    return () => clearInterval(pollingRef.current)
-  }, [fetchGame])
+    if (!gameData) return
+    setCurrentVariant(prev => prev ?? gameData.settings?.no_pick_variant)
+    setRevealPartner(prev => prev ?? gameData.settings?.reveal_partner)
+    setDobEnabled(prev => prev ?? gameData.settings?.double_on_bump)
+  }, [gameData])
+
+  // ── Mirror hook errors into local error state ────────────────────────────────
+  useEffect(() => {
+    if (hookError) setError(hookError.message)
+  }, [hookError])
 
   // ── Auto-play the last trick ────────────────────────────────────────────────
   // Once we're down to the final trick (every player has exactly 1 card left),
@@ -286,13 +279,13 @@ export default function GamePage({ gameId, user, onNavigate }) {
       botPlayRef.current.timer = null
       try {
         await api.games.action(gameId, 'bot_play', {})
-        await fetchGame()
+        await refresh()
       } catch {
         // State may have already advanced (e.g. another client acted); ignore.
       }
     }, delay)
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [gameData, gameId, fetchGame])
+  }, [gameData, gameId, refresh])
 
   // Cancel any pending bot-play timer on unmount.
   useEffect(() => () => {
@@ -353,7 +346,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
     setActionLoading(true)
     try {
       await api.games.action(gameId, type, payload, actAs)
-      await fetchGame()
+      await refresh()
     } finally {
       setActionLoading(false)
     }
@@ -369,7 +362,7 @@ export default function GamePage({ gameId, user, onNavigate }) {
   async function handleFillWithBots() {
     try {
       await api.games.fillWithBots(gameId)
-      await fetchGame()
+      await refresh()
     } catch (e) {
       setError(e.message)
     }

--- a/frontend/src/pages/LobbyPage.jsx
+++ b/frontend/src/pages/LobbyPage.jsx
@@ -30,9 +30,36 @@ export default function LobbyPage({ user, onNavigate, onLogout }) {
   }
 
   useEffect(() => {
+    let intervalId = null
+
+    const start = () => {
+      if (intervalId != null) return
+      intervalId = setInterval(loadGames, 5000)
+    }
+    const stop = () => {
+      if (intervalId != null) {
+        clearInterval(intervalId)
+        intervalId = null
+      }
+    }
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        stop()
+      } else {
+        loadGames()
+        start()
+      }
+    }
+
     loadGames()
-    const interval = setInterval(loadGames, 5000)
-    return () => clearInterval(interval)
+    if (!document.hidden) start()
+    document.addEventListener('visibilitychange', onVisibility)
+
+    return () => {
+      stop()
+      document.removeEventListener('visibilitychange', onVisibility)
+    }
   }, [])
 
   async function handleCreate(e) {

--- a/frontend/test-setup.js
+++ b/frontend/test-setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest'

--- a/frontend/vitest.config.js
+++ b/frontend/vitest.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'path'
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@shared': path.resolve(__dirname, '../shared'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./test-setup.js'],
+    include: ['src/**/*.test.{js,jsx}'],
+  },
+})

--- a/functions/api/_helpers.js
+++ b/functions/api/_helpers.js
@@ -111,3 +111,14 @@ function _localMidnightUTC(y, m, d, timezone) {
   // Local midnight = noonRef minus the local time at noonRef
   return new Date(noonRef.getTime() - (h * 3600 + min * 60 + sec) * 1000)
 }
+
+let cachedScoreTimezone = null
+
+export async function getScoreTimezone(db) {
+  if (cachedScoreTimezone) return cachedScoreTimezone
+  const row = await db.prepare(
+    "SELECT value FROM config WHERE key = 'score_timezone'"
+  ).first()
+  cachedScoreTimezone = row?.value ?? 'America/Chicago'
+  return cachedScoreTimezone
+}

--- a/functions/api/admin/users/[id]/index.js
+++ b/functions/api/admin/users/[id]/index.js
@@ -1,4 +1,4 @@
-import { json, err, requireAdmin, hashPassword, randomHex, getDayScoreRange, AuthError } from '../../../_helpers.js'
+import { json, err, requireAdmin, hashPassword, randomHex, getDayScoreRange, getScoreTimezone, AuthError } from '../../../_helpers.js'
 
 export async function onRequest({ request, env, params }) {
   try {
@@ -21,8 +21,7 @@ async function getUser({ request, env, params }) {
   ).bind(userId).first()
   if (!user) return err('User not found.', 404)
 
-  const tzRow = await env.DB.prepare("SELECT value FROM config WHERE key = 'score_timezone'").first()
-  const timezone = tzRow?.value ?? 'America/Chicago'
+  const timezone = await getScoreTimezone(env.DB)
   const [dayStart, dayEnd] = getDayScoreRange(timezone)
 
   const lifetimeRow = await env.DB.prepare(

--- a/functions/api/admin/users/index.js
+++ b/functions/api/admin/users/index.js
@@ -1,11 +1,10 @@
-import { json, err, requireAdmin, getDayScoreRange, AuthError } from '../../_helpers.js'
+import { json, err, requireAdmin, getDayScoreRange, getScoreTimezone, AuthError } from '../../_helpers.js'
 
 export async function onRequestGet({ request, env }) {
   try {
     const _admin = await requireAdmin(request, env.DB)
 
-    const tzRow = await env.DB.prepare("SELECT value FROM config WHERE key = 'score_timezone'").first()
-    const timezone = tzRow?.value ?? 'America/Chicago'
+    const timezone = await getScoreTimezone(env.DB)
     const [dayStart, dayEnd] = getDayScoreRange(timezone)
 
     const { results } = await env.DB.prepare(

--- a/functions/api/auth/me.js
+++ b/functions/api/auth/me.js
@@ -1,11 +1,10 @@
-import { json, err, getUser, getDayScoreRange } from '../_helpers.js'
+import { json, err, getUser, getDayScoreRange, getScoreTimezone } from '../_helpers.js'
 
 export async function onRequestGet({ request, env }) {
   const user = await getUser(request, env.DB)
   if (!user) return err('Not authenticated.', 401)
 
-  const tzRow = await env.DB.prepare("SELECT value FROM config WHERE key = 'score_timezone'").first()
-  const timezone = tzRow?.value ?? 'America/Chicago'
+  const timezone = await getScoreTimezone(env.DB)
   const [dayStart, dayEnd] = getDayScoreRange(timezone)
 
   const lifetimeRow = await env.DB.prepare(

--- a/functions/api/games/[id]/index.js
+++ b/functions/api/games/[id]/index.js
@@ -1,4 +1,4 @@
-import { json, err, requireUser, getDayScoreRange, AuthError } from '../../_helpers.js'
+import { json, err, requireUser, getDayScoreRange, getScoreTimezone, AuthError } from '../../_helpers.js'
 import { getPlayerView } from '../../../../shared/gameEngine.js'
 
 export async function onRequestGet({ request, env, params }) {
@@ -27,8 +27,7 @@ export async function onRequestGet({ request, env, params }) {
     ).bind(gameId).all()
 
     // Lifetime from user_scores cache; game score and day score from bounded score_events queries
-    const tzRow = await env.DB.prepare("SELECT value FROM config WHERE key = 'score_timezone'").first()
-    const timezone = tzRow?.value ?? 'America/Chicago'
+    const timezone = await getScoreTimezone(env.DB)
     const [dayStart, dayEnd] = getDayScoreRange(timezone)
 
     const { results: scoreRows } = await env.DB.prepare(`

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,41 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@vitejs/plugin-react": "^4.3.1",
-        "vite": "^5.4.10"
+        "jsdom": "^25.0.1",
+        "vite": "^5.4.10",
+        "vitest": "^4.1.5"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -449,10 +481,125 @@
         "node": ">=12"
       }
     },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -462,10 +609,11 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -1308,9 +1456,9 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.3.tgz",
-      "integrity": "sha512-xK9sGVbJWYb08+mTJt3/YV24WxvxpXcXtP6B172paPZ+Ts69Re9dAr7lKwJoeIx8OoeuimEiRZ7umkiUVClmmQ==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1327,9 +1475,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.124.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
-      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "version": "0.127.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.127.0.tgz",
+      "integrity": "sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -1342,9 +1490,9 @@
       "integrity": "sha512-kIDugA7Ps4U+2BHxiNHmvgPIQDWPDU4IeU6TNRdvXQM1uZX+FibqDQT2xUOnnO2yq/LUHcwnGlu1hvf4KfXnMg=="
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==",
       "cpu": [
         "arm64"
       ],
@@ -1359,9 +1507,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==",
       "cpu": [
         "arm64"
       ],
@@ -1376,9 +1524,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==",
       "cpu": [
         "x64"
       ],
@@ -1393,9 +1541,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==",
       "cpu": [
         "x64"
       ],
@@ -1410,9 +1558,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
-      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.17.tgz",
+      "integrity": "sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==",
       "cpu": [
         "arm"
       ],
@@ -1427,9 +1575,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==",
       "cpu": [
         "arm64"
       ],
@@ -1447,9 +1595,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==",
       "cpu": [
         "arm64"
       ],
@@ -1467,9 +1615,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==",
       "cpu": [
         "ppc64"
       ],
@@ -1487,9 +1635,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==",
       "cpu": [
         "s390x"
       ],
@@ -1507,9 +1655,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
-      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.17.tgz",
+      "integrity": "sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==",
       "cpu": [
         "x64"
       ],
@@ -1527,9 +1675,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
-      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==",
       "cpu": [
         "x64"
       ],
@@ -1547,9 +1695,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.17.tgz",
+      "integrity": "sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==",
       "cpu": [
         "arm64"
       ],
@@ -1564,9 +1712,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
-      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.17.tgz",
+      "integrity": "sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==",
       "cpu": [
         "wasm32"
       ],
@@ -1574,18 +1722,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "1.9.2",
-        "@emnapi/runtime": "1.9.2",
-        "@napi-rs/wasm-runtime": "^1.1.3"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==",
       "cpu": [
         "arm64"
       ],
@@ -1600,9 +1748,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
-      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.17.tgz",
+      "integrity": "sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==",
       "cpu": [
         "x64"
       ],
@@ -1954,6 +2102,82 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1964,6 +2188,14 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2051,16 +2283,16 @@
       }
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
-      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.1.0"
       },
@@ -2069,9 +2301,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
-      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2082,13 +2314,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
-      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.4",
+        "@vitest/utils": "4.1.5",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -2096,14 +2328,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
-      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -2122,9 +2354,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
-      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -2132,13 +2364,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
-      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.4",
+        "@vitest/pretty-format": "4.1.5",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.1.0"
       },
@@ -2167,6 +2399,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2191,6 +2433,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/as-table": {
       "version": "1.0.55",
       "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
@@ -2209,6 +2461,13 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.16",
@@ -2259,6 +2518,20 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2376,6 +2649,19 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concurrently": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-8.2.2.tgz",
@@ -2418,11 +2704,53 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/data-uri-to-buffer": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
       "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
       "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/date-fns": {
       "version": "2.30.0",
@@ -2457,11 +2785,38 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/defu": {
       "version": "6.1.6",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
       "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
       "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -2470,6 +2825,29 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2484,12 +2862,74 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.17.19",
@@ -2601,6 +3041,23 @@
         }
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2613,6 +3070,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/gensync": {
@@ -2633,6 +3100,45 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/get-source": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
@@ -2649,11 +3155,130 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2674,10 +3299,58 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -3002,6 +3675,17 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.25.9",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
@@ -3009,6 +3693,16 @@
       "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.8"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/mime": {
@@ -3021,6 +3715,39 @@
       },
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/miniflare": {
@@ -3087,6 +3814,13 @@
       "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true
     },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -3103,6 +3837,19 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -3136,9 +3883,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -3154,6 +3901,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3163,11 +3911,51 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/printable-characters": {
       "version": "1.0.42",
       "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
       "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
       "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -3192,6 +3980,14 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3199,6 +3995,20 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/require-directory": {
@@ -3211,14 +4021,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
-      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.17.tgz",
+      "integrity": "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.124.0",
-        "@rolldown/pluginutils": "1.0.0-rc.15"
+        "@oxc-project/types": "=0.127.0",
+        "@rolldown/pluginutils": "1.0.0-rc.17"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -3227,27 +4037,27 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.17",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
     "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.15",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
-      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "version": "1.0.0-rc.17",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.17.tgz",
+      "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3325,6 +4135,13 @@
         "estree-walker": "^0.6.1"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -3332,6 +4149,26 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -3519,6 +4356,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/supports-color": {
       "version": "8.1.1",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
@@ -3533,6 +4383,13 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -3576,6 +4433,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/tree-kill": {
@@ -4104,19 +5007,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
-      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.4",
-        "@vitest/mocker": "4.1.4",
-        "@vitest/pretty-format": "4.1.4",
-        "@vitest/runner": "4.1.4",
-        "@vitest/snapshot": "4.1.4",
-        "@vitest/spy": "4.1.4",
-        "@vitest/utils": "4.1.4",
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -4144,12 +5047,12 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.4",
-        "@vitest/browser-preview": "4.1.4",
-        "@vitest/browser-webdriverio": "4.1.4",
-        "@vitest/coverage-istanbul": "4.1.4",
-        "@vitest/coverage-v8": "4.1.4",
-        "@vitest/ui": "4.1.4",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
         "happy-dom": "*",
         "jsdom": "*",
         "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -4194,13 +5097,13 @@
       }
     },
     "node_modules/vitest/node_modules/@vitest/mocker": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
-      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.4",
+        "@vitest/spy": "4.1.5",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -4241,17 +5144,17 @@
       }
     },
     "node_modules/vitest/node_modules/vite": {
-      "version": "8.0.8",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
-      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "version": "8.0.10",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.10.tgz",
+      "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.15",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.10",
+        "rolldown": "1.0.0-rc.17",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -4316,6 +5219,67 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/why-is-node-running": {
@@ -4429,6 +5393,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "deploy": "npm run build && wrangler pages deploy frontend/dist",
     "db:migrate:local": "wrangler d1 migrations apply sheepshead-db --local",
     "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run && npm test -w frontend",
     "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['shared/**/*.test.{js,ts}'],
+    passWithNoTests: true,
+  },
+})


### PR DESCRIPTION
## Summary

- Introduces `useGameState(gameId, fetchFn)` hook in `frontend/src/hooks/` that owns all game-page polling. Cadence is 2s for `active`, 5s for `waiting`, stopped for `complete`. Pauses when `document.hidden`, resumes with one immediate fetch when visible. The hook's return shape `{ game, loading, error, refresh }` is the public contract — when push transport lands in #149, only the hook's internals change.
- `GamePage.jsx` migrated to the hook. `fetchGame()` calls in `handleAction`, `handleFillWithBots`, and the bot-play effect swapped for `refresh()`.
- `LobbyPage.jsx` polling now pauses when the tab is hidden and resumes with one immediate fetch when visible.
- `score_timezone` config singleton memoized in Worker module scope. Promoted to a shared helper in `functions/api/_helpers.js` because 4 endpoints read it (`games/[id]`, `auth/me`, `admin/users/index`, `admin/users/[id]`) — each now skips one D1 query per request after the first cold-start fetch.
- Adds Vitest + jsdom + React Testing Library to the frontend workspace; 8 unit tests cover the hook's cadence, status-transition reconfigure, visibility, unmount cleanup, gameId-change, and `refresh()` behaviors.

Spec: `docs/superpowers/specs/2026-04-26-issue-145-request-optimization-design.md`
Plan: `docs/superpowers/plans/2026-04-26-issue-145-request-optimization-plan.md`

Closes #145.

ETag / push-based transport deferred to #149 (subsumed in that issue's body under "Subsumed from #145").

## Test plan

- [x] `npm test` — 231/231 pass (223 existing shared + 8 new hook tests)
- [x] `npm run build` — clean (235 kB bundle)
- [x] Manual e2e in browser: lobby idle polls every 5s; mid-game polls every 2s; both pause when tab hidden; both resume with one immediate fetch when visible
- [ ] Post-deploy: monitor Cloudflare dashboard for one week. Targets: <50K Worker requests/week, <100 requests/hour during idle 1-hour windows, 6 D1 queries per `GET /api/games/[id]` (down from 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)