### PR TITLE
fix(ui): force Pico dark theme to restore game log readability

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
## Summary
- Users on light-mode OSes report the game log (and other dark-themed panels) is nearly unreadable — dim text on dark green felt.
- Root cause: Pico CSS applies `color: var(--pico-color)` to `p`/`table`/`ul` via a type selector (specificity 0,0,1), which beats the `.game-log { color: #ccc }` parent rule for those children. With `prefers-color-scheme: light`, `--pico-color` resolves to `#373c44` (near-black) on top of the dark overlay.
- Fix: set `data-theme="dark"` on `<html>`, Pico's official mechanism for pinning the dark palette regardless of OS preference. Restores readable contrast across every dark-bg block (game log, action panel, score board, player seats).

## Test plan
- [ ] Open the app in a light-mode browser/OS and confirm game log entries are readable.
- [ ] Open in dark-mode — confirm no regression.
- [ ] Spot-check action panel, score board, and player seats for legibility.

I (Claude) made this change at Andy's request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)