### PR TITLE
Rework bot pick strategy to enable Leaster/Schwanzer (#126)

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -13,12 +13,43 @@ Bots operate only on their own player view — they can see their own hand, all 
 
 ## Pick Decision (`decidePick`)
 
-The bot picks if its **hand score** is at least **24**.
+The bot picks if **all** of the following hold:
 
-Hand score = `(schwanzer points × 4) + buriable points`
+1. **Trump-count floor:** the hand contains at least 3 trump cards.
+2. **Hand score meets a position-aware threshold:** `handScore(hand) >= base − discount × passesSoFar`.
 
-- **Schwanzer points**: each card in hand contributes schwanzer card points (queen = 3, jack = 2, trump = 1, ace = 1, ten = 1, etc.)
-- **Buriable points**: sum of card points for the top 2 non-trump cards in the hand (0 if fewer than 2 non-trump cards)
+Both bot decisions and the human pick-suggestion go through this single function — the suggestion shown to a human is the same play a competent bot would make.
+
+### Hand score formula
+
+```
+handScore = (schwanzer points) × 4
+          + 3 × (count of non-trump aces)
+          + 2 × (count of non-trump tens)
+          + 5  if the Queen of Clubs is held
+```
+
+- **Schwanzer points** (defined in `gameEngine.js`): Queen=3, Jack=2, non-Q-non-J diamond=1, else=0. This term is the strongest signal of trump quality.
+- **Queen of Clubs bonus:** the QC is the highest card in the deck and never loses a trump fight; it is materially stronger than other queens, so it gets a flat +5.
+- **Non-trump aces and tens** capture point density in fail. Counted as `+3` and `+2` respectively. Note that the Ace and Ten of Diamonds are *trump*, not fail — they contribute via the schwanzer-points term, not here.
+
+### Position-aware threshold
+
+The threshold drops by `discount` (currently `2`) for each seat that has already passed in this hand. With the base set to `35`, the per-seat thresholds are:
+
+| Seat in pick order | Threshold |
+|---|---|
+| 1 (first to act) | 35 |
+| 2 | 33 |
+| 3 | 31 |
+| 4 | 29 |
+| 5 (last) | 27 |
+
+This reflects real sheepshead strategy: each preceding pass is evidence that the remaining hands are weaker, so a later seat can pick on a marginally weaker hand. Calibrated against an offline Monte Carlo simulator (`scripts/simulate-pick.mjs`) targeting a ~15% Leaster/Schwanzer rate.
+
+### Hard trump-count veto
+
+If the hand contains 2 or fewer trump, the bot never picks regardless of `handScore`. Real players auto-pass these hands. This veto prevents pathological "all aces, no trump" hands from clearing the threshold.
 
 ---
 
@@ -136,7 +167,7 @@ These pure functions support the strategy above but make no decisions themselves
 | `countTrumpPlayed` | Count visible trump in completed tricks and the current trick |
 | `trumpRemainingElsewhere` | Estimate trump still held by other players: `14 − own trump − seen trump − buried trump` |
 | `buriablePoints` | Card points of the best 2 non-trump cards for burial |
-| `handScore` | Combined pick-quality score: `schwanzerPts × 4 + buriablePoints` |
+| `handScore` | Combined pick-quality score: `schwanzerPts × 4 + 3×(non-trump aces) + 2×(non-trump tens) + 5 if QC held` |
 | `beats` | Returns true if a challenger card beats the current winner given led suit |
 | `currentWinner` | Returns the play object currently winning a trick |
 | `bestVoidBury` | Finds the best 2-card bury that voids a non-trump suit with ≥11 combined card points |

--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -166,7 +166,6 @@ These pure functions support the strategy above but make no decisions themselves
 |---|---|
 | `countTrumpPlayed` | Count visible trump in completed tricks and the current trick |
 | `trumpRemainingElsewhere` | Estimate trump still held by other players: `14 − own trump − seen trump − buried trump` |
-| `buriablePoints` | Card points of the best 2 non-trump cards for burial |
 | `handScore` | Combined pick-quality score: `schwanzerPts × 4 + 3×(non-trump aces) + 2×(non-trump tens) + 5 if QC held` |
 | `beats` | Returns true if a challenger card beats the current winner given led suit |
 | `currentWinner` | Returns the play object currently winning a trick |

--- a/docs/superpowers/plans/2026-04-27-bot-pick-strategy-rework.md
+++ b/docs/superpowers/plans/2026-04-27-bot-pick-strategy-rework.md
@@ -1,0 +1,674 @@
+# Bot Pick Strategy Rework — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the bot pick decision so Leaster/Schwanzer hands occur at a realistic ~15% rate, by replacing the current `handScore` formula, adding a trump-count hard veto, making the threshold position-aware, and adding an offline calibration simulator.
+
+**Architecture:** All pick logic lives in `shared/botStrategy.js` and `shared/botInference.js`. Both bot decisions (`functions/api/_botHelpers.js`) and the human pick-suggestion (`shared/botSuggestion.js`) already call `decidePick(view, userId)` — the rework happens entirely inside that function plus its helper `handScore`. Position information is already in `view.pickIndex` (set by `dealHand` / `pass` in `gameEngine.js`), so no signature plumbing is needed across callers.
+
+**Tech Stack:** Node.js (ES modules), Vitest for tests, plain Node CLI for the simulator.
+
+**Spec:** [`docs/superpowers/specs/2026-04-27-bot-pick-strategy-rework-design.md`](../specs/2026-04-27-bot-pick-strategy-rework-design.md)
+**Related issues:** [#126](https://github.com/andynumber2/sheepshead/issues/126), [#157](https://github.com/andynumber2/sheepshead/issues/157)
+
+---
+
+## File Map
+
+- **Modify** `shared/botInference.js` — replace the `handScore` implementation.
+- **Modify** `shared/botStrategy.js` — add `pickThreshold`, `decidePickWith`; rewrite `decidePick`.
+- **Modify** `shared/gameEngine.test.js` — replace existing `decidePick` tests (3) with new tests covering the new formula, trump-count veto, and position threshold; add `handScore` and `pickThreshold` tests.
+- **Create** `scripts/simulate-pick.js` — Monte Carlo CLI simulator.
+- **Modify** `package.json` — add `sim:pick` script.
+- **Modify** `docs/BOTS.md` — sync the "Pick Decision" section with the new logic.
+
+Tests in `shared/botSuggestion.labels.test.js` mock `decidePick`, so they should not need changes — verify in Task 7.
+
+---
+
+## Task 1: Rewrite `handScore` formula
+
+**Files:**
+- Modify: `shared/botInference.js:45-50`
+- Test: `shared/gameEngine.test.js` (new `describe('handScore', …)` block)
+
+The new formula is:
+```
+handScore = schwanzerPts × 4
+          + 3 × (count of non-trump aces)
+          + 2 × (count of non-trump tens)
+          + 5 if Queen of Clubs held
+```
+
+`schwanzerPts` and `schwanzerCardPoints` already exist in `shared/gameEngine.js` and are reused. `isTrump` is also already exported from there.
+
+- [ ] **Step 1: Add a failing test for the new `handScore`**
+
+In `shared/gameEngine.test.js`, add this `describe` block immediately above the existing `describe('decidePick', …)` block:
+
+```js
+import { handScore } from './botInference.js'
+
+describe('handScore', () => {
+  it('returns schwanzerPts × 4 for an all-trump-no-QC hand', () => {
+    // QH=3, QD=3, JS=2, JH=2, JD=2, 9D=1 → schwanzer 13 → 13*4 = 52
+    // No QC, no fail aces, no fail tens
+    const hand = [c('Q','H'), c('Q','D'), c('J','S'), c('J','H'), c('J','D'), c('9','D')]
+    expect(handScore(hand)).toBe(52)
+  })
+
+  it('adds 5 when QC is held', () => {
+    // QC=3, JS=2, JH=2, 7C=0, 8C=0, 9C=0 → schwanzer 7 → 7*4 = 28; +5 QC = 33
+    const hand = [c('Q','C'), c('J','S'), c('J','H'), c('7','C'), c('8','C'), c('9','C')]
+    expect(handScore(hand)).toBe(33)
+  })
+
+  it('adds 3 per non-trump ace', () => {
+    // QH=3, JH=2, AC=0, AH=0, 7S=0, 8S=0 → schwanzer 5 → 20; +3*2 fail aces = 26
+    // No QC, no tens
+    const hand = [c('Q','H'), c('J','H'), c('A','C'), c('A','H'), c('7','S'), c('8','S')]
+    expect(handScore(hand)).toBe(26)
+  })
+
+  it('adds 2 per non-trump ten', () => {
+    // QH=3, JH=2, 10C=0, 10H=0, 7S=0, 8S=0 → schwanzer 5 → 20; +2*2 fail tens = 24
+    const hand = [c('Q','H'), c('J','H'), c('10','C'), c('10','H'), c('7','S'), c('8','S')]
+    expect(handScore(hand)).toBe(24)
+  })
+
+  it('does not count A♦ or 10♦ as a fail ace/ten (they are trump)', () => {
+    // AD and 10D are diamonds → trump. They contribute schwanzerPts=1 each (diamond pips)
+    // but are NOT fail aces/tens.
+    // QH=3, JH=2, AD=1, 10D=1, 7S=0, 8S=0 → schwanzer 7 → 28; no QC, no fail A/10 → 28
+    const hand = [c('Q','H'), c('J','H'), c('A','D'), c('10','D'), c('7','S'), c('8','S')]
+    expect(handScore(hand)).toBe(28)
+  })
+
+  it('combines all terms', () => {
+    // QC=3, QS=3, JC=2, AC=0, AH=0, 10S=0 → schwanzer 8 → 32; +5 QC; +3*2 aces; +2*1 ten = 45
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('A','C'), c('A','H'), c('10','S')]
+    expect(handScore(hand)).toBe(45)
+  })
+
+  it('ignores hidden cards', () => {
+    // Only QC visible: schwanzer 3 → 12; +5 QC = 17
+    const hand = [c('Q','C'), { id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }]
+    expect(handScore(hand)).toBe(17)
+  })
+})
+```
+
+If `handScore` is not yet imported at the top of the test file, add it to the existing import line. Check the top of the file — there is already a line `import { ... } from './botStrategy.js'`; add a new import line for `handScore`:
+
+```js
+import { handScore } from './botInference.js'
+```
+
+- [ ] **Step 2: Run the new tests and verify they fail**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "handScore"`
+Expected: most cases FAIL (the current formula returns different numbers — e.g., the QC bonus does not exist, fail-ace weighting is via `buriablePoints` not a count).
+
+- [ ] **Step 3: Replace `handScore` in `shared/botInference.js`**
+
+Replace the existing implementation (lines around 45-50). The new function:
+
+```js
+// Combined hand quality score for the pick decision.
+// schwanzerPts × 4 + 3 × failAces + 2 × failTens + (5 if QC).
+// Hidden cards are ignored — handScore is called from decidePick on the bot's own hand,
+// but the hidden filter mirrors the prior implementation for safety.
+export function handScore(hand) {
+  const visible = hand.filter(c => !c.hidden)
+  const schwanzerPts = visible.reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
+  const failAces = visible.filter(c => !isTrump(c) && c.rank === 'A').length
+  const failTens = visible.filter(c => !isTrump(c) && c.rank === '10').length
+  const hasQC = visible.some(c => c.id === 'QC')
+  return schwanzerPts * 4 + 3 * failAces + 2 * failTens + (hasQC ? 5 : 0)
+}
+```
+
+`isTrump` is already imported at the top of `botInference.js` from `./gameEngine.js`. The unused export `buriablePoints` (currently above `handScore`) is no longer referenced by `handScore` — search the codebase for other consumers:
+
+```bash
+grep -rn "buriablePoints" --include="*.js"
+```
+
+If `buriablePoints` has no other consumers, delete it and remove it from the export list. If it does, leave it as-is (unused-by-pick code is acceptable to keep).
+
+- [ ] **Step 4: Run all `handScore` tests and verify they pass**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "handScore"`
+Expected: all 7 tests PASS.
+
+- [ ] **Step 5: Run the full test suite to catch any regressions**
+
+Run: `npx vitest run`
+Expected: only pre-existing `decidePick` tests fail (those are rewritten in Task 3). Make a note of which tests fail so Task 3 catches them all.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/botInference.js shared/gameEngine.test.js
+git commit -m "feat(bot): rewrite handScore with QC bonus, fail-ace/ten counts (#126)"
+```
+
+---
+
+## Task 2: Add `pickThreshold` and position-aware `decidePick`
+
+**Files:**
+- Modify: `shared/botStrategy.js:134-138`
+- Test: `shared/gameEngine.test.js` (new `describe('pickThreshold', …)` block)
+
+Introduce two new exported names: `PICK_THRESHOLD_BASE`, `PICK_THRESHOLD_DISCOUNT` (constants, *placeholder values* — calibrated in Task 5), and a new function `pickThreshold(passesSoFar)` that computes the threshold for that seat. `decidePick` is rewritten to use it, plus the trump-count hard veto.
+
+The simulator (Task 4) needs to vary the threshold without changing module state. To support that, also export `decidePickWith(view, userId, base, discount)` — the parameterized core. Production `decidePick` is a thin wrapper.
+
+- [ ] **Step 1: Add a failing test for `pickThreshold`**
+
+In `shared/gameEngine.test.js`, immediately above the existing `describe('decidePick', …)` block, add:
+
+```js
+import { pickThreshold, PICK_THRESHOLD_BASE, PICK_THRESHOLD_DISCOUNT } from './botStrategy.js'
+
+describe('pickThreshold', () => {
+  it('returns BASE at passesSoFar = 0', () => {
+    expect(pickThreshold(0)).toBe(PICK_THRESHOLD_BASE)
+  })
+
+  it('subtracts DISCOUNT per pass', () => {
+    expect(pickThreshold(1)).toBe(PICK_THRESHOLD_BASE - PICK_THRESHOLD_DISCOUNT)
+    expect(pickThreshold(4)).toBe(PICK_THRESHOLD_BASE - 4 * PICK_THRESHOLD_DISCOUNT)
+  })
+})
+```
+
+- [ ] **Step 2: Run the test and verify it fails (import error)**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "pickThreshold"`
+Expected: FAIL — `pickThreshold` and the constants do not yet exist.
+
+- [ ] **Step 3: Implement `pickThreshold`, `decidePickWith`, and rewrite `decidePick` in `shared/botStrategy.js`**
+
+Replace the existing block (lines 134-138):
+
+```js
+// ─── decidePick ───────────────────────────────────────────────────────────────
+export function decidePick(view, userId) {
+  const hand = view.hands[userId]
+  return handScore(hand) >= 24
+}
+```
+
+with:
+
+```js
+// ─── decidePick ───────────────────────────────────────────────────────────────
+// Placeholder calibration values; tuned in scripts/simulate-pick.js (issue #126).
+export const PICK_THRESHOLD_BASE = 30
+export const PICK_THRESHOLD_DISCOUNT = 2
+
+export function pickThreshold(passesSoFar) {
+  return PICK_THRESHOLD_BASE - PICK_THRESHOLD_DISCOUNT * passesSoFar
+}
+
+// Parameterized core — used by the simulator to sweep base/discount values.
+export function decidePickWith(view, userId, base, discount) {
+  const hand = view.hands[userId]
+  const visible = hand.filter(c => !c.hidden)
+
+  // Hard veto: too few trump → never pick.
+  const trumpCount = visible.filter(c => isTrump(c)).length
+  if (trumpCount <= 2) return false
+
+  const passesSoFar = view.pickIndex ?? 0
+  return handScore(hand) >= base - discount * passesSoFar
+}
+
+export function decidePick(view, userId) {
+  return decidePickWith(view, userId, PICK_THRESHOLD_BASE, PICK_THRESHOLD_DISCOUNT)
+}
+```
+
+Add `isTrump` to the import line at the top of `shared/botStrategy.js` (it currently imports from `gameEngine.js` — extend that import):
+
+```js
+import { ... existing imports ..., isTrump } from './gameEngine.js'
+```
+
+(Look at the existing import line and append `isTrump` to the destructuring list.)
+
+- [ ] **Step 4: Run `pickThreshold` tests and verify they pass**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "pickThreshold"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/botStrategy.js shared/gameEngine.test.js
+git commit -m "feat(bot): add pickThreshold and decidePickWith (#126)"
+```
+
+---
+
+## Task 3: Rewrite `decidePick` tests for new behavior
+
+**Files:**
+- Modify: `shared/gameEngine.test.js:1754-1772` (existing `describe('decidePick', …)` block)
+
+The three existing tests assume the old formula and the absence of a trump-count veto. Replace them with tests that cover: pick when strong, pass when weak, hard veto on low trump, position discount.
+
+- [ ] **Step 1: Replace the existing `describe('decidePick', …)` block**
+
+Locate the existing block (around line 1754) and replace its body entirely:
+
+```js
+describe('decidePick', () => {
+  it('picks a strong hand at seat 0', () => {
+    // QC=3, QS=3, JC=2, JS=2, AD=1, 10D=1 → schwanzer 12 → 48; +5 QC; trump 6 → score 53
+    // Threshold at pickIndex=0 = BASE (30). Picks.
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('A','D'), c('10','D')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(true)
+  })
+
+  it('passes a weak hand at seat 0', () => {
+    // QH=3, JH=2, 7C=0, 8C=0, 9S=0, 8S=0 → schwanzer 5 → 20; trump 2 → HARD VETO → pass
+    const hand = [c('Q','H'), c('J','H'), c('7','C'), c('8','C'), c('9','S'), c('8','S')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
+  })
+
+  it('hard veto: never picks with trumpCount ≤ 2 even if score is high', () => {
+    // QH=3, QD=3, AC=0, AH=0, AS=0, 10C=0 → schwanzer 7 → 28; +3*3 aces = 37
+    // But trump count = 2 (QH, QD) → hard veto → false.
+    const hand = [c('Q','H'), c('Q','D'), c('A','C'), c('A','H'), c('A','S'), c('10','C')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
+  })
+
+  it('position-aware: a marginal hand passes early-seat but picks late-seat', () => {
+    // Construct a hand whose handScore equals BASE - 2*DISCOUNT (picks at pickIndex=2 only).
+    // We use the exported constants so this stays consistent if calibration changes,
+    // as long as the relationship handScore ≈ BASE - 2*DISCOUNT is preserved.
+    //
+    // Hand: QC=3, QH=3, JS=2, JD=2, 9D=1, AC(fail ace) → schwanzer 11 → 44
+    //       +5 QC + 3*1 fail ace = 52; trump 5 (QC,QH,JS,JD,9D).
+    // This hand picks at any seat — verify pickIndex=0 picks.
+    // For position contrast, build a marginal hand:
+    //   QH=3, JH=2, JD=2, 9D=1, AC, 7S → schwanzer 8 → 32; +3*1 = 35; trump 4 (QH,JH,JD,9D).
+    // If BASE=30, discount=2: thresholds are 30, 28, 26, 24, 22 across seats. Score 35 picks at all seats.
+    //
+    // To make a true position-sensitive case, target score < BASE but ≥ BASE - 2*DISCOUNT:
+    //   QH=3, JH=2, 9D=1, 7C, 8C, 9S → schwanzer 6 → 24; trump 3 (QH, JH, 9D); no QC, no fail A/10 → score 24.
+    //   At pickIndex=0 (threshold 30): 24 < 30 → pass.
+    //   At pickIndex=3 (threshold 24): 24 ≥ 24 → pick.
+    const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 3 }, 'p1')).toBe(true)
+  })
+
+  it('defaults pickIndex to 0 when undefined', () => {
+    // Same marginal hand as above; without pickIndex, behaves as seat 0 → pass.
+    const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
+    expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(false)
+  })
+})
+```
+
+**Note:** The "position-aware" test asserts specific behavior that depends on the placeholder values `BASE=30, DISCOUNT=2`. After calibration (Task 5), if either constant changes such that the score-24 hand no longer straddles seat-0-vs-seat-3, this test must be updated to use a new hand that does. The note is in Task 5.
+
+- [ ] **Step 2: Run the new `decidePick` tests and verify they pass**
+
+Run: `npx vitest run shared/gameEngine.test.js -t "decidePick"`
+Expected: all 5 tests PASS.
+
+- [ ] **Step 3: Run the full suite to confirm no regressions**
+
+Run: `npx vitest run`
+Expected: all tests PASS (frontend tests are not part of this scope; if `npm test -w frontend` runs anything related to bot logic, double-check).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add shared/gameEngine.test.js
+git commit -m "test(bot): rewrite decidePick tests for new formula (#126)"
+```
+
+---
+
+## Task 4: Build the Monte Carlo simulator
+
+**Files:**
+- Create: `scripts/simulate-pick.js`
+- Modify: `package.json` (add `sim:pick` script)
+
+Standalone Node script. Imports the production `dealHand` and `decidePickWith`. Iterates N hands, walks each pick order, records whether any seat picked. Outputs aggregate stats. Supports a seeded PRNG so runs are reproducible.
+
+- [ ] **Step 1: Create `scripts/simulate-pick.js`**
+
+```js
+#!/usr/bin/env node
+// Monte Carlo simulator for the bot pick decision.
+// Calibrates BASE and DISCOUNT against a target no-pick (Leaster/Schwanzer) rate.
+//
+// Usage:
+//   npm run sim:pick -- --base 30 --discount 2 --hands 10000 [--seed 42]
+
+import { dealHand } from '../shared/gameEngine.js'
+import { decidePickWith } from '../shared/botStrategy.js'
+
+function parseArgs(argv) {
+  const args = { base: 30, discount: 2, hands: 10000, seed: undefined }
+  for (let i = 2; i < argv.length; i++) {
+    const tok = argv[i]
+    const next = argv[i + 1]
+    if (tok === '--base')      { args.base = Number(next); i++ }
+    else if (tok === '--discount') { args.discount = Number(next); i++ }
+    else if (tok === '--hands')    { args.hands = Number(next); i++ }
+    else if (tok === '--seed')     { args.seed = Number(next); i++ }
+    else if (tok === '--help' || tok === '-h') {
+      console.log('Usage: npm run sim:pick -- --base N --discount N --hands N [--seed N]')
+      process.exit(0)
+    } else {
+      console.error(`Unknown arg: ${tok}`)
+      process.exit(1)
+    }
+  }
+  if (Number.isNaN(args.base) || Number.isNaN(args.discount) || Number.isNaN(args.hands)) {
+    console.error('--base, --discount, and --hands must all be numbers')
+    process.exit(1)
+  }
+  return args
+}
+
+// mulberry32: tiny seeded PRNG. Deterministic for a given seed.
+function makeMulberry32(seed) {
+  let s = seed >>> 0
+  return function () {
+    s = (s + 0x6D2B79F5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function simulate({ base, discount, hands, seed }) {
+  // dealHand uses Math.random internally via shuffle. Override for deterministic runs.
+  if (seed !== undefined) {
+    Math.random = makeMulberry32(seed)
+  }
+
+  const playerIds = ['p0', 'p1', 'p2', 'p3', 'p4']
+  const picksBySeat = [0, 0, 0, 0, 0]
+  let noPick = 0
+  let pickedHandScoreSum = 0
+  let pickedCount = 0
+  let passedHandScoreSum = 0
+  let passedCount = 0
+
+  for (let h = 0; h < hands; h++) {
+    const state = dealHand(playerIds, 0, 1, 1)
+    let picked = false
+    for (let i = 0; i < state.pickOrder.length; i++) {
+      const userId = state.pickOrder[i]
+      const view = { hands: state.hands, pickIndex: i }
+      if (decidePickWith(view, userId, base, discount)) {
+        picksBySeat[i]++
+        picked = true
+        break
+      }
+    }
+    // Tally handScore stats for the picker (or final passer if no pick).
+    // We don't import handScore directly here to keep this file decoupled;
+    // skip score stats for v1.
+    if (!picked) noPick++
+  }
+
+  const total = hands
+  return {
+    total,
+    picksBySeat,
+    pickedTotal: picksBySeat.reduce((a, b) => a + b, 0),
+    noPick,
+    noPickRate: noPick / total,
+  }
+}
+
+const args = parseArgs(process.argv)
+const r = simulate(args)
+
+const pct = (x) => (x * 100).toFixed(2) + '%'
+console.log('=== Pick Simulation ===')
+console.log(`base=${args.base} discount=${args.discount} hands=${args.hands}` +
+            (args.seed !== undefined ? ` seed=${args.seed}` : ' (random seed)'))
+console.log(`Total hands:        ${r.total}`)
+console.log(`Picked total:       ${r.pickedTotal} (${pct(r.pickedTotal / r.total)})`)
+for (let i = 0; i < 5; i++) {
+  console.log(`  Seat ${i + 1} picks: ${r.picksBySeat[i]} (${pct(r.picksBySeat[i] / r.total)})`)
+}
+console.log(`No-pick (Leaster):  ${r.noPick} (${pct(r.noPickRate)})`)
+console.log(`Target ~15%; current delta: ${((r.noPickRate - 0.15) * 100).toFixed(2)}%`)
+```
+
+- [ ] **Step 2: Add the `sim:pick` script to `package.json`**
+
+Edit `package.json` and add a new key inside `"scripts"`:
+
+```json
+"sim:pick": "node scripts/simulate-pick.js"
+```
+
+The full `"scripts"` block becomes (preserve existing keys):
+
+```json
+"scripts": {
+  "dev": "concurrently -n frontend,wrangler -c cyan,yellow \"npm run dev:frontend\" \"npm run dev:wrangler\"",
+  "dev:frontend": "npm run dev -w frontend",
+  "dev:wrangler": "wrangler pages dev --port 8788",
+  "build": "npm run build -w frontend",
+  "deploy": "npm run build && wrangler pages deploy frontend/dist",
+  "db:migrate:local": "wrangler d1 migrations apply sheepshead-db --local",
+  "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote",
+  "test": "vitest run && npm test -w frontend",
+  "sim:pick": "node scripts/simulate-pick.js",
+  "postinstall": "git config core.hooksPath .githooks"
+}
+```
+
+- [ ] **Step 3: Smoke-test the simulator**
+
+Run: `npm run sim:pick -- --base 30 --discount 2 --hands 1000 --seed 42`
+Expected: prints stats; no-pick rate is *some* number (likely far from 15% with placeholder values — that's fine, this step just verifies the simulator runs end-to-end). Re-run the same command twice with `--seed 42` and verify identical output (deterministic).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/simulate-pick.js package.json
+git commit -m "feat(bot): add Monte Carlo pick-decision simulator (#126)"
+```
+
+---
+
+## Task 5: Calibrate `BASE` and `DISCOUNT`
+
+**Files:**
+- Modify: `shared/botStrategy.js` (the `PICK_THRESHOLD_BASE` and `PICK_THRESHOLD_DISCOUNT` constants)
+- Possibly modify: `shared/gameEngine.test.js` (the position-aware `decidePick` test, if calibration shifts the relevant boundary)
+
+Goal: pick `BASE`/`DISCOUNT` so that the simulated no-pick rate over 10,000 hands lands within ±2% of 15%.
+
+- [ ] **Step 1: Sweep candidate values**
+
+Run the simulator across a coarse grid. Each run with `--seed 42` for reproducibility, `--hands 10000` for stable estimates.
+
+```bash
+for base in 28 30 32 34 36 38 40; do
+  for discount in 1 2 3; do
+    npm run sim:pick -- --base $base --discount $discount --hands 10000 --seed 42 2>&1 \
+      | grep -E "base=|No-pick"
+  done
+done
+```
+
+Pick the (base, discount) pair whose `No-pick` rate is closest to 15%. Note that runs with very small `--hands` will have noticeable variance; 10,000 hands gives an SE of ~0.4 percentage points on a 15% rate, which is enough.
+
+- [ ] **Step 2: Confirm with a different seed**
+
+Run the chosen pair against 2-3 different seeds with `--hands 10000` and confirm the no-pick rate lands within ±2% of 15% in each. This guards against seed-fitting.
+
+```bash
+npm run sim:pick -- --base <chosen> --discount <chosen> --hands 10000 --seed 1
+npm run sim:pick -- --base <chosen> --discount <chosen> --hands 10000 --seed 2
+npm run sim:pick -- --base <chosen> --discount <chosen> --hands 10000 --seed 3
+```
+
+- [ ] **Step 3: Update the constants in `shared/botStrategy.js`**
+
+Replace:
+```js
+export const PICK_THRESHOLD_BASE = 30
+export const PICK_THRESHOLD_DISCOUNT = 2
+```
+with the calibrated values.
+
+- [ ] **Step 4: Re-run the test suite**
+
+Run: `npx vitest run`
+Expected: all tests PASS.
+
+If the position-aware `decidePick` test now fails — the test hand was constructed for `BASE=30, DISCOUNT=2` to straddle seat 0 vs seat 3 — adjust the hand or the seat indices in that test so the assertion still demonstrates "passes early seat, picks late seat" with the new constants. Pick a hand whose `handScore` equals `NEW_BASE - K × NEW_DISCOUNT` for some `K ∈ {2, 3, 4}`. Concrete recipe:
+
+1. Compute `target = NEW_BASE - 3 × NEW_DISCOUNT`.
+2. Construct a 6-card hand (3+ trump, no QC, no fail aces, no fail tens) whose `schwanzerPts × 4 = target`. For example, if `target = 24`, you need schwanzerPts = 6: e.g., `Q♥(3) + J♥(2) + 9♦(1) + 3 fail blanks`.
+3. Re-run the test with seat 0 → pass and seat 3 → pick.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/botStrategy.js shared/gameEngine.test.js
+git commit -m "feat(bot): calibrate pick threshold to ~15% Leaster rate (#126)"
+```
+
+---
+
+## Task 6: Update `docs/BOTS.md`
+
+**Files:**
+- Modify: `docs/BOTS.md` (Pick Decision section)
+
+Sync the documentation with the new pick logic.
+
+- [ ] **Step 1: Replace the "Pick Decision" section**
+
+Locate the current "Pick Decision (`decidePick`)" section (around line 14) and replace it with:
+
+```markdown
+## Pick Decision (`decidePick`)
+
+The bot picks if **all** of the following hold:
+
+1. **Trump-count floor:** the hand contains at least 3 trump cards.
+2. **Hand score meets a position-aware threshold:** `handScore(hand) >= base − discount × passesSoFar`.
+
+Both bot decisions and the human pick-suggestion go through this single function — the suggestion shown to a human is the same play a competent bot would make.
+
+### Hand score formula
+
+```
+handScore = (schwanzer points) × 4
+          + 3 × (count of non-trump aces)
+          + 2 × (count of non-trump tens)
+          + 5  if the Queen of Clubs is held
+```
+
+- **Schwanzer points** (defined in `gameEngine.js`): Queen=3, Jack=2, non-Q-non-J diamond=1, else=0. This term is the strongest signal of trump quality.
+- **Queen of Clubs bonus:** the QC is the highest card in the deck and never loses a trump fight; it is materially stronger than other queens, so it gets a flat +5.
+- **Non-trump aces and tens** capture point density in fail. Counted as `+3` and `+2` respectively. Note that the Ace and Ten of Diamonds are *trump*, not fail — they contribute via the schwanzer-points term, not here.
+
+### Position-aware threshold
+
+The threshold drops by `discount` (currently `<DISCOUNT_VALUE>`) for each seat that has already passed in this hand. With the base set to `<BASE_VALUE>`, the per-seat thresholds are:
+
+| Seat in pick order | Threshold |
+|---|---|
+| 1 (first to act) | `<BASE>` |
+| 2 | `<BASE - DISCOUNT>` |
+| 3 | `<BASE - 2*DISCOUNT>` |
+| 4 | `<BASE - 3*DISCOUNT>` |
+| 5 (last) | `<BASE - 4*DISCOUNT>` |
+
+This reflects real sheepshead strategy: each preceding pass is evidence that the remaining hands are weaker, so a later seat can pick on a marginally weaker hand.
+
+### Hard trump-count veto
+
+If the hand contains 2 or fewer trump, the bot never picks regardless of `handScore`. Real players auto-pass these hands. This veto prevents pathological "all aces, no trump" hands from clearing the threshold.
+```
+
+Replace `<BASE_VALUE>` and `<DISCOUNT_VALUE>` with the calibrated numbers from Task 5, and fill in the table likewise.
+
+- [ ] **Step 2: Confirm RULES.md and other docs do not reference the old `>= 24` threshold**
+
+Run:
+```bash
+grep -n "24" docs/BOTS.md docs/RULES.md
+grep -n "schwanzerPts \* 4 + buriablePoints\|handScore" docs/BOTS.md
+```
+Resolve any stale references.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/BOTS.md
+git commit -m "docs(bots): sync BOTS.md with new pick decision (#126)"
+```
+
+---
+
+## Task 7: Final verification
+
+**Files:** none modified — just running checks.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npx vitest run`
+Expected: all tests PASS.
+
+- [ ] **Step 2: Run frontend tests**
+
+Run: `npm test -w frontend`
+Expected: all PASS (this rework should not affect the frontend).
+
+- [ ] **Step 3: Confirm `botSuggestion.labels.test.js` still works**
+
+That file mocks `decidePick` directly (`vi.fn()`), so it should be unaffected. The above suite run covers it; this step is just a callout in case the mock surface needs updating.
+
+- [ ] **Step 4: Spot-check via `npm run dev`** (optional but recommended)
+
+Start the dev server and play through a few hands, watching for:
+- Bots passing on weak hands (clearly weaker hands than before should now pass).
+- The pick suggestion (when toggled on) producing the same call a bot would.
+
+If the human-suggestion UI surfaces a pick recommendation visibly differently, double-check that `botSuggestion.js` is wired to the new `decidePick` (it already is, per Task 0 exploration — no change needed).
+
+- [ ] **Step 5: Run the simulator one more time and record the result in the PR description**
+
+```bash
+npm run sim:pick -- --base <BASE> --discount <DISCOUNT> --hands 50000 --seed 42
+```
+
+Paste the output into the PR description as evidence of the calibration.
+
+- [ ] **Step 6: Final commit if anything was tweaked, then push for review**
+
+```bash
+git status
+# If clean, no commit needed.
+```
+
+---
+
+## Out of scope (logged in #157)
+
+- Fail-suit-count term (count of distinct fail suits in hand)
+- A♦ / 10♦ context-dependent bonus
+- All-three-fail-aces penalty

--- a/docs/superpowers/specs/2026-04-27-bot-pick-strategy-rework-design-for-PMs.md
+++ b/docs/superpowers/specs/2026-04-27-bot-pick-strategy-rework-design-for-PMs.md
@@ -1,0 +1,56 @@
+# Bot Pick Strategy Rework — PM Summary
+
+**Date:** 2026-04-27
+**Issue:** [#126](https://github.com/andynumber2/sheepshead/issues/126)
+
+## What we're changing
+
+How the computer-controlled players decide whether to "pick" — the central commitment in a sheepshead hand, where one player takes on the risk of capturing more than half the points in exchange for the chance to call a partner.
+
+## Why
+
+Today, the bots pick on almost any hand. Across five bots evaluating each hand independently, at least one of them almost always meets the (low) bar for picking. Two consequences:
+
+1. **Two of the game's variants — Leaster and Schwanzer — almost never happen.** These variants only occur when *every* player passes. With our current bots, this is functionally impossible. Real players see these hands sometimes; our players don't.
+2. **The bots feel less like skilled opponents.** A confident pick on a weak hand is a losing strategy in real sheepshead, and the bots make this mistake routinely.
+
+The fix is to make the bots' pick decision a more honest model of how a competent human player would decide.
+
+## What "competent picking" actually looks like
+
+A few principles drive a real player's pick decision:
+
+- **Trump count matters most.** With 2 or fewer trump in your hand, you almost never pick — period.
+- **Top trumps are not all equal.** The Queen of Clubs in particular is the highest card in the deck and never loses a trump fight. Holding it is meaningfully different from holding any other queen.
+- **Position matters.** If three other players have already passed before it's your turn, that tells you something — those hands were weak, so by comparison, your hand is relatively stronger. Real players lower their threshold a bit with each pass that has happened in front of them.
+- **Side cards (non-trump aces and tens) help, but not as much as the current formula assumes.** A single ace can capture a lot of points if it survives, but it doesn't always survive. The current logic treats it as if it always does.
+
+We are folding all four of these into the new pick decision.
+
+## What stays the same
+
+- Game rules don't change.
+- How the picker buries cards, calls a partner, or plays out tricks doesn't change. This is **only** the pick / pass decision.
+- The blitz, partner call, and bury logic are untouched.
+
+## How we know the new logic is right
+
+This kind of change is easy to over-correct (bots that never pick is just as broken as bots that always pick). To avoid guessing, we are building an offline simulator: a small command-line tool that deals tens of thousands of synthetic hands and reports how often a no-pick occurs under any given setting. We tune the parameters until the simulated no-pick rate lands near the **target of ~15%**, which is consistent with how often Leaster/Schwanzer occurs in real human games.
+
+After shipping, we will also check the live game database — every completed hand records its variant, so we can confirm that real play matches the simulation. If it diverges, we retune.
+
+## What's intentionally *not* in this change
+
+Three additional refinements were considered and deferred (logged as a separate follow-up). They are real, but each is either too rare or too context-dependent to justify in a first pass:
+
+- A bonus for being short or void in fail suits.
+- Treating the Ace and Ten of Diamonds specially (they are valuable in strong hands and a liability in weak ones — needs more nuance than a flat bonus).
+- A penalty for the rare case of holding all three fail aces.
+
+We will revisit these once we see the new logic in action.
+
+## Success criteria
+
+- Simulated no-pick rate lands within ±2% of 15%.
+- Real-play no-pick rate (measured after launch from the hands database) lands within ±5% of 15% over the first 100+ completed hands.
+- Bots and the human-player suggestion use the same logic — players see the same advice a competent bot would make.

--- a/docs/superpowers/specs/2026-04-27-bot-pick-strategy-rework-design.md
+++ b/docs/superpowers/specs/2026-04-27-bot-pick-strategy-rework-design.md
@@ -1,0 +1,124 @@
+# Bot Pick Strategy Rework — Design
+
+**Date:** 2026-04-27
+**Issue:** [#126](https://github.com/andynumber2/sheepshead/issues/126)
+**Follow-up issue (deferred items):** [#157](https://github.com/andynumber2/sheepshead/issues/157)
+
+## Problem
+
+Bot pick decisions trigger far too aggressively. The current rule is `handScore >= 24` where `handScore = schwanzerPts × 4 + buriablePoints`. Across five independent bots, at least one almost always meets this bar, making Leaster and Schwanzer hands functionally unreachable through normal play. This was surfaced during QA of the hand-recap feature.
+
+The fix is **not** a QA escape hatch. The goal is to make the bot's pick decision a more accurate model of competent sheepshead play, with Leaster/Schwanzer occurring as a natural side effect.
+
+## Goals
+
+- Bots pick at a game-theoretically defensible rate.
+- Target Leaster/Schwanzer frequency: **~15%** (consistent with real-play observation).
+- Single shared decision path for bots and the human pick-suggestion.
+- Tunable: thresholds discoverable via offline simulation, not guessed.
+
+## Non-goals
+
+- No admin/debug toggles to force Leaster/Schwanzer (would mask the underlying problem).
+- No changes to `decideBlitz`, `decideBury`, `decideCall`, or any play-phase logic.
+- No changes to game-engine deal logic or scoring rules.
+
+## Design
+
+### 1. New pick-decision formula
+
+```
+handScore =
+    schwanzerPts × 4
+  + 3 × (count of fail aces in hand)
+  + 2 × (count of fail tens in hand)
+  + 5 if Queen of Clubs in hand
+```
+
+Replaces the current `schwanzerPts × 4 + buriablePoints` formula.
+
+**Why each term:**
+
+- **`schwanzerPts × 4`** is retained. It's a reasonable proxy for trump quality (queens, jacks, diamond pips) and continuity matters — calibration is easier when the base term hasn't moved.
+- **`3 × failAces`, `2 × failTens`** replaces `buriablePoints`. The old term overweights buriable cards (a single fail ace = +11 raw card points), letting marginal hands clear the threshold on the strength of one card. The replacement values capture the same signal — non-trump point density — but at a weight closer to actual equity.
+- **`+5 if QC held`**. The Queen of Clubs is the highest card in the deck. It cannot lose a trump fight. Today the formula treats QC identically to QD; in reality QC is materially stronger. Five is roughly its equity premium.
+
+### 2. Hard veto: trump-count floor
+
+```
+if (trumpCount(hand) <= 2) return false
+```
+
+Applied before the score check. With 2 or fewer trump, no hand should pick regardless of fail strength. Real players auto-pass these hands. The rule prevents pathological "all aces, no trump" hands from clearing the threshold.
+
+### 3. Position-aware threshold
+
+```
+threshold = BASE − DISCOUNT × passesSoFar
+```
+
+Where `passesSoFar` is the number of seats that have already been offered the blind in this hand and passed.
+
+- `BASE` and `DISCOUNT` are constants determined by simulation. Initial values to be calibrated against the 15% target.
+- Earlier seats face a higher bar (they have less information; more bots remain who could over-pick them). Later seats face a lower bar.
+- This is the single biggest reason bots over-pick today: every bot acts as if it were seat 1 with no information.
+
+The `decidePick` signature changes to accept `passesSoFar` (or to read it from `view`, depending on what's already available — implementation detail for the plan).
+
+### 4. Single shared path
+
+Both bot pick decisions and the human pick-suggestion go through the same `decidePick` function with the same formula and threshold. The suggestion shown to the human is the same play a competent bot would make. Humans can override.
+
+No separate "looser human suggestion" mode. A worse model is not a feature.
+
+### 5. Calibration: Monte Carlo simulator
+
+A new CLI tool at `scripts/simulate-pick.js`, wired to `package.json` as `npm run sim:pick`.
+
+**Inputs (CLI args):**
+- `--base <N>` — base threshold
+- `--discount <N>` — per-pass discount
+- `--hands <N>` — number of synthetic hands to simulate (default 10000)
+- `--seed <N>` — optional seed for deterministic runs
+
+**Behaviour:**
+- Imports the real `dealHand` and `decidePick` from the production code paths. No re-implementation — what is simulated is what is shipped.
+- For each synthetic hand, runs the full pick sequence: each seat in turn evaluates `decidePick` with the running `passesSoFar` count. First true → that seat picks. All-false → no-pick.
+- Aggregates: total hands, picks per seat (1–5), no-pick rate, average handScore among picks vs passes.
+
+**Seeding:** the existing `shuffle` uses `Math.random`. To support `--seed`, the simulator will need either an injected RNG or a small `seedrandom`-style replacement local to the simulator. The plan should pick the lightest option; falling back to non-deterministic if `--seed` is omitted is acceptable.
+
+**Why a script, not a test:**
+Calibration runs are tuning sessions, not pass/fail. A test that asserted "no-pick rate is in [13%, 17%]" would either be flaky from sample variance or assert a number we don't yet trust. Keep this orthogonal to the test suite.
+
+### 6. Post-ship validation
+
+The `hands.variant` column already records each completed hand's variant. After the change ships, query that table to confirm real-play no-pick rate matches the simulation:
+
+```sql
+SELECT variant, COUNT(*)
+FROM hands
+WHERE completed_at IS NOT NULL
+GROUP BY variant;
+```
+
+No new telemetry needed. If the live rate diverges materially from 15%, retune `BASE` / `DISCOUNT` and re-ship.
+
+### 7. Documentation sync
+
+`docs/BOTS.md` must be updated to describe the new pick logic accurately, per project convention. The "Pick Decision" section is rewritten to cover: the new formula, the trump-count floor, and the position-aware threshold.
+
+## Out of scope (deferred to issue #157)
+
+- Fail-suit-count term (a refined version of "void bonus" that counts distinct fail suits instead of voids).
+- A♦/10♦ context-dependent bonus (only a positive in strong hands; liability in weak ones — not a flat term).
+- All-three-fail-aces penalty (too rare to justify a special case in v1).
+
+## Success criteria
+
+1. Simulated no-pick rate with chosen `BASE`/`DISCOUNT` lands within ±2% of the 15% target across ≥10,000 simulated hands.
+2. The hard veto correctly rejects all hands with ≤2 trump in the simulator.
+3. The QC bonus, fail-ace bonus, and fail-ten bonus are observable in unit tests of the new formula.
+4. Bots and the human suggestion produce identical pick decisions for identical inputs.
+5. `docs/BOTS.md` matches the implemented logic.
+6. Post-ship: real-play no-pick rate (queried from `hands.variant`) lands within ±5% of 15% over the first 100+ completed hands. If not, retune.

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:migrate:local": "wrangler d1 migrations apply sheepshead-db --local",
     "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote",
     "test": "vitest run && npm test -w frontend",
+    "sim:pick": "node scripts/simulate-pick.js",
     "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "db:migrate:local": "wrangler d1 migrations apply sheepshead-db --local",
     "db:migrate": "wrangler d1 migrations apply sheepshead-db --remote",
     "test": "vitest run && npm test -w frontend",
-    "sim:pick": "node scripts/simulate-pick.js",
+    "sim:pick": "node scripts/simulate-pick.mjs",
     "postinstall": "git config core.hooksPath .githooks"
   },
   "devDependencies": {

--- a/scripts/simulate-pick.js
+++ b/scripts/simulate-pick.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Monte Carlo simulator for the bot pick decision.
+// Calibrates BASE and DISCOUNT against a target no-pick (Leaster/Schwanzer) rate.
+//
+// Usage:
+//   npm run sim:pick -- --base 30 --discount 2 --hands 10000 [--seed 42]
+
+import { dealHand } from '../shared/gameEngine.js'
+import { decidePickWith } from '../shared/botStrategy.js'
+
+function parseArgs(argv) {
+  const args = { base: 30, discount: 2, hands: 10000, seed: undefined }
+  for (let i = 2; i < argv.length; i++) {
+    const tok = argv[i]
+    const next = argv[i + 1]
+    if (tok === '--base')      { args.base = Number(next); i++ }
+    else if (tok === '--discount') { args.discount = Number(next); i++ }
+    else if (tok === '--hands')    { args.hands = Number(next); i++ }
+    else if (tok === '--seed')     { args.seed = Number(next); i++ }
+    else if (tok === '--help' || tok === '-h') {
+      console.log('Usage: npm run sim:pick -- --base N --discount N --hands N [--seed N]')
+      process.exit(0)
+    } else {
+      console.error(`Unknown arg: ${tok}`)
+      process.exit(1)
+    }
+  }
+  if (Number.isNaN(args.base) || Number.isNaN(args.discount) || Number.isNaN(args.hands)) {
+    console.error('--base, --discount, and --hands must all be numbers')
+    process.exit(1)
+  }
+  return args
+}
+
+// mulberry32: tiny seeded PRNG. Deterministic for a given seed.
+function makeMulberry32(seed) {
+  let s = seed >>> 0
+  return function () {
+    s = (s + 0x6D2B79F5) | 0
+    let t = Math.imul(s ^ (s >>> 15), 1 | s)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function simulate({ base, discount, hands, seed }) {
+  // dealHand uses Math.random internally via shuffle. Override for deterministic runs.
+  if (seed !== undefined) {
+    Math.random = makeMulberry32(seed)
+  }
+
+  const playerIds = ['p0', 'p1', 'p2', 'p3', 'p4']
+  const picksBySeat = [0, 0, 0, 0, 0]
+  let noPick = 0
+
+  for (let h = 0; h < hands; h++) {
+    const state = dealHand(playerIds, 0, 1, 1)
+    let picked = false
+    for (let i = 0; i < state.pickOrder.length; i++) {
+      const userId = state.pickOrder[i]
+      const view = { hands: state.hands, pickIndex: i }
+      if (decidePickWith(view, userId, base, discount)) {
+        picksBySeat[i]++
+        picked = true
+        break
+      }
+    }
+    if (!picked) noPick++
+  }
+
+  const total = hands
+  return {
+    total,
+    picksBySeat,
+    pickedTotal: picksBySeat.reduce((a, b) => a + b, 0),
+    noPick,
+    noPickRate: noPick / total,
+  }
+}
+
+const args = parseArgs(process.argv)
+const r = simulate(args)
+
+const pct = (x) => (x * 100).toFixed(2) + '%'
+console.log('=== Pick Simulation ===')
+console.log(`base=${args.base} discount=${args.discount} hands=${args.hands}` +
+            (args.seed !== undefined ? ` seed=${args.seed}` : ' (random seed)'))
+console.log(`Total hands:        ${r.total}`)
+console.log(`Picked total:       ${r.pickedTotal} (${pct(r.pickedTotal / r.total)})`)
+for (let i = 0; i < 5; i++) {
+  console.log(`  Seat ${i + 1} picks: ${r.picksBySeat[i]} (${pct(r.picksBySeat[i] / r.total)})`)
+}
+console.log(`No-pick (Leaster):  ${r.noPick} (${pct(r.noPickRate)})`)
+console.log(`Target ~15%; current delta: ${((r.noPickRate - 0.15) * 100).toFixed(2)}%`)

--- a/scripts/simulate-pick.mjs
+++ b/scripts/simulate-pick.mjs
@@ -29,6 +29,10 @@ function parseArgs(argv) {
     console.error('--base, --discount, and --hands must all be numbers')
     process.exit(1)
   }
+  if (!Number.isInteger(args.hands) || args.hands < 1) {
+    console.error('--hands must be a positive integer')
+    process.exit(1)
+  }
   return args
 }
 
@@ -88,7 +92,7 @@ console.log(`base=${args.base} discount=${args.discount} hands=${args.hands}` +
 console.log(`Total hands:        ${r.total}`)
 console.log(`Picked total:       ${r.pickedTotal} (${pct(r.pickedTotal / r.total)})`)
 for (let i = 0; i < 5; i++) {
-  console.log(`  Seat ${i + 1} picks: ${r.picksBySeat[i]} (${pct(r.picksBySeat[i] / r.total)})`)
+  console.log(`  Pick position ${i + 1}: ${r.picksBySeat[i]} (${pct(r.picksBySeat[i] / r.total)})`)
 }
 console.log(`No-pick (Leaster):  ${r.noPick} (${pct(r.noPickRate)})`)
 console.log(`Target ~15%; current delta: ${((r.noPickRate - 0.15) * 100).toFixed(2)}%`)

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -33,20 +33,17 @@ export function trumpRemainingElsewhere(view, userId) {
 
 // ─── Hand evaluation ──────────────────────────────────────────────────────────
 
-// Sum of card points for the top 2 non-trump cards in hand.
-// Returns 0 if fewer than 2 non-trump cards exist.
-export function buriablePoints(hand) {
-  const nonTrump = hand.filter(c => !c.hidden && !isTrump(c))
-  if (nonTrump.length < 2) return 0
-  const sorted = [...nonTrump].sort((a, b) => cardPoints(b) - cardPoints(a))
-  return sorted.slice(0, 2).reduce((sum, c) => sum + cardPoints(c), 0)
-}
-
 // Combined hand quality score for the pick decision.
-// schwanzerPts * 4 + buriablePoints. Threshold: >= 24 → pick.
+// schwanzerPts × 4 + 3 × failAces + 2 × failTens + (5 if QC).
+// Hidden cards are ignored — handScore is called from decidePick on the bot's own hand,
+// but the hidden filter mirrors the prior implementation for safety.
 export function handScore(hand) {
-  const schwanzerPts = hand.filter(c => !c.hidden).reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
-  return schwanzerPts * 4 + buriablePoints(hand)
+  const visible = hand.filter(c => !c.hidden)
+  const schwanzerPts = visible.reduce((sum, c) => sum + schwanzerCardPoints(c), 0)
+  const failAces = visible.filter(c => !isTrump(c) && c.rank === 'A').length
+  const failTens = visible.filter(c => !isTrump(c) && c.rank === '10').length
+  const hasQC = visible.some(c => c.id === 'QC')
+  return schwanzerPts * 4 + 3 * failAces + 2 * failTens + (hasQC ? 5 : 0)
 }
 
 // ─── Trick evaluation ─────────────────────────────────────────────────────────

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -133,7 +133,7 @@ function cheapestWinningTrump(cards) {
 
 // ─── decidePick ───────────────────────────────────────────────────────────────
 // Placeholder calibration values; tuned in scripts/simulate-pick.js (issue #126).
-export const PICK_THRESHOLD_BASE = 30
+export const PICK_THRESHOLD_BASE = 35
 export const PICK_THRESHOLD_DISCOUNT = 2
 
 export function pickThreshold(passesSoFar) {

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -132,7 +132,7 @@ function cheapestWinningTrump(cards) {
 }
 
 // ─── decidePick ───────────────────────────────────────────────────────────────
-// Placeholder calibration values; tuned in scripts/simulate-pick.js (issue #126).
+// Calibrated values from scripts/simulate-pick.mjs targeting ~15% no-pick rate (issue #126).
 export const PICK_THRESHOLD_BASE = 35
 export const PICK_THRESHOLD_DISCOUNT = 2
 

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -132,9 +132,29 @@ function cheapestWinningTrump(cards) {
 }
 
 // ─── decidePick ───────────────────────────────────────────────────────────────
-export function decidePick(view, userId) {
+// Placeholder calibration values; tuned in scripts/simulate-pick.js (issue #126).
+export const PICK_THRESHOLD_BASE = 30
+export const PICK_THRESHOLD_DISCOUNT = 2
+
+export function pickThreshold(passesSoFar) {
+  return PICK_THRESHOLD_BASE - PICK_THRESHOLD_DISCOUNT * passesSoFar
+}
+
+// Parameterized core — used by the simulator to sweep base/discount values.
+export function decidePickWith(view, userId, base, discount) {
   const hand = view.hands[userId]
-  return handScore(hand) >= 24
+  const visible = hand.filter(c => !c.hidden)
+
+  // Hard veto: too few trump → never pick.
+  const trumpCount = visible.filter(c => isTrump(c)).length
+  if (trumpCount <= 2) return false
+
+  const passesSoFar = view.pickIndex ?? 0
+  return handScore(hand) >= base - discount * passesSoFar
+}
+
+export function decidePick(view, userId) {
+  return decidePickWith(view, userId, PICK_THRESHOLD_BASE, PICK_THRESHOLD_DISCOUNT)
 }
 
 // ─── decideBlitz ──────────────────────────────────────────────────────────────

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1766,22 +1766,39 @@ describe('pickThreshold', () => {
 })
 
 describe('decidePick', () => {
-  it('picks when handScore >= 24 (6 schwanzer pts, 0 burial = 24)', () => {
-    // QC=3, QS=3 = 6 schwanzer pts; 7C+8C non-trump = 0 burial; score = 24
-    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('7','C'), c('8','C')]
-    expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(true)
+  it('picks a strong hand at seat 0', () => {
+    // QC=3, QS=3, JC=2, JS=2, AD=1, 10D=1 → schwanzer 12 → 48; +5 QC; trump 6 → score 53
+    // Threshold at pickIndex=0 = BASE (30). Picks.
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('A','D'), c('10','D')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(true)
   })
 
-  it('passes when handScore < 24 (5 schwanzer pts, 0 burial = 20)', () => {
-    // QC=3, JC=2 = 5 schwanzer pts; 7C+8C non-trump = 0 burial; score = 20
-    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('8','C'), c('9','C'), c('9','H')]
+  it('passes a weak hand at seat 0', () => {
+    // QH=3, JH=2, 7C=0, 8C=0, 9S=0, 8S=0 → schwanzer 5 → 20; trump 2 → HARD VETO → pass
+    const hand = [c('Q','H'), c('J','H'), c('7','C'), c('8','C'), c('9','S'), c('8','S')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
+  })
+
+  it('hard veto: never picks with trumpCount ≤ 2 even if score is high', () => {
+    // QH=3, QD=3, AC=0, AH=0, AS=0, 10C=0 → schwanzer 7 → 28; +3*3 aces = 37
+    // But trump count = 2 (QH, QD) → hard veto → false.
+    const hand = [c('Q','H'), c('Q','D'), c('A','C'), c('A','H'), c('A','S'), c('10','C')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
+  })
+
+  it('position-aware: a marginal hand passes early-seat but picks late-seat', () => {
+    // Hand: QH=3, JH=2, 9D=1, 7C, 8C, 9S → schwanzer 6 → 24; trump 3 (QH, JH, 9D); no QC, no fail A/10 → score 24.
+    // At pickIndex=0 (threshold 30): 24 < 30 → pass.
+    // At pickIndex=3 (threshold 24): 24 ≥ 24 → pick.
+    const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
+    expect(decidePick({ hands: { p1: hand }, pickIndex: 3 }, 'p1')).toBe(true)
+  })
+
+  it('defaults pickIndex to 0 when undefined', () => {
+    // Same marginal hand as above; without pickIndex, behaves as seat 0 → pass.
+    const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
     expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(false)
-  })
-
-  it('picks when 5 schwanzer pts + two aces (score = 42)', () => {
-    // QC=3, JC=2 = 5 schwanzer pts; AC+AH non-trump = 22 burial; score = 42
-    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('A','C'), c('A','H'), c('8','S')]
-    expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(true)
   })
 })
 

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1768,7 +1768,7 @@ describe('pickThreshold', () => {
 describe('decidePick', () => {
   it('picks a strong hand at seat 0', () => {
     // QC=3, QS=3, JC=2, JS=2, AD=1, 10D=1 → schwanzer 12 → 48; +5 QC; trump 6 → score 53
-    // Threshold at pickIndex=0 = BASE (30). Picks.
+    // Threshold at pickIndex=0 = BASE (35). Picks.
     const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('A','D'), c('10','D')]
     expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(true)
   })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1773,14 +1773,16 @@ describe('decidePick', () => {
     expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(true)
   })
 
-  it('passes a weak hand at seat 0', () => {
-    // QH=3, JH=2, 7C=0, 8C=0, 9S=0, 8S=0 → schwanzer 5 → 20; trump 2 → HARD VETO → pass
-    const hand = [c('Q','H'), c('J','H'), c('7','C'), c('8','C'), c('9','S'), c('8','S')]
+  it('passes a low-score hand at seat 0 (score below threshold, no veto)', () => {
+    // Same marginal hand used in tests 4 and 5: QH=3, JH=2, 9D=1, 7C, 8C, 9S
+    // → schwanzer 6 → 24; trump 3 (QH, JH, 9D); no QC, no fail A/10 → score 24.
+    // Threshold at pickIndex=0 = 30 → 24 < 30 → pass. Trump count = 3 so veto does NOT fire.
+    const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
     expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
   })
 
   it('hard veto: never picks with trumpCount ≤ 2 even if score is high', () => {
-    // QH=3, QD=3, AC=0, AH=0, AS=0, 10C=0 → schwanzer 7 → 28; +3*3 aces = 37
+    // QH=3, QD=3, AC=0, AH=0, AS=0, 10C(fail ten) → schwanzer 6 → 24; +3*3 aces +2*1 ten = 35
     // But trump count = 2 (QH, QD) → hard veto → false.
     const hand = [c('Q','H'), c('Q','D'), c('A','C'), c('A','H'), c('A','S'), c('10','C')]
     expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1774,9 +1774,8 @@ describe('decidePick', () => {
   })
 
   it('passes a low-score hand at seat 0 (score below threshold, no veto)', () => {
-    // Same marginal hand used in tests 4 and 5: QH=3, JH=2, 9D=1, 7C, 8C, 9S
-    // → schwanzer 6 → 24; trump 3 (QH, JH, 9D); no QC, no fail A/10 → score 24.
-    // Threshold at pickIndex=0 = 30 → 24 < 30 → pass. Trump count = 3 so veto does NOT fire.
+    // QH=3, JH=2, 9D=1, 7C, 8C, 9S → schwanzer 6 → 24; trump 3 (QH, JH, 9D); no QC, no fail A/10 → score 24.
+    // Threshold at pickIndex=0 = BASE=35 → 24 < 35 → pass. Trump count = 3 so veto does NOT fire.
     const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
     expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
   })
@@ -1789,17 +1788,18 @@ describe('decidePick', () => {
   })
 
   it('position-aware: a marginal hand passes early-seat but picks late-seat', () => {
-    // Hand: QH=3, JH=2, 9D=1, 7C, 8C, 9S → schwanzer 6 → 24; trump 3 (QH, JH, 9D); no QC, no fail A/10 → score 24.
-    // At pickIndex=0 (threshold 30): 24 < 30 → pass.
-    // At pickIndex=3 (threshold 24): 24 ≥ 24 → pick.
-    const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
+    // Hand: QH=3, JH=2, JD=2, 9D=1, 7C, 8C → schwanzer 8 → score 32; trump 4 (QH, JH, JD, 9D); no QC, no fail A/10.
+    // BASE=35, DISCOUNT=2.
+    // At pickIndex=0 (threshold 35): 32 < 35 → pass.
+    // At pickIndex=3 (threshold 35 - 3×2 = 29): 32 ≥ 29 → pick.
+    const hand = [c('Q','H'), c('J','H'), c('J','D'), c('9','D'), c('7','C'), c('8','C')]
     expect(decidePick({ hands: { p1: hand }, pickIndex: 0 }, 'p1')).toBe(false)
     expect(decidePick({ hands: { p1: hand }, pickIndex: 3 }, 'p1')).toBe(true)
   })
 
   it('defaults pickIndex to 0 when undefined', () => {
     // Same marginal hand as above; without pickIndex, behaves as seat 0 → pass.
-    const hand = [c('Q','H'), c('J','H'), c('9','D'), c('7','C'), c('8','C'), c('9','S')]
+    const hand = [c('Q','H'), c('J','H'), c('J','D'), c('9','D'), c('7','C'), c('8','C')]
     expect(decidePick({ hands: { p1: hand } }, 'p1')).toBe(false)
   })
 })

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -11,7 +11,7 @@ import {
 } from './gameEngine.js'
 import {
   countTrumpPlayed, trumpRemainingElsewhere,
-  buriablePoints, handScore,
+  handScore,
   beats, currentWinner, teammateWinning,
   bestVoidBury,
   isGuaranteedWinner,
@@ -1530,51 +1530,6 @@ describe('trumpRemainingElsewhere', () => {
   })
 })
 
-describe('buriablePoints', () => {
-  it('returns sum of top 2 non-trump cards by point value', () => {
-    // AC=11, 10H=10, KS=4 → top 2 are AC + 10H = 21
-    const hand = [c('Q','C'), c('J','S'), c('A','C'), c('10','H'), c('K','S'), c('9','C')]
-    expect(buriablePoints(hand)).toBe(21)
-  })
-
-  it('returns 0 when fewer than 2 non-trump cards exist', () => {
-    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('A','D'), c('10','D')]
-    expect(buriablePoints(hand)).toBe(0)
-  })
-
-  it('returns 0 when exactly 1 non-trump card exists', () => {
-    // Only KS is non-trump; fewer than 2 → 0
-    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('A','D'), c('K','S')]
-    expect(buriablePoints(hand)).toBe(0)
-  })
-
-  it('returns sum when exactly 2 non-trump cards exist', () => {
-    // KS=4, 9C=0 → 4
-    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('J','S'), c('K','S'), c('9','C')]
-    expect(buriablePoints(hand)).toBe(4)
-  })
-})
-
-describe('handScore', () => {
-  it('returns schwanzerPts * 4 + buriablePoints (exact formula check)', () => {
-    // QC=3, QS=3 = 6 schwanzer pts; 7C=0, 8C=0 non-trump → buriable=0; score = 6*4+0 = 24
-    const hand = [c('Q','C'), c('Q','S'), c('7','C'), c('8','C'), c('9','H'), c('8','H')]
-    expect(handScore(hand)).toBe(24)
-  })
-
-  it('scores < 24 for 5 schwanzer pts, 0 burial', () => {
-    // QC=3, JC=2 = 5 schwanzer pts; 7C=0, 8C=0 non-trump → buriable=0; score = 5*4+0 = 20
-    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('8','C'), c('9','C'), c('9','H')]
-    expect(handScore(hand)).toBeLessThan(24)
-    expect(handScore(hand)).toBe(20)
-  })
-
-  it('scores >= 24 for 5 schwanzer pts + two aces to bury', () => {
-    // QC=3, JC=2 = 5 schwanzer pts; AC=11, AH=11 → buriable=22; score = 5*4+22 = 42
-    const hand = [c('Q','C'), c('J','C'), c('7','C'), c('A','C'), c('A','H'), c('8','S')]
-    expect(handScore(hand)).toBe(42)
-  })
-})
 
 describe('beats', () => {
   it('trump beats non-trump', () => {
@@ -1748,6 +1703,54 @@ describe('bestVoidBury', () => {
       c('K','S'), c('Q','C'),
     ]
     expect(bestVoidBury(hand)).toBeNull()
+  })
+})
+
+describe('handScore', () => {
+  it('returns schwanzerPts × 4 for an all-trump-no-QC hand', () => {
+    // QH=3, QD=3, JS=2, JH=2, JD=2, 9D=1 → schwanzer 13 → 13*4 = 52
+    // No QC, no fail aces, no fail tens
+    const hand = [c('Q','H'), c('Q','D'), c('J','S'), c('J','H'), c('J','D'), c('9','D')]
+    expect(handScore(hand)).toBe(52)
+  })
+
+  it('adds 5 when QC is held', () => {
+    // QC=3, JS=2, JH=2, 7C=0, 8C=0, 9C=0 → schwanzer 7 → 7*4 = 28; +5 QC = 33
+    const hand = [c('Q','C'), c('J','S'), c('J','H'), c('7','C'), c('8','C'), c('9','C')]
+    expect(handScore(hand)).toBe(33)
+  })
+
+  it('adds 3 per non-trump ace', () => {
+    // QH=3, JH=2, AC=0, AH=0, 7S=0, 8S=0 → schwanzer 5 → 20; +3*2 fail aces = 26
+    // No QC, no tens
+    const hand = [c('Q','H'), c('J','H'), c('A','C'), c('A','H'), c('7','S'), c('8','S')]
+    expect(handScore(hand)).toBe(26)
+  })
+
+  it('adds 2 per non-trump ten', () => {
+    // QH=3, JH=2, 10C=0, 10H=0, 7S=0, 8S=0 → schwanzer 5 → 20; +2*2 fail tens = 24
+    const hand = [c('Q','H'), c('J','H'), c('10','C'), c('10','H'), c('7','S'), c('8','S')]
+    expect(handScore(hand)).toBe(24)
+  })
+
+  it('does not count A♦ or 10♦ as a fail ace/ten (they are trump)', () => {
+    // AD and 10D are diamonds → trump. They contribute schwanzerPts=1 each (diamond pips)
+    // but are NOT fail aces/tens.
+    // QH=3, JH=2, AD=1, 10D=1, 7S=0, 8S=0 → schwanzer 7 → 28; no QC, no fail A/10 → 28
+    const hand = [c('Q','H'), c('J','H'), c('A','D'), c('10','D'), c('7','S'), c('8','S')]
+    expect(handScore(hand)).toBe(28)
+  })
+
+  it('combines all terms', () => {
+    // QC=3, QS=3, JC=2, AC=0, AH=0, 10S=0 → schwanzer 8 → 32; +5 QC; +3*2 aces; +2*1 ten = 45
+    const hand = [c('Q','C'), c('Q','S'), c('J','C'), c('A','C'), c('A','H'), c('10','S')]
+    expect(handScore(hand)).toBe(45)
+  })
+
+  it('ignores hidden cards', () => {
+    // Only QC visible: schwanzer 3 → 12; +5 QC = 17
+    const hand = [c('Q','C'), { id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }]
+    expect(handScore(hand)).toBe(17)
   })
 })
 

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest'
-import { decidePick, decideBury, decideCall, decidePlay } from './botStrategy.js'
+import { pickThreshold, PICK_THRESHOLD_BASE, PICK_THRESHOLD_DISCOUNT, decidePick, decideBury, decideCall, decidePlay } from './botStrategy.js'
 import {
   isTrump, trumpRank, suitRank, effectiveSuit, cardPoints,
   schwanzerCardPoints, resolveSchwanzer,
@@ -1751,6 +1751,17 @@ describe('handScore', () => {
     // Only QC visible: schwanzer 3 → 12; +5 QC = 17
     const hand = [c('Q','C'), { id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }]
     expect(handScore(hand)).toBe(17)
+  })
+})
+
+describe('pickThreshold', () => {
+  it('returns BASE at passesSoFar = 0', () => {
+    expect(pickThreshold(0)).toBe(PICK_THRESHOLD_BASE)
+  })
+
+  it('subtracts DISCOUNT per pass', () => {
+    expect(pickThreshold(1)).toBe(PICK_THRESHOLD_BASE - PICK_THRESHOLD_DISCOUNT)
+    expect(pickThreshold(4)).toBe(PICK_THRESHOLD_BASE - 4 * PICK_THRESHOLD_DISCOUNT)
   })
 })
 

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}


### PR DESCRIPTION
Closes #126.

## Summary
- Replaces the bot pick decision with a more accurate model of competent sheepshead play. Bots now pass on hands they shouldn't pick on, so Leaster/Schwanzer hands occur at a realistic rate (~15%) instead of effectively never.
- New formula: `schwanzerPts × 4 + 3·failAces + 2·failTens + (5 if QC)`. Adds an explicit Queen-of-Clubs bonus (highest card, never loses a trump fight) and replaces the old over-weighted `buriablePoints` term.
- Hard trump-count veto (≤2 trump → never pick) and position-aware threshold (`35 − 2 × passesSoFar`) — each preceding pass lowers the bar slightly, matching real-table strategy.
- Single shared path: bots and the human pick-suggestion both use `decidePick`. No signature change for callers (`view.pickIndex` was already available).
- New offline calibration tool: `npm run sim:pick -- --base N --discount N --hands N [--seed N]`. Imports production code paths so what is simulated is what is shipped.

## Calibration result (50,000 hands, seed=42)
```
Pick position 1: 13.93%
Pick position 2: 16.53%
Pick position 3: 18.69%
Pick position 4: 18.61%
Pick position 5: 16.71%
No-pick (Leaster): 15.52%   (target ~15%, delta +0.52%)
```
Three-seed verification at 10,000 hands: 16.04% / 15.07% / 15.37% — all within target ±2%.

## Out of scope (deferred to #157)
- Fail-suit-count term
- A♦ / 10♦ context-dependent bonus
- All-three-fail-aces penalty

## Spec / plan
- Design: `docs/superpowers/specs/2026-04-27-bot-pick-strategy-rework-design.md`
- PM summary: `docs/superpowers/specs/2026-04-27-bot-pick-strategy-rework-design-for-PMs.md`
- Implementation plan: `docs/superpowers/plans/2026-04-27-bot-pick-strategy-rework.md`

## Test plan
- [x] `npx vitest run` — 248/248 pass
- [x] `npm test -w frontend` — 8/8 pass
- [x] `npm run sim:pick -- --base 35 --discount 2 --hands 50000 --seed 42` reports 15.52% no-pick rate
- [x] Three-seed verification at 10,000 hands lands within 13–17%
- [ ] Post-merge: query `hands.variant` from the live D1 once 100+ completed hands have accumulated; confirm real-play no-pick rate is within ±5% of 15%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)