### PR TITLE
feat(bot): force-up trump-in on fail-led picker-winning tricks

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -147,7 +147,9 @@ A recurring concept below is a **guaranteed winner**: a trump card the bot holds
    - **Bot must follow a non-called fail suit** (only fail winners available):
      - Threats remaining > 0 → **skip** (an unrevealed opponent could be void and trump over). Fall through to default.
      - Threats remaining = 0 → take with the schmear-self pick using the **fail priority** (see below).
-3. **Trump in on called suit**: If the called suit was led and the picker team is currently winning the trick, play the lowest available trump to contest.
+3. **Trump in to contest a picker-team-winning fail-led trick**: If a fail card was led, the picker team is currently winning, and the bot is void in the led suit, trump in. The picker-team-winning gate naturally excludes the case where another opponent has already trumped in (then a teammate would be winning and the schmear branch above would have fired). Card choice splits on the partner-reveal state:
+   - **Partner-revealing called-suit lead** (called suit led and partner **not yet revealed**): use the **trump schmear priority** (A, 10, K before pip cards; Js/Qs reserved). The partner is forced to play the called card on this trick, so cashing high trump captures both those points and the partner's high card.
+   - **Otherwise**: play the **highest trump** (strongest by trump rank — Q♣ at the top). The aim is to force the picker to overtrump with their best trump to retake the lead, or simply steal the trick if the picker has already played.
 4. **Otherwise**: play the lowest card.
 
 **Schmear priority** (used by both the schmear branch above and the force-take branch's 0-threats-remaining cases): walk a rank-priority list and pick the first card found.

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -551,14 +551,30 @@ export function decidePlay(view, userId) {
         }
       }
     }
