### PR TITLE
feat(bot): defender force-takes trick to enable called-suit lead-back

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -106,10 +106,24 @@ A recurring concept below is a **guaranteed winner**: a trump card the bot holds
 
 #### Opponent bot following
 1. **Schmear** (a confirmed teammate — partner identity must be known — is currently winning):
-   - **Safe** (no picker or partner remains to play, or the teammate's winning card is itself a guaranteed winner): dump the highest-value non-trump. If only trump available, play the lowest card.
+   - **Safe** (no picker or partner remains to play, or the teammate's winning card is itself a guaranteed winner): dump the highest-priority non-trump per the **schmear priority** (see below). If only trump available, play the lowest card.
    - **Not safe**: if the bot can take the trick with a guaranteed-winning card, play the lowest-point such card. Otherwise schmear anyway — no speculative trump burn when a guaranteed takeover isn't available.
-2. **Trump in on called suit**: If the called suit was led and the picker team is currently winning the trick, play the lowest available trump to contest.
-3. **Otherwise**: play the lowest card.
+2. **Force-take to enable called-suit lead-back**: When the partner is **not yet revealed**, the current trick is **not** led with the called suit, the bot holds **at least one non-trump card of the called suit** in hand (a card that can be led back next trick), and the bot can take the current trick:
+   - Compute **potential opponents remaining** = count of non-self players still to play this trick. With partner unrevealed, no other defender is confirmed as a teammate, so every yet-to-play seat is treated as a picker-team threat.
+   - **Bot can play trump** (void in led suit, or trump led):
+     - Threats remaining > 0 → take with **highest trump** in the winning set.
+     - Threats remaining = 0 → take with the schmear-self pick using the **trump priority** (see below).
+   - **Bot must follow a non-called fail suit** (only fail winners available):
+     - Threats remaining > 0 → **skip** (an unrevealed opponent could be void and trump over). Fall through to default.
+     - Threats remaining = 0 → take with the schmear-self pick using the **fail priority** (see below).
+3. **Trump in on called suit**: If the called suit was led and the picker team is currently winning the trick, play the lowest available trump to contest.
+4. **Otherwise**: play the lowest card.
+
+**Schmear priority** (used by both the schmear branch above and the force-take branch's 0-threats-remaining cases): walk a rank-priority list and pick the first card found.
+- **Trump priority**: A, 10, K, 9, 8, 7, J, Q. Within the same letter (only meaningful for J or Q), prefer the **weakest by trump rank** (e.g. among Qs: Q♦ before Q♥ before Q♠ before Q♣).
+- **Fail priority**: A, 10, K, 9, 8, 7. Within the same rank (only meaningful for the schmear branch where the input may span multiple non-trump suits), prefer the card from the **shortest non-trump suit in hand** (move toward voiding); secondary tiebreak by suit alphabetical.
+
+Rationale: cash high-point cards (A=11, 10=10, K=4) first; spend zero-point pip cards next; keep the tactically valuable Js and Qs in reserve.
 
 ---
 
@@ -129,3 +143,4 @@ These pure functions support the strategy above but make no decisions themselves
 | `teammateWinning` | Returns true if the current trick leader is on the same team as the bot |
 | `isGuaranteedWinner` | For a trump card, returns true iff every higher-rank trump has been seen (own hand, played tricks, current trick, visible bury). Unseen higher trump is treated as opponent-held. Non-trump cards are never guaranteed. |
 | `cheapestGuaranteedWin` | From a set of candidate cards, returns the lowest-point card that satisfies `isGuaranteedWinner` (tiebreak: weaker trump first). Returns null if none qualify. |
+| `pickBySchmearPriority` | Pick the least-painful winning card to spend, walking a rank-priority list (`A,10,K,9,8,7,J,Q` for trump; `A,10,K,9,8,7` for fail). Trump tiebreak: weakest trump rank. Fail tiebreak: shortest non-trump suit in hand, then alphabetical. |

--- a/docs/superpowers/plans/2026-04-26-bot-defender-force-take-called-suit.md
+++ b/docs/superpowers/plans/2026-04-26-bot-defender-force-take-called-suit.md
@@ -1,0 +1,798 @@
+# Bot Defender Force-Take to Enable Called-Suit Lead-Back — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a defender-bot following-trick branch that force-takes the current trick (highest trump when threats remain, schmear-self priority when no threats remain) so the bot can lead the called suit on the following trick to flush the picker's partner. Consolidate existing duplicated schmear closures around the same priority helper while we're there.
+
+**Architecture:** One new pure helper `pickBySchmearPriority(candidates, kind, hand)` in `shared/botInference.js`. Two existing schmear closures in `shared/botStrategy.js` (`schmear()` and `schmearOpp()`) refactored to call it with `kind: 'fail'`. New branch in `decidePlay`'s opponent-following section between the existing schmear-on-confirmed-teammate block and the trump-in-on-called-suit block. Lead-back behavior already exists at `botStrategy.js:312-318` and is unchanged. `docs/BOTS.md` updated to match.
+
+**Tech Stack:** JavaScript (ESM), Vitest test runner. No new dependencies.
+
+---
+
+## File Structure
+
+| File | Role | Change |
+|---|---|---|
+| `shared/botInference.js` | Pure card-selection primitives | **Modify**: add `TRUMP_SCHMEAR_PRIORITY`, `FAIL_SCHMEAR_PRIORITY`, `pickBySchmearPriority` |
+| `shared/botStrategy.js` | Bot decision logic (`decidePlay` etc.) | **Modify**: import new helper; replace bodies of `schmear()` and `schmearOpp()` closures; add new opponent-following branch |
+| `shared/gameEngine.test.js` | Existing test file housing bot strategy tests | **Modify**: add helper unit tests, schmear regression tests, and new-branch behavior tests |
+| `docs/BOTS.md` | Plain-English bot strategy reference | **Modify**: add new branch to "Opponent bot following" section; update schmear description to mention new tiebreak |
+
+Spec to reference throughout: `docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design.md`.
+
+---
+
+## Spec section: Helper
+
+### Task 1: Add `pickBySchmearPriority` helper
+
+**Files:**
+- Modify: `shared/botInference.js`
+- Test: `shared/gameEngine.test.js` (add to existing botInference test region; create a new `describe` block)
+
+- [ ] **Step 1.1: Write failing tests for the helper**
+
+Add a new `describe` block at the end of `shared/gameEngine.test.js` (the file already imports from `botInference.js` at the top — add `pickBySchmearPriority` to that import). Use the existing `c(rank, suit)` helper for card construction (defined at line 21).
+
+```javascript
+import {
+  // ... existing imports
+  pickBySchmearPriority,
+} from './botInference.js'
+
+describe('pickBySchmearPriority', () => {
+  it('trump kind: returns A♦ when winning set covers all priority ranks', () => {
+    const candidates = [c('A','D'), c('10','D'), c('K','D'), c('9','D'), c('J','H'), c('Q','D')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('AD')
+  })
+
+  it('trump kind: returns J♥ over Q (J before Q in priority)', () => {
+    const candidates = [c('Q','C'), c('Q','D'), c('J','H')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('JH')
+  })
+
+  it('trump kind: among Qs, returns weakest by trump rank (Q♦)', () => {
+    const candidates = [c('Q','C'), c('Q','D'), c('Q','S')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('QD')
+  })
+
+  it('trump kind: among Js, returns weakest by trump rank (J♦)', () => {
+    const candidates = [c('J','C'), c('J','S'), c('J','D')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('JD')
+  })
+
+  it('fail kind: returns A♠ when winning set is single-suit', () => {
+    const candidates = [c('A','S'), c('K','S'), c('8','S')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('AS')
+  })
+
+  it('fail kind: prefers card from shortest non-trump suit in hand', () => {
+    const candidates = [c('A','S'), c('A','C')]
+    // Hand has 3 spades and 1 club among non-trump → clubs is shorter
+    const hand = [c('A','S'), c('K','S'), c('9','S'), c('A','C'), c('Q','D')]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('AC')
+  })
+
+  it('fail kind: alphabetical suit tiebreak when suit lengths tied', () => {
+    const candidates = [c('A','S'), c('A','C')]
+    // 2 spades, 2 clubs in non-trump hand → tied; C < S alphabetically → AC
+    const hand = [c('A','S'), c('8','S'), c('A','C'), c('7','C')]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('AC')
+  })
+
+  it('fail kind: moves toward voiding — picks card from the rarer non-trump suit', () => {
+    const candidates = [c('9','S'), c('9','C')]
+    // Hand has 1 spade and 3 clubs in non-trump → spades is shorter
+    const hand = [c('9','S'), c('9','C'), c('K','C'), c('7','C'), c('Q','D')]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('9S')
+  })
+
+  it('returns null when candidates is empty', () => {
+    expect(pickBySchmearPriority([], 'trump', [])).toBe(null)
+    expect(pickBySchmearPriority([], 'fail', [])).toBe(null)
+  })
+
+  it('returns null when no candidate matches any priority rank', () => {
+    // Should not happen in practice but defensive
+    const candidates = []
+    expect(pickBySchmearPriority(candidates, 'fail', [])).toBe(null)
+  })
+})
+```
+
+- [ ] **Step 1.2: Run the new tests to confirm they fail**
+
+Run: `npx vitest run shared/gameEngine.test.js -t pickBySchmearPriority`
+Expected: All tests fail with `pickBySchmearPriority is not exported by ./botInference.js` (or similar import error).
+
+- [ ] **Step 1.3: Implement the helper in `shared/botInference.js`**
+
+Add at the end of `shared/botInference.js` (after the `teammateWinning` block, in a new section):
+
+```javascript
+// ─── Schmear-priority pick ────────────────────────────────────────────────────
+
+// Rank priority for "schmear-self" — when the bot is guaranteed to take the
+// trick and is choosing the least-painful winning card to spend.
+//
+// Order rationale: cash high-point cards (A=11, 10=10, K=4) first, then 0-point
+// pip cards (9, 8, 7), then keep tactical strength in reserve (Js before Qs,
+// since Q is the top trump rank).
+const TRUMP_SCHMEAR_PRIORITY = ['A', '10', 'K', '9', '8', '7', 'J', 'Q']
+const FAIL_SCHMEAR_PRIORITY = ['A', '10', 'K', '9', '8', '7']
+
+// Returns the schmear-priority pick from `candidates`, or null if no candidate
+// matches any priority rank (or `candidates` is empty).
+//
+// `kind` ∈ {'trump', 'fail'} selects the priority list.
+// `hand` is the bot's full remaining hand — used only for the fail tiebreak
+// (prefer card whose suit is shortest in hand to move toward voiding a suit).
+//
+// Within-rank tiebreaks:
+//   'trump' → weakest by trump rank (e.g., among Qs: Q♦ over Q♣)
+//   'fail'  → shortest non-trump suit in `hand`; secondary tiebreak alphabetical by suit
+export function pickBySchmearPriority(candidates, kind, hand) {
+  if (!candidates || candidates.length === 0) return null
+  const ranks = kind === 'trump' ? TRUMP_SCHMEAR_PRIORITY : FAIL_SCHMEAR_PRIORITY
+
+  for (const rank of ranks) {
+    const matches = candidates.filter(card => card.rank === rank)
+    if (matches.length === 0) continue
+    if (matches.length === 1) return matches[0]
+
+    if (kind === 'trump') {
+      // Weakest by trump rank = highest trumpRank index value
+      return matches.reduce((best, card) =>
+        trumpRank(card) > trumpRank(best) ? card : best
+      )
+    }
+
+    // 'fail' tiebreak: shortest non-trump suit in hand, then alphabetical
+    const nonTrumpHand = (hand ?? []).filter(card => !card.hidden && !isTrump(card))
+    const suitCount = {}
+    for (const card of nonTrumpHand) {
+      suitCount[card.suit] = (suitCount[card.suit] ?? 0) + 1
+    }
+    return matches.reduce((best, card) => {
+      const cCount = suitCount[card.suit] ?? 0
+      const bestCount = suitCount[best.suit] ?? 0
+      if (cCount !== bestCount) return cCount < bestCount ? card : best
+      return card.suit < best.suit ? card : best
+    })
+  }
+
+  return null
+}
+```
+
+- [ ] **Step 1.4: Run the new tests to confirm they pass**
+
+Run: `npx vitest run shared/gameEngine.test.js -t pickBySchmearPriority`
+Expected: All 9 tests pass.
+
+- [ ] **Step 1.5: Run the full test suite to confirm no regressions**
+
+Run: `npm test`
+Expected: All previously-passing tests still pass; new tests pass; 0 failures.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add shared/botInference.js shared/gameEngine.test.js
+git commit -m "feat(bot): add pickBySchmearPriority helper
+
+New pure helper in botInference.js that picks the least-painful
+winning card to spend, walking a rank-priority list with kind-specific
+within-rank tiebreaks (weakest trump rank for trump; shortest non-trump
+suit in hand for fail)."
+```
+
+---
+
+## Spec section: Refactor existing schmear closures
+
+### Task 2: Replace schmear/schmearOpp bodies with helper call
+
+**Files:**
+- Modify: `shared/botStrategy.js` (around line 9 import; line 333 `schmear()`; line 450 `schmearOpp()`)
+- Test: `shared/gameEngine.test.js` — adjust the existing schmear test that depends on prior tiebreak behavior; add a regression test asserting the new shortest-suit tiebreak.
+
+- [ ] **Step 2.1: Write failing regression test for new shortest-suit tiebreak**
+
+Add the following test inside the existing `describe('decidePlay schmearing', ...)` block in `shared/gameEngine.test.js` (around line 1816):
+
+```javascript
+it('schmears card from shortest non-trump suit on within-rank tie', () => {
+  // Bot p3 (defender). Picker=p1, partner=p2 (revealed/known). Confirmed defender
+  // teammate p4 is winning with Q♣. teammateWinning=true → schmearOpp fires.
+  // Bot hand has A♠ and A♣ — both highest priority. Hand has 3 spades and 1 club
+  // among non-trump → clubs is the shortest non-trump suit → schmear A♣, not A♠.
+  const view = makeFollowView({
+    userId: 'p3',
+    picker: 'p1',
+    partner: 'p2',
+    trickWinner: 'p4',
+    trickCard: c('Q','C'),
+    handCards: [c('A','S'), c('K','S'), c('9','S'), c('A','C')],
+  })
+  expect(decidePlay(view, 'p3')).toBe('AC')
+})
+```
+
+- [ ] **Step 2.2: Run the new regression test to confirm it fails**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "shortest non-trump suit on within-rank tie"`
+Expected: Failure — current schmear uses `highestValueCard`, which returns whichever A its reduce encounters first (likely AS).
+
+- [ ] **Step 2.3: Add `pickBySchmearPriority` to `botStrategy.js` imports**
+
+Edit `shared/botStrategy.js` line 9. Change:
+
+```javascript
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, trumpRemainingElsewhere, isGuaranteedWinner, cheapestGuaranteedWin } from './botInference.js'
+```
+
+to:
+
+```javascript
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, trumpRemainingElsewhere, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority } from './botInference.js'
+```
+
+- [ ] **Step 2.4: Refactor `schmear()` body (picker-team branch)**
+
+In `shared/botStrategy.js`, find the `schmear` closure (currently around lines 333-337):
+
+```javascript
+const schmear = () => {
+  const nonTrump = realCards.filter(c => !isTrump(c))
+  if (nonTrump.length > 0) return highestValueCard(nonTrump).id
+  return lowestCard(realCards).id  // only trump available — don't burn trump to schmear
+}
+```
+
+Replace with:
+
+```javascript
+const schmear = () => {
+  const nonTrump = realCards.filter(c => !isTrump(c))
+  // Pass the bot's full hand (not realCards) so the suit-count tiebreak counts
+  // suits across the entire remaining hand, not just legal plays.
+  const pick = pickBySchmearPriority(nonTrump, 'fail', view.hands[userId])
+  return (pick ?? lowestCard(realCards)).id  // helper returns null when no non-trump available — don't burn trump
+}
+```
+
+- [ ] **Step 2.5: Refactor `schmearOpp()` body (opponent branch)**
+
+In `shared/botStrategy.js`, find the `schmearOpp` closure (currently around lines 450-454):
+
+```javascript
+const schmearOpp = () => {
+  const nonTrump = realCards.filter(c => !isTrump(c))
+  if (nonTrump.length > 0) return highestValueCard(nonTrump).id
+  return lowestCard(realCards).id
+}
+```
+
+Replace with:
+
+```javascript
+const schmearOpp = () => {
+  const nonTrump = realCards.filter(c => !isTrump(c))
+  const pick = pickBySchmearPriority(nonTrump, 'fail', view.hands[userId])
+  return (pick ?? lowestCard(realCards)).id
+}
+```
+
+- [ ] **Step 2.6: Run the new regression test to confirm it now passes**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "shortest non-trump suit on within-rank tie"`
+Expected: PASS — schmear now returns AC.
+
+- [ ] **Step 2.7: Run full test suite; review and update any existing tests that depended on old tiebreak**
+
+Run: `npm test`
+Expected: Most tests pass. If any of the existing schmear-related tests in `gameEngine.test.js` fail because they hand-picked `highestValueCard`'s first-encountered tiebreak, update them to reflect the new behavior. Likely candidates: the four tests in `describe('decidePlay schmearing', ...)` starting line 1816, and the schmear tests in `describe('decidePlay — picker-team schmear guard (#121)', ...)` starting line 2666.
+
+For each failing test:
+1. Read the test setup (handCards, trickWinner, trickCard).
+2. Compute the new expected card under the priority rule:
+   - List candidates after `nonTrump = realCards.filter(c => !isTrump(c))`.
+   - Find the highest-priority rank that appears (`A` first, then `10`, etc.).
+   - If multiple of that rank, prefer the card in the shortest non-trump suit of `realCards`; alphabetical secondary.
+3. Update the assertion to the new expected ID. Do **not** remove the test.
+
+If a test fails for a reason other than the new tiebreak (e.g. unrelated regression), STOP and surface it.
+
+- [ ] **Step 2.8: Commit**
+
+```bash
+git add shared/botStrategy.js shared/gameEngine.test.js
+git commit -m "refactor(bot): consolidate schmear closures via pickBySchmearPriority
+
+Both schmear() and schmearOpp() now delegate to the shared helper.
+Behavior change: within-rank tiebreak among non-trump cards now prefers
+the card from the shortest non-trump suit in hand, moving the bot toward
+voiding a suit. Existing schmear tests updated where the old reduce
+tiebreak was implicitly relied upon."
+```
+
+---
+
+## Spec section: New opponent-following branch (force-take for called-suit lead-back)
+
+### Task 3: Add the new branch to `decidePlay`
+
+**Files:**
+- Modify: `shared/botStrategy.js` (insert new branch in opponent-following section, after the `schmearOpp` block ending around line 478, before the "Trump in on called suit" block around line 480)
+- Test: `shared/gameEngine.test.js` (new `describe` block)
+
+- [ ] **Step 3.1: Write failing tests for the new branch**
+
+Add a new `describe` block at the end of `shared/gameEngine.test.js`:
+
+```javascript
+describe('decidePlay — defender force-take to enable called-suit lead-back', () => {
+  // Helper: build a 5-player view with the bot following on a trick already in progress.
+  // playedSeq is an array of {userId, card} representing the current trick so far.
+  function makeForceTakeView({
+    userId,
+    picker,
+    partner,
+    partnerRevealed,
+    calledSuit,
+    handCards,
+    playedSeq,
+  }) {
+    // Hands: only the bot's hand needs real cards; others can be placeholders for length detection.
+    const allIds = ['p1','p2','p3','p4','p5']
+    const hands = {}
+    for (const id of allIds) hands[id] = id === userId ? handCards : []
+    return {
+      hands,
+      currentTrick: playedSeq,
+      tricks: [],
+      picker,
+      partner,
+      partnerRevealed,
+      isLeaster: false,
+      phase: 'playing',
+      calledSuit,
+      calledAce: calledSuit ? { aceId: `A${calledSuit}` } : null,
+      calledTen: null,
+      calledKing: null,
+      pickerForcedPlays: [],
+      underCard: null,
+      buried: [],
+    }
+  }
+
+  it('void in led fail, picker still to play → highest trump (Q♣)', () => {
+    // Bot p3 (defender), called suit = hearts, partner unrevealed.
+    // p1 (picker) hasn't played; p2 led 8♠. Bot has Q♣ (top trump), J♦, A♥ (called-suit fail).
+    // Bot is void in spades → can play trump. picker still to play → highest trump = Q♣.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('A','H')],
+      playedSeq: [{ userId: 'p2', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('QC')
+  })
+
+  it('void in led fail, last to play (0 opps remaining) → A♦ from priority list', () => {
+    // Bot p5 (defender). p1 (picker) and p2,p3,p4 already played; bot is last.
+    // Called suit = hearts, partner unrevealed.
+    // Played: p1=8♠, p2=7♠, p3=K♠, p4=9♠. Bot is void in spades. Hand: A♦, 7♦, A♥.
+    // 0 opps remain → schmear-self priority → A♦ (top of trump priority).
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('A','D'), c('7','D'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('8','S') },
+        { userId: 'p2', card: c('7','S') },
+        { userId: 'p3', card: c('K','S') },
+        { userId: 'p4', card: c('9','S') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('AD')
+  })
+
+  it('trump led, 0 opps, only Qs in winning set → weakest Q (Q♦)', () => {
+    // Bot p5 (defender), last to play. Called=H, partner unrevealed.
+    // Played: p1=K♦ (trump led), p2=8♠? — but this would be invalid (must follow
+    // trump if held). Use a setup where everyone is void in trump:
+    // p1=K♦ (leads trump), p2=8♠ (void in trump), p3=7♠, p4=9♠. winner = K♦.
+    // Bot p5 has [Q♣, Q♦, A♥]. Must follow trump (has trump) → realCards excludes
+    // A♥ (called card) → [Q♣, Q♦]. Both beat K♦.
+    // 0 opps remain → schmear-self trump priority. Walk to Q rank → tiebreak by
+    // weakest trump rank → Q♦ (rank 3) over Q♣ (rank 0).
+    //
+    // Note: This setup is engine-legal only if other players truly have no trump.
+    // The test exercises decidePlay directly with a constructed view, so engine
+    // legality of historical plays isn't enforced.
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('Q','D'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('K','D') },
+        { userId: 'p2', card: c('8','S') },
+        { userId: 'p3', card: c('7','S') },
+        { userId: 'p4', card: c('9','S') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('QD')
+  })
+
+  it('trump led, 0 opps, Q♦ and J♥ both winning → J♥ (J before Q in priority)', () => {
+    // Bot p5 (defender), last to play. Called=H, partner unrevealed.
+    // Played: p1=8♦, p2=7♦, p3=9♦, p4=K♦ (trump trick). Current winner: p4 K♦ (rank 10).
+    // Bot hand: [Q♦, J♥, A♥]. Must follow trump → realCards excludes A♥ (called card,
+    // ledSuit T ≠ called H). realCards = [Q♦, J♥]. Both beat K♦.
+    // 0 opps remain → schmear-self trump priority. Walk A,10,K,9,8,7,J,Q:
+    //   J♥ found before Q♦ → return J♥.
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','D'), c('J','H'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('8','D') },
+        { userId: 'p2', card: c('7','D') },
+        { userId: 'p3', card: c('9','D') },
+        { userId: 'p4', card: c('K','D') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('JH')
+  })
+
+  it('must-follow non-called fail, opps remain → strategy SKIPPED, plays lowest', () => {
+    // Bot p3 (defender). Called suit = hearts. Partner unrevealed. Picker still to play.
+    // p2 led 8♠. Bot has A♠ (could win), 7♠, A♥ (called-suit fail).
+    // Must follow spades → realCards = [A♠, 7♠]. Bot has A♥ to lead back.
+    // BUT picker still to play and could be void in spades → trump over.
+    // → strategy skipped; default lowest = 7♠.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('A','S'), c('7','S'), c('A','H')],
+      playedSeq: [{ userId: 'p2', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('7S')
+  })
+
+  it('must-follow non-called fail, 0 opps, A♠ and K♠ both winning → A♠', () => {
+    // Bot p5 (defender), last to play. Called=H, partner unrevealed.
+    // Played: p1=9♠ (current winner among spades), p2=8♠, p3=7♠, p4=9♣ (void).
+    // Bot p5 hand: [A♠, K♠, A♥]. Must follow spades → realCards = [A♠, K♠].
+    //   A♠(rank 0) and K♠(rank 2) both beat 9♠(rank 4). winningSet = [A♠, K♠].
+    // canPlayTrump = false (both non-trump). 0 opps remain.
+    // → fail priority: A first → A♠.
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('A','S'), c('K','S'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('9','S') },
+        { userId: 'p2', card: c('8','S') },
+        { userId: 'p3', card: c('7','S') },
+        { userId: 'p4', card: c('9','C') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('AS')
+  })
+
+  it('strategy skipped when bot has no called-suit non-trump card', () => {
+    // Bot p3 defender. Called = hearts. Partner unrevealed. Picker still to play.
+    // Bot is void in spades and has trump but NO hearts (called-suit non-trump).
+    // p2 led 8♠. Hand: Q♣, J♦, 8♣. Bot is void in spades, can play any.
+    // Trigger #3 fails → strategy skipped → default opponent-following lowest non-trump = 8♣.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('8','C')],
+      playedSeq: [{ userId: 'p2', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('8C')
+  })
+
+  it('strategy skipped when partner is already revealed', () => {
+    // partnerRevealed=true, partner=p4. Picker p1 leads 8♠ (so picker is winning →
+    // teammateWinning is false → schmearOpp does NOT fire). New branch is skipped
+    // because partnerRevealed=true. Trump-in-on-called-suit skipped (S !== H).
+    // Falls to default lowestCard(realCards).
+    //
+    // Bot hand [Q♣, J♦, A♥]. A♥ is called card; ledSuit S ≠ called H, so A♥ excluded
+    // from realCards. realCards = [Q♣, J♦]. Both trump. lowestCard by points: Q♣=3, J♦=2 → J♦.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p4',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('A','H')],
+      playedSeq: [{ userId: 'p1', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('JD')
+  })
+
+  it('strategy skipped when bot has no winning cards', () => {
+    // Bot p3 defender, called=H, partner unrevealed, picker still to play.
+    // p2 led Q♣ (top trump). Bot hand: [J♦, 7♦, A♥].
+    // Bot has no spades; ledSuit is trump. Bot has trump → must follow trump.
+    // realCards: A♥ is called card; ledSuit T ≠ called H → A♥ excluded.
+    //   = [J♦, 7♦] (both trump → satisfy follow-suit rule).
+    // winningSet: J♦(rank 7) and 7♦(rank 13) both lose to Q♣ (rank 0) → empty.
+    // New branch: winningSet empty → fall through. Default lowestCard:
+    //   both trump, both 0 points (J♦=2, 7♦=0). 7♦ has lower points → 7♦.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('J','D'), c('7','D'), c('A','H')],
+      playedSeq: [{ userId: 'p2', card: c('Q','C') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('7D')
+  })
+
+  it('current trick led with called suit → existing trump-in branch fires (not new branch)', () => {
+    // Called = hearts, p2 led 9♥ (the called suit itself). Bot p3 defender, partner unrevealed.
+    // Bot is void in hearts; has trump. Existing logic: trump in with lowest trump.
+    // Bot hand: Q♣, J♦, 8♣. Void in hearts → realCards is full hand.
+    // Existing line 480 branch: "Trump in on called suit if picker team currently winning"
+    // Currently p2 is winning with 9♥. p2 is unknown role from defender POV (partner unrevealed).
+    // The check at line 484 is `winner.userId !== picker && winner.userId !== partner`
+    //   → with partner=null and winner=p2, opponentWinning = (p2 !== p1) && (p2 !== null) = true.
+    // opponentWinning=true → DOES NOT trump in. Falls through to default lowestCard(nonTrump) = 8♣.
+    // This test confirms the new branch is correctly gated to non-called-suit-led tricks.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('8','C')],
+      playedSeq: [{ userId: 'p2', card: c('9','H') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('8C')
+  })
+})
+```
+
+- [ ] **Step 3.2: Run the new tests to confirm they fail**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "defender force-take"`
+Expected: Most assertions in this block fail (current code defaults to lowest card, not the strategic picks). The "strategy skipped" tests may already pass (they assert the existing default behavior).
+
+- [ ] **Step 3.3: Implement the new branch in `shared/botStrategy.js`**
+
+In `shared/botStrategy.js`, find the opponent-following section. After the `schmearOpp` `teammateWinning` block (which currently ends with `return schmearOpp()` around line 478) and **before** the existing "Trump in on called suit if picker team is currently winning the trick" block (around line 480-489), insert the new branch.
+
+The exact insertion point is between the closing `}` of the `if (teammateWinning(view, userId)) { ... }` block and the line `// Trump in on called suit if picker team is currently winning the trick`.
+
+Insert this code:
+
+```javascript
+    // Force-take to enable called-suit lead-back: when the called suit hasn't been led
+    // yet (partner unrevealed) and the bot has a called-suit fail card to lead back,
+    // win this trick aggressively so the bot can lead the called suit on the next
+    // trick and flush the picker's partner.
+    {
+      const { calledSuit, partnerRevealed } = view
+      const ledThisTrickIsCalled = ledSuit === calledSuit
+      const hasCalledSuitFail = !!calledSuit && realCards.some(card =>
+        !isTrump(card) && effectiveSuit(card) === calledSuit
+      )
+      // Note: realCards already filters by must-follow rules. If the bot has a called-suit
+      // card but is here following a different suit, the called-suit card is in `view.hands[userId]`
+      // but not in `realCards`. We need to check the bot's full hand for the lead-back card.
+      const fullHand = view.hands[userId] ?? []
+      const hasCalledSuitFailInHand = !!calledSuit && fullHand.some(card =>
+        !card.hidden && !isTrump(card) && effectiveSuit(card) === calledSuit
+      )
+
+      if (!partnerRevealed && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
+        const winningSet = realCards.filter(card => {
+          for (const play of currentTrick) {
+            if (!beats(card, play.card, ledSuit)) return false
+          }
+          return true
+        })
+
+        if (winningSet.length > 0) {
+          const playedIds = new Set(currentTrick.map(p => p.userId))
+          const allIds = Object.keys(view.hands)
+          const potentialOppsRemaining = allIds.filter(id =>
+            !playedIds.has(id) && id !== userId
+          ).length
+
+          const canPlayTrump = winningSet.some(card => isTrump(card))
+
+          if (canPlayTrump) {
+            // Void in led suit, or trump led
+            if (potentialOppsRemaining > 0) {
+              // Highest trump in winning set
+              return highestTrump(winningSet).id
+            }
+            // 0 opps remain — schmear-self with trump priority
+            const pick = pickBySchmearPriority(winningSet, 'trump', fullHand)
+            if (pick) return pick.id
+          } else {
+            // Must-follow non-called fail; only fail-suit winners
+            if (potentialOppsRemaining === 0) {
+              const pick = pickBySchmearPriority(winningSet, 'fail', fullHand)
+              if (pick) return pick.id
+            }
+            // potentialOppsRemaining > 0 → fall through (opponent could trump over)
+          }
+        }
+      }
+    }
+    // Trump in on called suit if picker team is currently winning the trick
+```
+
+(Leave the existing "Trump in on called suit..." block exactly as it was.)
+
+- [ ] **Step 3.4: Run the new branch tests to confirm they pass**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "defender force-take"`
+Expected: All tests in the new `describe` block pass.
+
+- [ ] **Step 3.5: Run the full test suite**
+
+Run: `npm test`
+Expected: All tests pass; 0 regressions. If any pre-existing test changes its expected outcome because of the new branch, STOP and review whether the change is intentional. The new branch is gated to defender + partner-unrevealed + has-called-suit-fail-in-hand + non-called-suit-led + has-winning-cards — narrow enough that broad regressions should be unlikely.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add shared/botStrategy.js shared/gameEngine.test.js
+git commit -m "feat(bot): defender force-takes trick to enable called-suit lead-back
+
+When a defender bot is following a non-called-suit-led trick, the
+partner is unrevealed, and the bot holds a called-suit fail card to
+lead back, the bot now takes the trick: highest trump when picker-team
+threats remain to play, schmear-self priority list when no threats
+remain. The existing leading logic already leads called suit on the
+next trick to flush the partner."
+```
+
+---
+
+## Spec section: Documentation sync
+
+### Task 4: Update `docs/BOTS.md`
+
+**Files:**
+- Modify: `docs/BOTS.md`
+
+- [ ] **Step 4.1: Read the current "Opponent bot following" section**
+
+Read `docs/BOTS.md` lines 107-113 (the "Opponent bot following" section). The current text:
+
+```
+#### Opponent bot following
+1. **Schmear** (a confirmed teammate — partner identity must be known — is currently winning):
+   - **Safe** (no picker or partner remains to play, or the teammate's winning card is itself a guaranteed winner): dump the highest-value non-trump. If only trump available, play the lowest card.
+   - **Not safe**: if the bot can take the trick with a guaranteed-winning card, play the lowest-point such card. Otherwise schmear anyway — no speculative trump burn when a guaranteed takeover isn't available.
+2. **Trump in on called suit**: If the called suit was led and the picker team is currently winning the trick, play the lowest available trump to contest.
+3. **Otherwise**: play the lowest card.
+```
+
+- [ ] **Step 4.2: Insert the new branch as item 2; renumber subsequent items**
+
+Replace the whole "Opponent bot following" section with:
+
+```
+#### Opponent bot following
+1. **Schmear** (a confirmed teammate — partner identity must be known — is currently winning):
+   - **Safe** (no picker or partner remains to play, or the teammate's winning card is itself a guaranteed winner): dump the highest-priority non-trump per the **schmear priority** (see below). If only trump available, play the lowest card.
+   - **Not safe**: if the bot can take the trick with a guaranteed-winning card, play the lowest-point such card. Otherwise schmear anyway — no speculative trump burn when a guaranteed takeover isn't available.
+2. **Force-take to enable called-suit lead-back**: When the partner is **not yet revealed**, the current trick is **not** led with the called suit, the bot holds **at least one non-trump card of the called suit** in hand (a card that can be led back next trick), and the bot can take the current trick:
+   - Compute **potential opponents remaining** = count of non-self players still to play this trick. With partner unrevealed, no other defender is confirmed as a teammate, so every yet-to-play seat is treated as a picker-team threat.
+   - **Bot can play trump** (void in led suit, or trump led):
+     - Threats remaining > 0 → take with **highest trump** in the winning set.
+     - Threats remaining = 0 → take with the schmear-self pick using the **trump priority** (see below).
+   - **Bot must follow a non-called fail suit** (only fail winners available):
+     - Threats remaining > 0 → **skip** (an unrevealed opponent could be void and trump over). Fall through to default.
+     - Threats remaining = 0 → take with the schmear-self pick using the **fail priority** (see below).
+3. **Trump in on called suit**: If the called suit was led and the picker team is currently winning the trick, play the lowest available trump to contest.
+4. **Otherwise**: play the lowest card.
+
+**Schmear priority** (used by both the schmear branch above and the force-take branch's 0-threats-remaining cases): walk a rank-priority list and pick the first card found.
+- **Trump priority**: A, 10, K, 9, 8, 7, J, Q. Within the same letter (only meaningful for J or Q), prefer the **weakest by trump rank** (e.g. among Qs: Q♦ before Q♥ before Q♠ before Q♣).
+- **Fail priority**: A, 10, K, 9, 8, 7. Within the same rank (only meaningful for the schmear branch where the input may span multiple non-trump suits), prefer the card from the **shortest non-trump suit in hand** (move toward voiding); secondary tiebreak by suit alphabetical.
+
+Rationale: cash high-point cards (A=11, 10=10, K=4) first; spend zero-point pip cards next; keep the tactically valuable Js and Qs in reserve.
+```
+
+- [ ] **Step 4.3: Update the Inference Helpers table to include the new helper**
+
+Find the "Inference Helpers" table at the bottom of `docs/BOTS.md` (around line 120). After the row for `cheapestGuaranteedWin`, add:
+
+```
+| `pickBySchmearPriority` | Pick the least-painful winning card to spend, walking a rank-priority list (`A,10,K,9,8,7,J,Q` for trump; `A,10,K,9,8,7` for fail). Trump tiebreak: weakest trump rank. Fail tiebreak: shortest non-trump suit in hand, then alphabetical. |
+```
+
+- [ ] **Step 4.4: Sanity-check the updated doc by reading it end-to-end**
+
+Read `docs/BOTS.md` in full and verify:
+- The "Opponent bot following" section is internally consistent.
+- The schmear-priority block is referenced correctly from both the schmear branch and the new force-take branch.
+- The Inference Helpers table includes `pickBySchmearPriority`.
+- No leftover references to "highest-value non-trump" in the schmear sub-bullet (replaced by "highest-priority non-trump per the schmear priority").
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add docs/BOTS.md
+git commit -m "docs(bots): document defender force-take and schmear priority
+
+Adds the new opponent-following branch to BOTS.md and centralizes the
+'schmear priority' rank list used by both the schmear branch and the
+new force-take branch. Updates the Inference Helpers table to include
+pickBySchmearPriority."
+```
+
+---
+
+## Final Verification
+
+### Task 5: Whole-suite verification and summary
+
+- [ ] **Step 5.1: Final full test run**
+
+Run: `npm test`
+Expected: All tests pass across both backend (`shared/`) and frontend suites.
+
+- [ ] **Step 5.2: Visual diff of changes vs main**
+
+Run: `git diff main --stat`
+Expected: Changes confined to:
+- `shared/botInference.js` (new helper)
+- `shared/botStrategy.js` (import, two refactored closures, new branch)
+- `shared/gameEngine.test.js` (helper tests, schmear tiebreak test, new branch tests, possibly a few existing-schmear test assertion updates)
+- `docs/BOTS.md` (opponent-following section, helper table)
+- `docs/superpowers/specs/2026-04-26-...` (already committed earlier in the brainstorming phase)
+- `docs/superpowers/plans/2026-04-26-...` (this plan, committed once at task setup)
+
+- [ ] **Step 5.3: Confirm BOTS.md / code consistency**
+
+Re-read `docs/BOTS.md` "Opponent bot following" section and `shared/botStrategy.js` opponent-following code path side-by-side. Verify ordering of branches and conditions match exactly.
+
+- [ ] **Step 5.4: Plan complete**
+
+If all of the above pass, the plan is complete. Hand back to the user with:
+- A short summary of what changed.
+- Suggestion to manually playtest a hand or two to feel the new behavior in action.
+- Note that the implementation is in worktree `.worktrees/bot-defender-force-take` on branch `feat/bot-defender-force-take-called-suit`; merging is a separate user decision.

--- a/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design-for-PMs.md
+++ b/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design-for-PMs.md
@@ -1,0 +1,88 @@
+# Bot Defender — Force-Take to Enable Called-Suit Lead-Back (PM Spec)
+
+## What We're Building
+
+A new tactic for defender bots (the players opposing the picker on a hand). The change makes them smarter about *when* to take a trick, not just *which card to play*.
+
+## Why
+
+In Sheepshead, leading the **called suit** — the suit the picker has named when finding a partner — is one of the most powerful plays the defending team has. The first time the called suit is led, the partner is **forced** to play the called card, which reveals their identity to the entire table. Once the defenders know who the partner is, their coordination improves dramatically for the rest of the hand.
+
+There are two halves to this play. First, a defender has to **earn the lead** by winning a trick. Then, on the next trick, that defender leads the called suit. The bots already know how to do the second half: when an opponent bot leads with the partner still unrevealed and has a called-suit card in hand, it leads it. What they don't know how to do is the first half — they don't recognize that *taking a trick they could have won* is worth doing specifically so they can perform the lead-back next time.
+
+Today, defender bots default to "play the lowest legal card." That keeps the bot conservative but leaves a real strategic opportunity unrealized: a bot that holds a winning card *and* a called-suit card to follow up is sitting on a two-trick combo and choosing not to play it.
+
+## What Changes
+
+When a defender bot is following a trick, the bot will check for a specific situation:
+
+- The called suit hasn't been led yet (equivalently, the partner hasn't been identified).
+- The bot itself holds a card of the called suit (a non-trump one, so it's leadable next turn).
+- The bot can win the trick currently in progress.
+
+When all three are true, the bot will attempt to win this trick — even spending a top trump if needed — so it can lead the called suit on the next trick and force the partner reveal. This is a **deliberate trade**: the bot is trading down on this trick (using a stronger card than strictly necessary) to set up the higher-value strategic play on the next trick.
+
+## How the Bot Decides Which Card to Win With
+
+This is where the rule has nuance, and the nuance was the bulk of the design conversation.
+
+### Why two cases?
+
+There are two situations to handle separately, because in one of them the bot can guarantee the win and in the other it can't.
+
+**Case 1: The bot is "void" in the led suit, or the trick is a trump trick.** This means the bot can play trump. Trump beats everything, so the bot can choose to play a high trump and basically guarantee taking the trick.
+
+**Case 2: The bot has to follow a fail suit (not the called suit).** Sheepshead rules say if you have a card of the led suit, you must play it — you can't trump in. The bot can only "win" using cards of the led suit. This is a weaker position because *any other player still to play* might be void in that suit themselves and could trump over the bot's high fail card.
+
+### How many threats are still to play?
+
+The bot also looks at how many players are still to play in the trick after it. With the partner unrevealed, the bot has to assume any of those remaining players could be the partner — i.e. on the picker's team — and treat each of them as a potential threat that could overtake the trick.
+
+### The four sub-decisions
+
+Combining the two cases above with whether any potential threats remain to play, we get four combinations:
+
+1. **Bot can play trump, threats remain.** Take the trick with the **highest trump** available. This maximizes the chance of holding the win even if a threat trumps over.
+
+2. **Bot can play trump, no threats remain (the bot is last to play, or only confirmed teammates are left).** Take the trick with the cheapest "schmear-friendly" card from a fixed priority list — see below.
+
+3. **Bot must follow a fail suit, threats remain.** **Skip the strategy.** A potential opponent who is void could trump over the bot's high fail and win the trick anyway, wasting the bot's strong card for nothing. Fall back to the default play (lowest card).
+
+4. **Bot must follow a fail suit, no threats remain.** Take the trick using the priority list for fail cards.
+
+### The "schmear-self" priority list
+
+When the bot is *guaranteed* to win the trick (case 2 and case 4 above), it should use this opportunity to dump a high-point card into its own pile rather than waste a tactically valuable card. The order is **rank-based**, not points-based, because raw card points and "how strong is this card to keep" point in different directions. (The Queen, for example, is worth only 3 points, but it's the strongest trump in the game — you don't want to throw it away for 3 points.)
+
+The priority order, played first-to-last:
+
+- **For trump:** Ace, then 10, then King, then 9, 8, 7, then Jack, then Queen.
+- **For fail:** Ace, then 10, then King, then 9, 8, 7.
+
+Rationale: cash the high-point cards (Ace = 11 points, 10 = 10 points, King = 4 points) first, then the zero-point middle cards, then the tactically valuable Jacks and Queens last — keeping the strongest trump in reserve as long as possible.
+
+When two cards in the same rank could be played (only possible for Jacks and Queens, since each suit has one), play the **weakest** version. Among Queens, the Queen of Diamonds is weakest in trump rank, then Hearts, then Spades, then Clubs. Same idea for Jacks.
+
+### "Always take" rule
+
+In the no-threats-remaining cases, the bot **always** takes the trick using the priority list — even if that means spending a Queen. The strategic value of leading the called suit back the very first time it can be led is high enough to justify spending a top trump. This was a deliberate decision during design: don't add a "but only if the cost is reasonable" clause, because the lead-back is too valuable.
+
+## What's Already Done vs. What's New
+
+**Already in place:** When a defender bot is on lead and the partner hasn't been revealed yet, the bot already leads the called suit. So the lead-back half of this strategy works automatically — once the bot wins a trick under the new rule, it will lead the called suit next turn without any additional changes.
+
+**New work:** Only the trick-following decision logic. A new branch in the bot's "what to play when following a trick" decision, plus one small helper function for the schmear-self priority list, plus tests, plus an update to the bot's plain-English documentation.
+
+## Out of Scope
+
+- Refactoring existing bot logic that handles "schmear on a teammate's win." That logic uses a different rule (highest-points non-trump) and consolidating it would muddy two separate ideas.
+- Behavior changes after the partner has been revealed.
+- Any UI work to surface bot reasoning. (One reason the new helper is being placed in the bot inference module rather than a private location is that future debug/replay UI work may surface inference primitives — but that work is not happening here.)
+
+## Success Criteria
+
+- Defender bots holding a winning card and a leadable called-suit card now take the trick and lead the called suit next turn.
+- The "always take" rule fires even when the only winning card is the top trump.
+- The "skip" rule fires correctly when the bot must follow a fail suit and any threat remains, preventing wasted high cards.
+- All existing automated tests continue to pass; new tests cover every branch of the decision table.
+- The plain-English bot documentation in `docs/BOTS.md` is updated to match.

--- a/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design-for-PMs.md
+++ b/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design-for-PMs.md
@@ -73,9 +73,20 @@ In the no-threats-remaining cases, the bot **always** takes the trick using the 
 
 **New work:** Only the trick-following decision logic. A new branch in the bot's "what to play when following a trick" decision, plus one small helper function for the schmear-self priority list, plus tests, plus an update to the bot's plain-English documentation.
 
+## Bonus Cleanup: Schmear Logic Consolidation
+
+There is existing bot logic for a related-but-different play called **"schmear"** — when a teammate has already won a trick, the bot dumps a high-point card to give them more points. Today, the schmear logic is duplicated in two places (one for picker-team bots, one for defender bots), and both implement essentially the same rule: pick the highest-points non-trump card from your hand.
+
+The new "schmear-self" logic for the trick-winning case turns out to be a generalization of the existing schmear logic — for the **fail-suit case**, the new priority list and the existing rule produce the same result. So as part of this change, we will:
+
+1. Extract the new priority-list logic into a shared helper.
+2. Replace both existing schmear sites to call that helper.
+3. While we're at it, give the existing schmear a small strategic upgrade: when the bot has multiple non-trump cards of the same rank in different suits (e.g., the Ace of Spades and the Ace of Clubs both in hand), prefer the one in the **shortest non-trump suit** — moving the bot toward voiding a suit, which is strategically valuable.
+
+This is a small intentional behavior change to existing schmear, called out so it's not a surprise.
+
 ## Out of Scope
 
-- Refactoring existing bot logic that handles "schmear on a teammate's win." That logic uses a different rule (highest-points non-trump) and consolidating it would muddy two separate ideas.
 - Behavior changes after the partner has been revealed.
 - Any UI work to surface bot reasoning. (One reason the new helper is being placed in the bot inference module rather than a private location is that future debug/replay UI work may surface inference primitives — but that work is not happening here.)
 

--- a/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design.md
+++ b/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design.md
@@ -1,0 +1,127 @@
+# Bot Defender — Force-Take to Enable Called-Suit Lead-Back
+
+## Problem
+
+When a defender bot is following a trick early in a hand (before the called suit has been led), it currently plays the lowest legal card by default. This misses a strategically powerful move: take the trick now, then lead the called suit on the next trick to flush out the picker's partner.
+
+The leading-side logic for this play is already in place — at `shared/botStrategy.js:312-318`, an opponent leading with the partner unrevealed already leads the lowest non-trump called-suit card. What is missing is the corresponding **force-take** behavior on the following side: the bot needs to actually win a trick first to earn the next lead.
+
+## Trigger Conditions
+
+The new branch fires only when **all** of the following hold:
+
+1. Bot is on the defense (not picker, not partner). This is guaranteed structurally by being in the opponent-following branch — `isPickerTeam = userId === picker || userId === partner` is already false here, regardless of `partnerRevealed`.
+2. Partner is **not yet revealed**. (Equivalent: the called suit has not yet been led — the partner is forced to play the called card whenever the called suit is led, so partner reveal and called-suit-led are equivalent events in normal play.)
+3. Bot holds at least one **non-trump** card of the called suit (i.e. has a card to lead back next trick).
+4. Bot has at least one card in its legal play set that beats the current trick winner ("can take the trick").
+5. The current trick was **not** led with the called suit (the existing trump-in-on-called-suit branch at line 480 handles that case).
+
+If any condition fails, fall through to existing default behavior.
+
+## Decision
+
+Define **`potentialOpponentsRemaining`** = count of players still to play in the current trick, excluding the bot itself. With partner unrevealed, no other defender is confirmed as a teammate, so every yet-to-play seat is treated as a potential picker-team threat.
+
+Behavior splits on (a) whether the bot can play trump (void in led suit, or trump was led) vs. must follow a non-called fail, and (b) `potentialOpponentsRemaining > 0` vs `=== 0`.
+
+| Case | Potential opps remaining | Action |
+|---|---|---|
+| Void in led suit, or trump led | > 0 | Take with **highest trump** in winning set. Even if an opponent overtrumps, this maximizes the chance of holding the trick. |
+| Void in led suit, or trump led | 0 | Take with the first card found in winning set by **trump schmear priority** (see below). |
+| Must-follow non-called fail, has winners in that fail | > 0 | **Skip** — opponent could be void in led suit and trump over. Fall through to default lowest card. |
+| Must-follow non-called fail, has winners in that fail | 0 | Take with the first card found in winning set by **fail schmear priority** (see below). |
+
+### Schmear-self priority order
+
+The principle: when guaranteed to win the trick, "schmear to self" — cash high-point cards while keeping your strongest trump as residual control. The order is **rank-based**, not points-based, because points (K=4 vs Q=3) and game-strength (Q is the top trump) point in opposite directions and we want to keep strength in reserve.
+
+**Trump priority** (used when winning set is trump): `A, 10, K, 9, 8, 7, J, Q`
+
+**Fail priority** (used when winning set is fail in led suit): `A, 10, K, 9, 8, 7`
+
+For each rank in priority order, pick any winning card of that rank and return it. Since A/10/K/9/8/7 each have only one trump representative (the diamond version), within-rank tiebreak only matters for J and Q. The tiebreak rule:
+
+- **Within a trump rank, prefer the weakest by trump rank order.** Among Q's: Q♦, then Q♥, then Q♠, then Q♣. Among J's: J♦, then J♥, then J♠, then J♣. (Reasoning: dump the weakest member first; keep your absolute top trump in reserve.)
+
+For fail priority, the winning set is restricted to the led-suit cards, so all candidates share a suit and no within-rank tiebreak is needed.
+
+### Always take, even at high cost
+
+In the 0-opps-remaining cases, the bot **must** take the trick using the priority list — even if the only winning card is a Q. The strategic value of leading the called suit back the first time is high enough to justify spending a top trump.
+
+## Code Placement
+
+A new branch in `decidePlay`'s opponent-following section in `shared/botStrategy.js`, inserted **between** the existing schmear-on-confirmed-teammate block (around line 449) and the existing trump-in-on-called-suit block (around line 480).
+
+Ordering rationale:
+
+1. **Schmear on confirmed teammate** (existing) — only fires when partner is revealed; the new branch requires partner unrevealed, so they never co-fire.
+2. **NEW: force-take to enable called-suit lead-back**.
+3. **Trump-in on called-suit-led trick** (existing) — fires only when the current trick was led with the called suit; the new branch is gated to non-called-suit-led tricks, so they never co-fire.
+4. **Default lowest card** (existing) — unchanged.
+
+The new branch is therefore independent of every existing branch in the opponent-following section.
+
+## Lead-Back
+
+No changes needed. The existing leading logic at `shared/botStrategy.js:312-318` already leads the lowest non-trump called-suit card when an opponent bot leads with `partnerRevealed === false`. After the new force-take wins the trick, the bot will be on lead next trick and will execute this existing behavior.
+
+## New Helper
+
+A single new pure helper in `shared/botInference.js`:
+
+`pickBySchmearPriority(winningCards, kind)` where `kind ∈ {'trump', 'fail'}`.
+
+- Walks the appropriate rank-priority list.
+- For each rank, finds candidates in `winningCards` matching that rank.
+- If multiple candidates exist (only possible for J/Q in the trump case), returns the weakest by trump rank.
+- Returns `null` if `winningCards` is empty.
+
+Placed in `botInference.js` rather than as a file-local helper in `botStrategy.js` because (a) it's a pure card-selection primitive in the same family as `cheapestGuaranteedWin` and `cheapestWinningTrump`, and (b) future debug/replay UI work may surface inference primitives, and consistent placement makes that easier.
+
+No refactor of the existing two `schmear()` / `schmearOpp()` closures (lines 333, 450). They implement a different rule (highest-points non-trump for "dump on teammate") and consolidating would force a false generalization. That is out of scope.
+
+## Tests
+
+Add cases to the existing bot strategy test file. Required scenarios:
+
+- **Void in led, opps remain → highest trump.** Bot is void in led fail, holds Q♣ and J♦ (both winning), picker still to play. Expect Q♣.
+- **Void in led, 0 opps, A♦ in winning set → A♦.** Bot is void, last to play, winning set includes A♦ and a low trump. Expect A♦.
+- **Void in led, 0 opps, only Q's in winning set → weakest Q.** Winning set is {Q♥, Q♣}. Expect Q♥.
+- **Trump led, 0 opps, K♦ and J♥ both winning → K♦.** K beats J in trump priority.
+- **Must-follow fail, opps remain → strategy skipped.** Bot has high spades that would win, but picker still to play. Expect lowest card (default behavior).
+- **Must-follow fail, 0 opps, A♠ and K♠ winning → A♠.**
+- **Bot has no called-suit non-trump → strategy skipped entirely.** Expect default behavior (lowest card).
+- **Partner already revealed → strategy skipped entirely.** Expect default behavior.
+- **Bot has no winning cards → strategy skipped entirely.** Expect lowest card.
+- **Current trick led with called suit → existing trump-in branch fires, new branch does not.** Verify existing behavior unchanged.
+
+Also add a small unit test file (or section) for `pickBySchmearPriority`:
+
+- Trump kind, winning set covers all ranks → returns A.
+- Trump kind, winning set is {Q♣, Q♦, J♥} → returns J♥ (J before Q in priority).
+- Trump kind, winning set is {Q♣, Q♦} → returns Q♦ (weakest Q).
+- Fail kind, winning set is {A♠, K♠, 8♠} → returns A♠.
+- Empty winning set → returns null.
+
+## Documentation Sync
+
+Update `docs/BOTS.md` "Opponent bot following" section. Add the new branch as item 2 (between current schmear and trump-in-on-called-suit), with prose covering the trigger conditions, the void-vs-must-follow split, the >0 vs 0 opps split, and the schmear-self priority lists.
+
+## Out of Scope
+
+- Refactoring the existing duplicated `schmear()` / `schmearOpp()` closures.
+- Adjusting the existing leading logic at line 312-318.
+- Adjusting the existing trump-in-on-called-suit branch at line 480.
+- Bot debug/replay UI surfaces for inference outputs (mentioned as future motivation for placing the helper in `botInference.js`, but no work here).
+- Behavior when `partnerRevealed === true`. Once partner is revealed, the strategy does not apply; existing behavior governs.
+
+## Success Criteria
+
+1. New branch fires only under the five trigger conditions above.
+2. Decision table is implemented exactly: highest trump for trump-side >0 opps; priority list for both 0-opps cases; skip-and-fall-through for must-follow-fail >0 opps.
+3. Within-rank tiebreak prefers weakest trump rank for J and Q.
+4. Lead-back behavior is observed in integration: bot wins trick via new branch → next trick, bot leads called suit (via existing leading logic).
+5. All existing tests continue to pass; new tests cover all listed scenarios.
+6. `docs/BOTS.md` updated and consistent with code.
+7. No changes to existing schmear closures, leading logic, or trump-in-on-called-suit branch.

--- a/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design.md
+++ b/docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design.md
@@ -70,16 +70,47 @@ No changes needed. The existing leading logic at `shared/botStrategy.js:312-318`
 
 A single new pure helper in `shared/botInference.js`:
 
-`pickBySchmearPriority(winningCards, kind)` where `kind ∈ {'trump', 'fail'}`.
+`pickBySchmearPriority(candidates, kind, hand)` where `kind ∈ {'trump', 'fail'}` and `hand` is the bot's full hand of remaining cards.
 
-- Walks the appropriate rank-priority list.
-- For each rank, finds candidates in `winningCards` matching that rank.
-- If multiple candidates exist (only possible for J/Q in the trump case), returns the weakest by trump rank.
-- Returns `null` if `winningCards` is empty.
+- Walks the appropriate rank-priority list (`A, 10, K, 9, 8, 7, J, Q` for trump; `A, 10, K, 9, 8, 7` for fail).
+- For each rank, finds candidates in `candidates` matching that rank.
+- If multiple candidates share the rank, applies the within-rank tiebreak rule for that `kind` (see below).
+- Returns `null` if `candidates` is empty or contains no card of any priority-list rank.
 
-Placed in `botInference.js` rather than as a file-local helper in `botStrategy.js` because (a) it's a pure card-selection primitive in the same family as `cheapestGuaranteedWin` and `cheapestWinningTrump`, and (b) future debug/replay UI work may surface inference primitives, and consistent placement makes that easier.
+### Within-rank tiebreaks
 
-No refactor of the existing two `schmear()` / `schmearOpp()` closures (lines 333, 450). They implement a different rule (highest-points non-trump for "dump on teammate") and consolidating would force a false generalization. That is out of scope.
+- **`kind: 'trump'`** → return the **weakest by trump rank**. Among Q's: Q♦ < Q♥ < Q♠ < Q♣. Among J's: J♦ < J♥ < J♠ < J♣. Reasoning: dump the weakest member of the rank first; keep the absolute top trump in reserve. (For other ranks in the trump priority list, only one card exists per rank since the diamond is the only trump representative — A♦, 10♦, K♦, 9♦, 8♦, 7♦ — so no tiebreak is reachable.)
+- **`kind: 'fail'`** → return the card whose **suit is shortest in `hand`** (counting non-trump cards only). Reasoning: voiding a non-trump suit is strategically valuable (enables future trump-ins). Move toward voiding by playing from the shortest suit you hold.
+  - Secondary tiebreak (multiple suits tied for shortest length, each contributing a card of the target rank): pick deterministically by suit alphabetical order. This is a degenerate case that rarely arises and the deeper choice has minimal strategic weight.
+
+### Placement rationale
+
+In `botInference.js` rather than as a file-local helper in `botStrategy.js` because (a) it's a pure card-selection primitive in the same family as `cheapestGuaranteedWin` and `cheapestWinningTrump`, and (b) future debug/replay UI work may surface inference primitives, and consistent placement makes that easier.
+
+## Refactor: existing schmear closures
+
+The two existing closures `schmear()` (line 333) and `schmearOpp()` (line 450) currently use `highestValueCard(nonTrump)` to pick the highest-points non-trump card from the bot's hand, falling back to `lowestCard(realCards)` when no non-trump exists.
+
+The fail-priority list (`A, 10, K, 9, 8, 7`) is exactly the highest-points-first ordering for non-trump cards (A=11, 10=10, K=4, 9/8/7=0). Calling `pickBySchmearPriority(nonTrump, 'fail', realCards)` produces the same ranking, with two improvements:
+
+1. **Defined tiebreak among 0-pointers** (9 vs 8 vs 7 — previously whichever `cardPoints` reduce returned first).
+2. **Strategic shortest-suit tiebreak** for same-rank multi-suit candidates (e.g., A♠ vs A♣ when both in hand) — moves the bot toward voiding a suit.
+
+Both existing closures collapse to a single shared form:
+
+```
+schmear() = (pickBySchmearPriority(realCards.filter(c => !isTrump(c)), 'fail', realCards)
+              ?? lowestCard(realCards)).id
+```
+
+Net effect: ~6 lines of duplicated body removed; the new helper has 3 call sites (existing schmear, existing schmearOpp, new branch's 0-opps cases) instead of 2.
+
+### Behavior change disclosure
+
+The refactor introduces a small intentional behavior change to existing schmear:
+
+- When the bot's non-trump hand contains multiple non-trump aces (or 10's, K's, etc.) of different suits, schmear will now pick the one in the **shortest non-trump suit in hand** rather than whatever `highestValueCard` happens to return. This is a deliberate strategic improvement (move toward voiding), not a bug fix.
+- Existing tests that depend on the prior tiebreak behavior may need to be updated. The implementation plan should review existing schmear tests and update assertions where they would break.
 
 ## Tests
 
@@ -96,13 +127,22 @@ Add cases to the existing bot strategy test file. Required scenarios:
 - **Bot has no winning cards → strategy skipped entirely.** Expect lowest card.
 - **Current trick led with called suit → existing trump-in branch fires, new branch does not.** Verify existing behavior unchanged.
 
-Also add a small unit test file (or section) for `pickBySchmearPriority`:
+Also add a unit test file (or section) for `pickBySchmearPriority`:
 
-- Trump kind, winning set covers all ranks → returns A.
-- Trump kind, winning set is {Q♣, Q♦, J♥} → returns J♥ (J before Q in priority).
-- Trump kind, winning set is {Q♣, Q♦} → returns Q♦ (weakest Q).
-- Fail kind, winning set is {A♠, K♠, 8♠} → returns A♠.
-- Empty winning set → returns null.
+- Trump kind, candidates cover all ranks → returns A♦.
+- Trump kind, candidates are {Q♣, Q♦, J♥} → returns J♥ (J before Q in priority).
+- Trump kind, candidates are {Q♣, Q♦} → returns Q♦ (weakest Q).
+- Fail kind, candidates {A♠, K♠, 8♠}, hand contains those plus other suits → returns A♠.
+- Fail kind, candidates {A♠, A♣}, hand has 3 spades and 1 club → returns A♣ (clubs is shorter in hand).
+- Fail kind, candidates {A♠, A♣}, hand has 2 spades and 2 clubs → returns A♣ (alphabetical secondary tiebreak).
+- Fail kind, candidates {9♠, 9♣}, hand has 1 spade and 3 clubs → returns 9♠ (move toward voiding spades).
+- Empty candidates → returns null.
+
+Plus regression / behavior-change tests for refactored existing schmear:
+
+- Existing schmear, hand has {A♠, K♣, 7♥} → picks A♠ (highest-priority rank, only one suit has it). Same result as before.
+- Existing schmear, hand has {A♠, A♣}, plus more spades than clubs → now picks A♣ (was: implementation-dependent). Document this as the intended new behavior.
+- Existing schmear, hand has only trump → returns lowest card overall (helper returns null, fallback fires). Unchanged.
 
 ## Documentation Sync
 
@@ -110,7 +150,6 @@ Update `docs/BOTS.md` "Opponent bot following" section. Add the new branch as it
 
 ## Out of Scope
 
-- Refactoring the existing duplicated `schmear()` / `schmearOpp()` closures.
 - Adjusting the existing leading logic at line 312-318.
 - Adjusting the existing trump-in-on-called-suit branch at line 480.
 - Bot debug/replay UI surfaces for inference outputs (mentioned as future motivation for placing the helper in `botInference.js`, but no work here).
@@ -124,4 +163,4 @@ Update `docs/BOTS.md` "Opponent bot following" section. Add the new branch as it
 4. Lead-back behavior is observed in integration: bot wins trick via new branch → next trick, bot leads called suit (via existing leading logic).
 5. All existing tests continue to pass; new tests cover all listed scenarios.
 6. `docs/BOTS.md` updated and consistent with code.
-7. No changes to existing schmear closures, leading logic, or trump-in-on-called-suit branch.
+7. Existing `schmear()` / `schmearOpp()` closures refactored to call the shared helper; intentional shortest-suit tiebreak documented and tested. No changes to leading logic or trump-in-on-called-suit branch.

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -189,6 +189,28 @@ export function cheapestGuaranteedWin(candidates, view, userId) {
 
 // ─── Schmear detection ────────────────────────────────────────────────────────
 
+// Returns true if the player currently winning the trick is on the same team as userId.
+// Picker-team bots: teammate = picker or partner.
+// Opponent bots: only returns true when partner is known AND winner is confirmed opponent.
+//   If partner is null (unrevealed), returns false — unsafe to schmear.
+export function teammateWinning(view, userId) {
+  const { currentTrick, picker, partner } = view
+  if (!currentTrick || currentTrick.length === 0) return false
+
+  const winner = currentWinner(currentTrick)
+  if (!winner) return false
+  const winnerId = winner.userId
+
+  const onPickerTeam = userId === picker || userId === partner
+
+  if (onPickerTeam) {
+    return winnerId === picker || winnerId === partner
+  } else {
+    if (partner === null) return false
+    return winnerId !== picker && winnerId !== partner
+  }
+}
+
 // ─── Schmear-priority pick ────────────────────────────────────────────────────
 
 // Rank priority for "schmear-self" — when the bot is guaranteed to take the
@@ -241,26 +263,4 @@ export function pickBySchmearPriority(candidates, kind, hand) {
   }
 
   return null
-}
-
-// Returns true if the player currently winning the trick is on the same team as userId.
-// Picker-team bots: teammate = picker or partner.
-// Opponent bots: only returns true when partner is known AND winner is confirmed opponent.
-//   If partner is null (unrevealed), returns false — unsafe to schmear.
-export function teammateWinning(view, userId) {
-  const { currentTrick, picker, partner } = view
-  if (!currentTrick || currentTrick.length === 0) return false
-
-  const winner = currentWinner(currentTrick)
-  if (!winner) return false
-  const winnerId = winner.userId
-
-  const onPickerTeam = userId === picker || userId === partner
-
-  if (onPickerTeam) {
-    return winnerId === picker || winnerId === partner
-  } else {
-    if (partner === null) return false
-    return winnerId !== picker && winnerId !== partner
-  }
 }

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -189,6 +189,60 @@ export function cheapestGuaranteedWin(candidates, view, userId) {
 
 // ─── Schmear detection ────────────────────────────────────────────────────────
 
+// ─── Schmear-priority pick ────────────────────────────────────────────────────
+
+// Rank priority for "schmear-self" — when the bot is guaranteed to take the
+// trick and is choosing the least-painful winning card to spend.
+//
+// Order rationale: cash high-point cards (A=11, 10=10, K=4) first, then 0-point
+// pip cards (9, 8, 7), then keep tactical strength in reserve (Js before Qs,
+// since Q is the top trump rank).
+const TRUMP_SCHMEAR_PRIORITY = ['A', '10', 'K', '9', '8', '7', 'J', 'Q']
+const FAIL_SCHMEAR_PRIORITY = ['A', '10', 'K', '9', '8', '7']
+
+// Returns the schmear-priority pick from `candidates`, or null if no candidate
+// matches any priority rank (or `candidates` is empty).
+//
+// `kind` ∈ {'trump', 'fail'} selects the priority list.
+// `hand` is the bot's full remaining hand — used only for the fail tiebreak
+// (prefer card whose suit is shortest in hand to move toward voiding a suit).
+//
+// Within-rank tiebreaks:
+//   'trump' → weakest by trump rank (e.g., among Qs: Q♦ over Q♣)
+//   'fail'  → shortest non-trump suit in `hand`; secondary tiebreak alphabetical by suit
+export function pickBySchmearPriority(candidates, kind, hand) {
+  if (!candidates || candidates.length === 0) return null
+  const ranks = kind === 'trump' ? TRUMP_SCHMEAR_PRIORITY : FAIL_SCHMEAR_PRIORITY
+
+  for (const rank of ranks) {
+    const matches = candidates.filter(card => card.rank === rank)
+    if (matches.length === 0) continue
+    if (matches.length === 1) return matches[0]
+
+    if (kind === 'trump') {
+      // Weakest by trump rank = highest trumpRank index value
+      return matches.reduce((best, card) =>
+        trumpRank(card) > trumpRank(best) ? card : best
+      )
+    }
+
+    // 'fail' tiebreak: shortest non-trump suit in hand, then alphabetical
+    const nonTrumpHand = (hand ?? []).filter(card => !card.hidden && !isTrump(card))
+    const suitCount = {}
+    for (const card of nonTrumpHand) {
+      suitCount[card.suit] = (suitCount[card.suit] ?? 0) + 1
+    }
+    return matches.reduce((best, card) => {
+      const cCount = suitCount[card.suit] ?? 0
+      const bestCount = suitCount[best.suit] ?? 0
+      if (cCount !== bestCount) return cCount < bestCount ? card : best
+      return card.suit < best.suit ? card : best
+    })
+  }
+
+  return null
+}
+
 // Returns true if the player currently winning the trick is on the same team as userId.
 // Picker-team bots: teammate = picker or partner.
 // Opponent bots: only returns true when partner is known AND winner is confirmed opponent.

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -479,6 +479,58 @@ export function decidePlay(view, userId) {
       if (takeover) return takeover.id
       return schmearOpp()
     }
+    // Force-take to enable called-suit lead-back: when the called suit hasn't been led
+    // yet (partner unrevealed) and the bot has a called-suit fail card to lead back,
+    // win this trick aggressively so the bot can lead the called suit on the next
+    // trick and flush the picker's partner.
+    {
+      const { calledSuit, partnerRevealed } = view
+      const ledThisTrickIsCalled = ledSuit === calledSuit
+      // Note: realCards already filters by must-follow rules. If the bot has a called-suit
+      // card but is here following a different suit, the called-suit card is in `view.hands[userId]`
+      // but not in `realCards`. We need to check the bot's full hand for the lead-back card.
+      const fullHand = view.hands[userId] ?? []
+      const hasCalledSuitFailInHand = !!calledSuit && fullHand.some(card =>
+        !card.hidden && !isTrump(card) && effectiveSuit(card) === calledSuit
+      )
+
+      if (!partnerRevealed && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
+        const winningSet = realCards.filter(card => {
+          for (const play of currentTrick) {
+            if (!beats(card, play.card, ledSuit)) return false
+          }
+          return true
+        })
+
+        if (winningSet.length > 0) {
+          const playedIds = new Set(currentTrick.map(p => p.userId))
+          const allIds = Object.keys(view.hands)
+          const potentialOppsRemaining = allIds.filter(id =>
+            !playedIds.has(id) && id !== userId
+          ).length
+
+          const canPlayTrump = winningSet.some(card => isTrump(card))
+
+          if (canPlayTrump) {
+            // Void in led suit, or trump led
+            if (potentialOppsRemaining > 0) {
+              // Highest trump in winning set
+              return highestTrump(winningSet).id
+            }
+            // 0 opps remain — schmear-self with trump priority
+            const pick = pickBySchmearPriority(winningSet, 'trump', fullHand)
+            if (pick) return pick.id
+          } else {
+            // Must-follow non-called fail; only fail-suit winners
+            if (potentialOppsRemaining === 0) {
+              const pick = pickBySchmearPriority(winningSet, 'fail', fullHand)
+              if (pick) return pick.id
+            }
+            // potentialOppsRemaining > 0 → fall through (opponent could trump over)
+          }
+        }
+      }
+    }
     // Trump in on called suit if picker team is currently winning the trick
     const { calledSuit } = view
     if (ledSuit === calledSuit) {

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, trumpRemainingElsewhere, isGuaranteedWinner, cheapestGuaranteedWin } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, trumpRemainingElsewhere, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -332,8 +332,10 @@ export function decidePlay(view, userId) {
     if (teammateWinning(view, userId)) {
       const schmear = () => {
         const nonTrump = realCards.filter(c => !isTrump(c))
-        if (nonTrump.length > 0) return highestValueCard(nonTrump).id
-        return lowestCard(realCards).id  // only trump available — don't burn trump to schmear
+        // Pass the bot's full hand (not realCards) so the suit-count tiebreak counts
+        // suits across the entire remaining hand, not just legal plays.
+        const pick = pickBySchmearPriority(nonTrump, 'fail', view.hands[userId])
+        return (pick ?? lowestCard(realCards)).id  // helper returns null when no non-trump available — don't burn trump
       }
 
       const winnerPlay = currentWinner(currentTrick)
@@ -449,8 +451,8 @@ export function decidePlay(view, userId) {
     if (teammateWinning(view, userId)) {
       const schmearOpp = () => {
         const nonTrump = realCards.filter(c => !isTrump(c))
-        if (nonTrump.length > 0) return highestValueCard(nonTrump).id
-        return lowestCard(realCards).id
+        const pick = pickBySchmearPriority(nonTrump, 'fail', view.hands[userId])
+        return (pick ?? lowestCard(realCards)).id
       }
 
       const winnerPlay = currentWinner(currentTrick)

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2911,3 +2911,253 @@ describe('pickBySchmearPriority', () => {
     expect(pickBySchmearPriority(candidates, 'fail', [])).toBe(null)
   })
 })
+
+describe('decidePlay — defender force-take to enable called-suit lead-back', () => {
+  // Helper: build a 5-player view with the bot following on a trick already in progress.
+  // playedSeq is an array of {userId, card} representing the current trick so far.
+  function makeForceTakeView({
+    userId,
+    picker,
+    partner,
+    partnerRevealed,
+    calledSuit,
+    handCards,
+    playedSeq,
+  }) {
+    // Hands: only the bot's hand needs real cards; others can be placeholders for length detection.
+    const allIds = ['p1','p2','p3','p4','p5']
+    const hands = {}
+    for (const id of allIds) hands[id] = id === userId ? handCards : []
+    return {
+      hands,
+      currentTrick: playedSeq,
+      tricks: [],
+      picker,
+      partner,
+      partnerRevealed,
+      isLeaster: false,
+      phase: 'playing',
+      calledSuit,
+      calledAce: calledSuit ? { aceId: `A${calledSuit}` } : null,
+      calledTen: null,
+      calledKing: null,
+      pickerForcedPlays: [],
+      underCard: null,
+      buried: [],
+    }
+  }
+
+  it('void in led fail, picker still to play → highest trump (Q♣)', () => {
+    // Bot p3 (defender), called suit = hearts, partner unrevealed.
+    // p1 (picker) hasn't played; p2 led 8♠. Bot has Q♣ (top trump), J♦, A♥ (called-suit fail).
+    // Bot is void in spades → can play trump. picker still to play → highest trump = Q♣.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('A','H')],
+      playedSeq: [{ userId: 'p2', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('QC')
+  })
+
+  it('void in led fail, last to play (0 opps remaining) → A♦ from priority list', () => {
+    // Bot p5 (defender). p1 (picker) and p2,p3,p4 already played; bot is last.
+    // Called suit = hearts, partner unrevealed.
+    // Played: p1=8♠, p2=7♠, p3=K♠, p4=9♠. Bot is void in spades. Hand: A♦, 7♦, A♥.
+    // 0 opps remain → schmear-self priority → A♦ (top of trump priority).
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('A','D'), c('7','D'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('8','S') },
+        { userId: 'p2', card: c('7','S') },
+        { userId: 'p3', card: c('K','S') },
+        { userId: 'p4', card: c('9','S') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('AD')
+  })
+
+  it('trump led, 0 opps, only Qs in winning set → weakest Q (Q♦)', () => {
+    // Bot p5 (defender), last to play. Called=H, partner unrevealed.
+    // Played: p1=K♦ (trump led), p2=8♠? — but this would be invalid (must follow
+    // trump if held). Use a setup where everyone is void in trump:
+    // p1=K♦ (leads trump), p2=8♠ (void in trump), p3=7♠, p4=9♠. winner = K♦.
+    // Bot p5 has [Q♣, Q♦, A♥]. Must follow trump (has trump) → realCards excludes
+    // A♥ (called card) → [Q♣, Q♦]. Both beat K♦.
+    // 0 opps remain → schmear-self trump priority. Walk to Q rank → tiebreak by
+    // weakest trump rank → Q♦ (rank 3) over Q♣ (rank 0).
+    //
+    // Note: This setup is engine-legal only if other players truly have no trump.
+    // The test exercises decidePlay directly with a constructed view, so engine
+    // legality of historical plays isn't enforced.
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('Q','D'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('K','D') },
+        { userId: 'p2', card: c('8','S') },
+        { userId: 'p3', card: c('7','S') },
+        { userId: 'p4', card: c('9','S') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('QD')
+  })
+
+  it('trump led, 0 opps, Q♦ and J♥ both winning → J♥ (J before Q in priority)', () => {
+    // Bot p5 (defender), last to play. Called=H, partner unrevealed.
+    // Played: p1=8♦, p2=7♦, p3=9♦, p4=K♦ (trump trick). Current winner: p4 K♦ (rank 10).
+    // Bot hand: [Q♦, J♥, A♥]. Must follow trump → realCards excludes A♥ (called card,
+    // ledSuit T ≠ called H). realCards = [Q♦, J♥]. Both beat K♦.
+    // 0 opps remain → schmear-self trump priority. Walk A,10,K,9,8,7,J,Q:
+    //   J♥ found before Q♦ → return J♥.
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','D'), c('J','H'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('8','D') },
+        { userId: 'p2', card: c('7','D') },
+        { userId: 'p3', card: c('9','D') },
+        { userId: 'p4', card: c('K','D') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('JH')
+  })
+
+  it('must-follow non-called fail, opps remain → strategy SKIPPED, plays lowest', () => {
+    // Bot p3 (defender). Called suit = hearts. Partner unrevealed. Picker still to play.
+    // p2 led 8♠. Bot has A♠ (could win), 7♠, A♥ (called-suit fail).
+    // Must follow spades → realCards = [A♠, 7♠]. Bot has A♥ to lead back.
+    // BUT picker still to play and could be void in spades → trump over.
+    // → strategy skipped; default lowest = 7♠.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('A','S'), c('7','S'), c('A','H')],
+      playedSeq: [{ userId: 'p2', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('7S')
+  })
+
+  it('must-follow non-called fail, 0 opps, A♠ and K♠ both winning → A♠', () => {
+    // Bot p5 (defender), last to play. Called=H, partner unrevealed.
+    // Played: p1=9♠ (current winner among spades), p2=8♠, p3=7♠, p4=9♣ (void).
+    // Bot p5 hand: [A♠, K♠, A♥]. Must follow spades → realCards = [A♠, K♠].
+    //   A♠(rank 0) and K♠(rank 2) both beat 9♠(rank 4). winningSet = [A♠, K♠].
+    // canPlayTrump = false (both non-trump). 0 opps remain.
+    // → fail priority: A first → A♠.
+    const view = makeForceTakeView({
+      userId: 'p5',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('A','S'), c('K','S'), c('A','H')],
+      playedSeq: [
+        { userId: 'p1', card: c('9','S') },
+        { userId: 'p2', card: c('8','S') },
+        { userId: 'p3', card: c('7','S') },
+        { userId: 'p4', card: c('9','C') },
+      ],
+    })
+    expect(decidePlay(view, 'p5')).toBe('AS')
+  })
+
+  it('strategy skipped when bot has no called-suit non-trump card', () => {
+    // Bot p3 defender. Called = hearts. Partner unrevealed. Picker still to play.
+    // Bot is void in spades and has trump but NO hearts (called-suit non-trump).
+    // p2 led 8♠. Hand: Q♣, J♦, 8♣. Bot is void in spades, can play any.
+    // Trigger #3 fails → strategy skipped → default opponent-following lowest non-trump = 8♣.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('8','C')],
+      playedSeq: [{ userId: 'p2', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('8C')
+  })
+
+  it('strategy skipped when partner is already revealed', () => {
+    // partnerRevealed=true, partner=p4. Picker p1 leads 8♠ (so picker is winning →
+    // teammateWinning is false → schmearOpp does NOT fire). New branch is skipped
+    // because partnerRevealed=true. Trump-in-on-called-suit skipped (S !== H).
+    // Falls to default lowestCard(realCards).
+    //
+    // Bot hand [Q♣, J♦, A♥]. A♥ is called card; ledSuit S ≠ called H, so A♥ excluded
+    // from realCards. realCards = [Q♣, J♦]. Both trump. lowestCard by points: Q♣=3, J♦=2 → J♦.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p4',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('A','H')],
+      playedSeq: [{ userId: 'p1', card: c('8','S') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('JD')
+  })
+
+  it('strategy skipped when bot has no winning cards', () => {
+    // Bot p3 defender, called=H, partner unrevealed, picker still to play.
+    // p2 led Q♣ (top trump). Bot hand: [J♦, 7♦, A♥].
+    // Bot has no spades; ledSuit is trump. Bot has trump → must follow trump.
+    // realCards: A♥ is called card; ledSuit T ≠ called H → A♥ excluded.
+    //   = [J♦, 7♦] (both trump → satisfy follow-suit rule).
+    // winningSet: J♦(rank 7) and 7♦(rank 13) both lose to Q♣ (rank 0) → empty.
+    // New branch: winningSet empty → fall through. Default lowestCard:
+    //   both trump, both 0 points (J♦=2, 7♦=0). 7♦ has lower points → 7♦.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('J','D'), c('7','D'), c('A','H')],
+      playedSeq: [{ userId: 'p2', card: c('Q','C') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('7D')
+  })
+
+  it('current trick led with called suit → existing trump-in branch fires (not new branch)', () => {
+    // Called = hearts, p2 led 9♥ (the called suit itself). Bot p3 defender, partner unrevealed.
+    // Bot is void in hearts; has trump. Existing logic: trump in with lowest trump.
+    // Bot hand: Q♣, J♦, 8♣. Void in hearts → realCards is full hand.
+    // Existing line 480 branch: "Trump in on called suit if picker team currently winning"
+    // Currently p2 is winning with 9♥. p2 is unknown role from defender POV (partner unrevealed).
+    // The check at line 484 is `winner.userId !== picker && winner.userId !== partner`
+    //   → with partner=null and winner=p2, opponentWinning = (p2 !== p1) && (p2 !== null) = true.
+    // opponentWinning=true → DOES NOT trump in. Falls through to default lowestCard(nonTrump) = 8♣.
+    // This test confirms the new branch is correctly gated to non-called-suit-led tricks.
+    const view = makeForceTakeView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      handCards: [c('Q','C'), c('J','D'), c('8','C')],
+      playedSeq: [{ userId: 'p2', card: c('9','H') }],
+    })
+    expect(decidePlay(view, 'p3')).toBe('8C')
+  })
+})

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1890,6 +1890,22 @@ describe('decidePlay schmearing', () => {
     // Should NOT schmear — play lowest (9S: 0 pts, first 0-pt non-trump encountered)
     expect(decidePlay(view, 'p3')).toBe('9S')
   })
+
+  it('schmears card from shortest non-trump suit on within-rank tie', () => {
+    // Bot p3 (defender). Picker=p1, partner=p2 (revealed/known). Confirmed defender
+    // teammate p4 is winning with Q♣. teammateWinning=true → schmearOpp fires.
+    // Bot hand has A♠ and A♣ — both highest priority. Hand has 3 spades and 1 club
+    // among non-trump → clubs is the shortest non-trump suit → schmear A♣, not A♠.
+    const view = makeFollowView({
+      userId: 'p3',
+      picker: 'p1',
+      partner: 'p2',
+      trickWinner: 'p4',
+      trickCard: c('Q','C'),
+      handCards: [c('A','S'), c('K','S'), c('9','S'), c('A','C')],
+    })
+    expect(decidePlay(view, 'p3')).toBe('AC')
+  })
 })
 
 describe('decidePlay trump counting', () => {

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -16,6 +16,7 @@ import {
   bestVoidBury,
   isGuaranteedWinner,
   cheapestGuaranteedWin,  // NEW
+  pickBySchmearPriority,
 } from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -2828,5 +2829,69 @@ describe('decidePlay — non-trump-win point maximization', () => {
     })
     // trumpRemainingElsewhere > 0 → lowestCard(nonTrumpWins) = 10H (10pts < 11pts).
     expect(decidePlay(view, 'p1')).toBe('10H')
+  })
+})
+
+describe('pickBySchmearPriority', () => {
+  it('trump kind: returns A♦ when winning set covers all priority ranks', () => {
+    const candidates = [c('A','D'), c('10','D'), c('K','D'), c('9','D'), c('J','H'), c('Q','D')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('AD')
+  })
+
+  it('trump kind: returns J♥ over Q (J before Q in priority)', () => {
+    const candidates = [c('Q','C'), c('Q','D'), c('J','H')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('JH')
+  })
+
+  it('trump kind: among Qs, returns weakest by trump rank (Q♦)', () => {
+    const candidates = [c('Q','C'), c('Q','D'), c('Q','S')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('QD')
+  })
+
+  it('trump kind: among Js, returns weakest by trump rank (J♦)', () => {
+    const candidates = [c('J','C'), c('J','S'), c('J','D')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'trump', hand).id).toBe('JD')
+  })
+
+  it('fail kind: returns A♠ when winning set is single-suit', () => {
+    const candidates = [c('A','S'), c('K','S'), c('8','S')]
+    const hand = [...candidates]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('AS')
+  })
+
+  it('fail kind: prefers card from shortest non-trump suit in hand', () => {
+    const candidates = [c('A','S'), c('A','C')]
+    // Hand has 3 spades and 1 club among non-trump → clubs is shorter
+    const hand = [c('A','S'), c('K','S'), c('9','S'), c('A','C'), c('Q','D')]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('AC')
+  })
+
+  it('fail kind: alphabetical suit tiebreak when suit lengths tied', () => {
+    const candidates = [c('A','S'), c('A','C')]
+    // 2 spades, 2 clubs in non-trump hand → tied; C < S alphabetically → AC
+    const hand = [c('A','S'), c('8','S'), c('A','C'), c('7','C')]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('AC')
+  })
+
+  it('fail kind: moves toward voiding — picks card from the rarer non-trump suit', () => {
+    const candidates = [c('9','S'), c('9','C')]
+    // Hand has 1 spade and 3 clubs in non-trump → spades is shorter
+    const hand = [c('9','S'), c('9','C'), c('K','C'), c('7','C'), c('Q','D')]
+    expect(pickBySchmearPriority(candidates, 'fail', hand).id).toBe('9S')
+  })
+
+  it('returns null when candidates is empty', () => {
+    expect(pickBySchmearPriority([], 'trump', [])).toBe(null)
+    expect(pickBySchmearPriority([], 'fail', [])).toBe(null)
+  })
+
+  it('returns null when no candidate matches any priority rank', () => {
+    // Should not happen in practice but defensive
+    const candidates = []
+    expect(pickBySchmearPriority(candidates, 'fail', [])).toBe(null)
   })
 })


### PR DESCRIPTION
## Summary

Adds a new defender-bot following-trick branch that force-takes the current trick when the partner is unrevealed and the bot holds a called-suit fail card, so the bot can lead the called suit on the next trick and flush the picker's partner. Existing leading logic already handles the lead-back; this PR earns the lead.

Bonus: extracts a shared `pickBySchmearPriority` helper used by both the new branch and the two existing duplicated `schmear()` / `schmearOpp()` closures. Existing schmear gains a strategic upgrade — within-rank ties now prefer the card from the shortest non-trump suit in hand (move toward voiding).

## What changed

- `shared/botInference.js` — new `pickBySchmearPriority(candidates, kind, hand)` helper.
- `shared/botStrategy.js` — both schmear closures consolidated to use the helper; new force-take branch in `decidePlay`'s opponent-following section, between schmear-on-confirmed-teammate and trump-in-on-called-suit.
- `shared/gameEngine.test.js` — 10 helper unit tests, 1 schmear regression test (shortest-suit tiebreak), 10 force-take decision-table tests.
- `docs/BOTS.md` — opponent-following section rewritten; centralized schmear-priority block; helper-table row added.
- `docs/superpowers/specs/2026-04-26-bot-defender-force-take-called-suit-design.md` and PM companion — design.
- `docs/superpowers/plans/2026-04-26-bot-defender-force-take-called-suit.md` — implementation plan.

## Decision table for the new branch

Triggers when: defender bot, partner unrevealed, current trick not led with called suit, bot holds non-trump called-suit card in hand, and bot can take the trick.

| Case | Threats remaining | Action |
|---|---|---|
| Void in led suit, or trump led | > 0 | Highest trump in winning set |
| Void in led suit, or trump led | 0 | Schmear-self trump priority (`A,10,K,9,8,7,J,Q`, weakest trump rank within rank) |
| Must-follow non-called fail | > 0 | Skip — opp could trump over |
| Must-follow non-called fail | 0 | Schmear-self fail priority (`A,10,K,9,8,7`) |

## Test plan

- [x] `npm test` — 244 backend + 8 frontend = 252 passing, 0 failures
- [x] All 10 force-take decision-table tests pass; all 10 helper unit tests pass; 1 schmear regression test passes
- [ ] Manual smoke test: play a hand against bots; verify defenders take a trick and lead the called suit when conditions match

🤖 Generated with [Claude Code](https://claude.com/claude-code)