-    // Trump in on called suit if picker team is currently winning the trick
-    const { calledSuit } = view
-    if (ledSuit === calledSuit) {
+    // Trump in to contest a picker-team-winning fail-led trick. Goal: force the
+    // picker up — make them play their strongest trump to retake the lead — or
+    // simply steal the trick if the picker has already played. The picker-team-
+    // winning gate naturally excludes the case where another opponent has
+    // already trumped in (then the bot's teammate is winning, handled above).
+    //
+    // Specialization: when the called suit was led and the partner has not yet
+    // been revealed, the partner is forced to play the called card on this
+    // trick, so cash A/10/K of trump via the schmear priority to capture those
+    // points along with the partner's high card.
+    if (!isTrump(currentTrick[0].card)) {
       const winner = currentWinner(currentTrick)
-      const opponentWinning = winner && winner.userId !== picker && winner.userId !== partner
-      if (!opponentWinning) {
+      const pickerTeamWinning = winner && (winner.userId === picker || winner.userId === partner)
+      if (pickerTeamWinning) {
         const trumpCards = realCards.filter(c => isTrump(c))
-        if (trumpCards.length > 0) return lowestCard(trumpCards).id
+        if (trumpCards.length > 0) {
+          const { calledSuit, partnerRevealed } = view
+          if (!partnerRevealed && ledSuit === calledSuit) {
+            const fullHand = view.hands[userId] ?? []
+            const pick = pickBySchmearPriority(trumpCards, 'trump', fullHand)
+            return (pick ?? lowestCard(trumpCards)).id
+          }
+          return highestTrump(trumpCards).id
+        }
       }
     }
     return lowestCard(realCards).id

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest'
+import { decidePlay } from './botStrategy.js'
+
+// Cards: { id, suit, rank }. Trump = all diamonds + all queens + all jacks.
+const c = (id, suit, rank) => ({ id, suit, rank })
+
+// Opponent (u2) is void in the called fail suit (H). Picker (u1) has led the
+// called suit; partner (u3) holds the called Ace and has not yet played.
+function trumpInOnCalledSuitView({ hand, partnerRevealed }) {
+  return {
+    phase: 'playing',
+    hands: { u1: [], u2: hand, u3: [], u4: [] },
+    currentTrick: [
+      { userId: 'u1', card: c('9H', 'H', '9') },
+    ],
+    tricks: [],
+    picker: 'u1',
+    partner: 'u3',
+    partnerRevealed,
+    calledSuit: 'H',
+    calledAce: { aceId: 'AH' },
+    isLeaster: false,
+    lastTrick: [],
+  }
+}
+
+describe('decidePlay — trump in on partner-revealing called-suit lead', () => {
+  it('schmears with A♦ when bot has high trump and partner is unrevealed', () => {
+    // Hand has A♦ (trump A), Q♣ (trump Q), and fail spades. Bot is void in H.
+    const hand = [
+      c('AD', 'D', 'A'), c('QC', 'C', 'Q'),
+      c('KS', 'S', 'K'), c('9S', 'S', '9'),
+      c('7C', 'C', '7'), c('8C', 'C', '8'),
+    ]
+    const view = trumpInOnCalledSuitView({ hand, partnerRevealed: false })
+    expect(decidePlay(view, 'u2')).toBe('AD')
+  })
+
+  it('plays highest trump (force-up) on called-suit lead once partner has been revealed', () => {
+    // Partner already revealed → schmear specialization does not apply.
+    // Falls into the general force-up case: highest trump = QC (Q♣ tops trumpRank).
+    const hand = [
+      c('AD', 'D', 'A'), c('QC', 'C', 'Q'),
+      c('KS', 'S', 'K'), c('9S', 'S', '9'),
+      c('7C', 'C', '7'), c('8C', 'C', '8'),
+    ]
+    const view = trumpInOnCalledSuitView({ hand, partnerRevealed: true })
+    expect(decidePlay(view, 'u2')).toBe('QC')
+  })
+
+  it('still trumps in (schmear) when only Js/Qs are available with partner unrevealed', () => {
+    // All trump (Qs and Js), no A/10/K/9/8/7 in hand. Schmear priority on Js/Qs:
+    // among Js, weakest by trump rank = JD; QC tops the trumpRank ordering.
+    const hand = [
+      c('QC', 'C', 'Q'), c('QS', 'S', 'Q'),
+      c('JC', 'C', 'J'), c('JS', 'S', 'J'),
+      c('JH', 'H', 'J'), c('JD', 'D', 'J'),
+    ]
+    const view = trumpInOnCalledSuitView({ hand, partnerRevealed: false })
+    const played = decidePlay(view, 'u2')
+    expect(['QC', 'QS', 'JC', 'JS', 'JH', 'JD']).toContain(played)
+  })
+
+  it('plays highest trump on a non-called fail lead when picker is winning (force-up)', () => {
+    // Picker leads 9♠ (spades, NOT the called suit). Bot is void in spades and
+    // holds trump. Picker is currently winning → trump in with highest trump.
+    const view = {
+      phase: 'playing',
+      hands: {
+        u1: [],
+        u2: [
+          c('AD', 'D', 'A'), c('QC', 'C', 'Q'),
+          c('7C', 'C', '7'), c('8C', 'C', '8'),
+          c('KH', 'H', 'K'), c('9H', 'H', '9'),
+        ],
+        u3: [], u4: [],
+      },
+      currentTrick: [
+        { userId: 'u1', card: c('9S', 'S', '9') },
+      ],
+      tricks: [],
+      picker: 'u1',
+      partner: 'u3',
+      partnerRevealed: false,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+    expect(decidePlay(view, 'u2')).toBe('QC')
+  })
+
+  it('does not trump in when a fellow opponent is already winning the trick', () => {
+    // Picker leads 9♥, opponent u4 trumps in with QH and is winning.
+    // Picker team is NOT winning → bot u2 should not waste trump.
+    const view = {
+      phase: 'playing',
+      hands: {
+        u1: [], u3: [], u4: [],
+        u2: [c('AD', 'D', 'A'), c('7C', 'C', '7'), c('8C', 'C', '8')],
+      },
+      currentTrick: [
+        { userId: 'u1', card: c('9H', 'H', '9') },
+        { userId: 'u4', card: c('QH', 'H', 'Q') },
+      ],
+      tricks: [],
+      picker: 'u1',
+      partner: 'u3',
+      partnerRevealed: false,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+    const played = decidePlay(view, 'u2')
+    expect(played).not.toBe('AD')
+  })
+})

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2137,9 +2137,10 @@ describe('decidePlay (botStrategy)', () => {
     }
   }
 
-  it('opponent plays trump when called suit is led and picker team is winning', () => {
-    // p1 (picker) leads 9♥ (called suit), p2 (partner) plays K♥ and is winning
-    // p3 has trump (J♦) and two fails — should trump in
+  it('opponent plays trump (highest) when called suit is led and picker team is winning', () => {
+    // p1 (picker) leads 9♥ (called suit), p2 (partner, already revealed) plays K♥
+    // and is winning. With partner already revealed the schmear specialization
+    // does not apply, so p3 plays highest trump to force-up: J♦.
     const view = makeView({
       userId: 'p3',
       hand: [c('J','D'), c('8','S'), c('7','C')],
@@ -3131,14 +3132,14 @@ describe('decidePlay — defender force-take to enable called-suit lead-back', (
     expect(decidePlay(view, 'p3')).toBe('8C')
   })
 
-  it('strategy skipped when partner is already revealed', () => {
-    // partnerRevealed=true, partner=p4. Picker p1 leads 8♠ (so picker is winning →
-    // teammateWinning is false → schmearOpp does NOT fire). New branch is skipped
-    // because partnerRevealed=true. Trump-in-on-called-suit skipped (S !== H).
-    // Falls to default lowestCard(realCards).
+  it('lead-back force-take is skipped when partner is already revealed; force-up branch trumps in', () => {
+    // partnerRevealed=true → schmearOpp does not fire (picker p1 winning), and the
+    // lead-back force-take branch is skipped (it gates on !partnerRevealed). Falls
+    // through to the general force-up branch: ledSuit S is fail, picker team is
+    // currently winning, bot is void in spades and holds trump → highest trump.
     //
-    // Bot hand [Q♣, J♦, A♥]. A♥ is called card; ledSuit S ≠ called H, so A♥ excluded
-    // from realCards. realCards = [Q♣, J♦]. Both trump. lowestCard by points: Q♣=3, J♦=2 → J♦.
+    // Bot hand [Q♣, J♦, A♥]. A♥ is called card; ledSuit S ≠ called H, so A♥ is
+    // excluded from realCards. realCards = [Q♣, J♦]. Both trump. highestTrump = Q♣.
     const view = makeForceTakeView({
       userId: 'p3',
       picker: 'p1',
@@ -3148,7 +3149,7 @@ describe('decidePlay — defender force-take to enable called-suit lead-back', (
       handCards: [c('Q','C'), c('J','D'), c('A','H')],
       playedSeq: [{ userId: 'p1', card: c('8','S') }],
     })
-    expect(decidePlay(view, 'p3')).toBe('JD')
+    expect(decidePlay(view, 'p3')).toBe('QC')
   })
 
   it('strategy skipped when bot has no winning cards', () => {


### PR DESCRIPTION
## Summary
- Generalises the opponent-following "trump in on called suit" rule. The branch now fires on **any fail-led trick** where the picker team is currently winning and the bot is void in the led suit.
- **Card choice** splits on partner-reveal state:
  - **Partner-revealing called-suit lead** (called suit led, partner not yet revealed): trump schmear priority (A/10/K). The partner is forced to play the called card on this trick, so cashing high trump captures those points along with the partner's high card.
  - **Otherwise**: highest trump (Q♣ at the top). Goal is to force the picker to overtrump with their best trump to retake the lead, or steal the trick outright if the picker has already played.
- The picker-team-winning gate naturally excludes the case where a fellow opponent has already trumped in (then the schmear-on-teammate-winning branch above handles it).
- `docs/BOTS.md` rule 3 of "Opponent bot following" rewritten to match.

## Test plan
- [x] New `shared/botStrategy.test.js`: 5 cases covering schmear-on-partner-revealing-lead, force-up after reveal, Js/Qs-only fallback, force-up on a non-called fail lead, and skip when a fellow opponent is already winning.
- [x] Updated two existing tests in `shared/gameEngine.test.js` whose old assertions baked in the previous narrower behavior — both now express the new contract (highest trump force-up).
- [x] `npx vitest run` — 253 passed, 0 failed.
- [ ] Manual smoke against bot games to confirm the behavior feels right in play.

🤖 Generated with [Claude Code](https://claude.com/claude-code)