### PR TITLE
feat(bot): extend card-counting inference to non-trump-follow decisions (#132 cases 1 & 3)

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -114,7 +114,10 @@ Play the **lowest-value card** always, to avoid winning tricks.
 
 ### Following a Trick
 
-A recurring concept below is a **guaranteed winner**: a trump card the bot holds such that every higher-rank trump has already been seen (in own hand, completed tricks, current trick, or visible bury). Any unseen higher trump is treated conservatively as still in an opponent's hand. Non-trump cards are never "guaranteed."
+A recurring concept below is a **guaranteed winner**: a card the bot holds that cannot be beaten by any opponent.
+
+- **Trump card**: every higher-rank trump must have been seen (in own hand, completed tricks, current trick, or visible bury). Any unseen higher trump is treated conservatively as still in an opponent's hand.
+- **Non-trump (fail) card**: two conditions must both hold: (1) every same-suit card of higher rank has been seen in the same sources, AND (2) no opponent can trump it — meaning either all 14 trump are accounted for, or every other player is known to be void in trump (they played fail on a trump-led trick in history).
 
 #### Picker-team bot following
 1. **Schmear** (teammate is currently winning):
@@ -197,7 +200,8 @@ of bot team.
 | `currentWinner` | Returns the play object currently winning a trick |
 | `bestVoidBury` | Finds the best 2-card bury that voids a non-trump suit with ≥11 combined card points |
 | `teammateWinning` | Returns true if the current trick leader is on the same team as the bot |
-| `isGuaranteedWinner` | For a trump card, returns true iff every higher-rank trump has been seen (own hand, played tricks, current trick, visible bury). Unseen higher trump is treated as opponent-held. Non-trump cards are never guaranteed. |
+| `deducedTrumpVoids` | Returns the set of players known to be void in trump, based on completed trick history. A player is trump-void if they played a non-trump card on a trick where trump was led. |
+| `isGuaranteedWinner` | Returns true iff a card cannot be beaten by any opponent. For trump: every higher-rank trump has been seen (own hand, played tricks, current trick, visible bury). For non-trump: every higher same-suit card has been seen AND no opponent can trump (all trump accounted for, or all others are deduced trump-void). |
 | `cheapestGuaranteedWin` | From a set of candidate cards, returns the lowest-point card that satisfies `isGuaranteedWinner` (tiebreak: weaker trump first). Returns null if none qualify. |
 | `pickBySchmearPriority` | Pick the least-painful winning card to spend, walking a rank-priority list (`A,10,K,9,8,7,J,Q` for trump; `A,10,K,9,8,7` for fail). Trump tiebreak: weakest trump rank. Fail tiebreak: shortest non-trump suit in hand, then alphabetical. |
 | `knownNonPartners` | Returns the set of userIds known not to be the partner from public information: picker, self (if non-picker-team), cracker, players who played non-called on a called-suit-led trick before the called card was played. |

--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -99,18 +99,19 @@ Play the **lowest-value card** always, to avoid winning tricks.
 ### Leading a Trick
 
 #### Picker-team bot leading
-1. **Cash a fail ace** if opponents are likely trump-exhausted (≤2 trump estimated remaining elsewhere).
+1. **Cash any guaranteed non-trump winner** (any rank, not just aces): every higher same-suit card must be accounted for AND no opponent can trump it (all trump exhausted, or every other player is known trump-void). The highest-value qualifying card is played first.
 2. **Lead highest trump** to win tricks and accumulate card points.
 3. If no trump, and the bot is the **partner**:
    - If the last trick had 3 or fewer trump played, lead a called-suit card (lowest of that suit).
    - Otherwise, lead the lowest-point fail card.
-4. If no trump and not the partner: lead the **highest-value fail card**.
+4. If no trump and not the partner: lead the **highest-value fail card**, avoiding suits where an opponent is known void (they could trump in). Specifically, check which fail suits are **safe** (no opponent is known void in that suit based on completed trick history). If any safe-suit fail cards are available, prefer the highest-value card among them. If all suits are risky, fall back to the highest-value fail card overall.
 
 #### Opponent bot leading
-1. **Cash a fail ace** if the picker team has **zero** trump remaining (all 14 trump accounted for in own hand, buried, and played tricks). The fail ace must not be the called card (in practice an opponent never holds the called card, but the code is explicit).
+1. **Cash any guaranteed non-trump winner** (excluding the called card, which cannot be led before reveal): every higher same-suit card must be accounted for AND no opponent can trump it (all trump exhausted, or every other player is known trump-void). The highest-value qualifying card is played first.
 2. **Lead called suit** (lowest card of that suit) if the partner has not yet been deduced and the bot holds at least one fail card of the called suit. This forces the partner to play their called card, revealing their identity.
-3. Otherwise, lead the **lowest non-trump card** to avoid burning trump.
-4. If no non-trump cards remain, lead the lowest card overall.
+3. **Lead into a picker-team void** if the partner identity is known (via crack/recrack/elimination): if a picker-team member (picker or partner) is known to be void in a fail suit and the bot holds non-trump, non-called-card cards in that suit, lead the **lowest-value** card among all qualifying void-suit candidates to draw trump cheaply without gifting points to the picker team.
+4. Otherwise, lead the **lowest non-trump card** to avoid burning trump.
+5. If no non-trump cards remain, lead the lowest card overall.
 
 ### Following a Trick
 
@@ -129,7 +130,7 @@ A recurring concept below is a **guaranteed winner**: a card the bot holds that 
      2. Else play the highest winning trump as risk reduction.
      3. Else fall back to a normal schmear.
 2. **Win the trick efficiently** (no teammate winning, bot can win):
-   - Prefer non-trump winners. Default is the lowest-point non-trump winner, but if the bot is safe from being trumped in (no opponents remaining, OR no trump left elsewhere), play the **highest-point** non-trump winner instead — squeeze the trick for everything it's worth.
+   - Prefer non-trump winners. Default is the lowest-point non-trump winner, but if the bot is safe (no opponents remaining, OR the best non-trump winner is itself a guaranteed winner — every higher same-suit card is accounted for and no opponent can trump in), play the **highest-point** non-trump winner instead — squeeze the trick for everything it's worth.
    - If only trump can win:
      - **Trump-led trick**: if no opponents remain to play, use the cheapest winning trump. Otherwise, if a guaranteed-winning trump is in the winning set, play the lowest-point one; else play the highest trump.
      - **Fail-led trick, bot is the picker** (void in led suit): lowest-point guaranteed-winning trump if any; else highest trump.
@@ -201,6 +202,7 @@ of bot team.
 | `bestVoidBury` | Finds the best 2-card bury that voids a non-trump suit with ≥11 combined card points |
 | `teammateWinning` | Returns true if the current trick leader is on the same team as the bot |
 | `deducedTrumpVoids` | Returns the set of players known to be void in trump, based on completed trick history. A player is trump-void if they played a non-trump card on a trick where trump was led. |
+| `deducedNonTrumpVoids` | Returns a map of `{ [userId]: Set<suit> }` — the fail suits each player is known void in, deduced from completed trick history. A player is void in a fail suit if, on a trick where that fail suit was led, they played a card of a different suit (including trump). Only scans completed tricks. |
 | `isGuaranteedWinner` | Returns true iff a card cannot be beaten by any opponent. For trump: every higher-rank trump has been seen (own hand, played tricks, current trick, visible bury). For non-trump: every higher same-suit card has been seen AND no opponent can trump (all trump accounted for, or all others are deduced trump-void). |
 | `cheapestGuaranteedWin` | From a set of candidate cards, returns the lowest-point card that satisfies `isGuaranteedWinner` (tiebreak: weaker trump first). Returns null if none qualify. |
 | `pickBySchmearPriority` | Pick the least-painful winning card to spend, walking a rank-priority list (`A,10,K,9,8,7,J,Q` for trump; `A,10,K,9,8,7` for fail). Trump tiebreak: weakest trump rank. Fail tiebreak: shortest non-trump suit in hand, then alphabetical. |

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -223,7 +223,7 @@ export function isGuaranteedWinner(card, view, userId) {
     if (!noTrumpElsewhere) {
       const voids = deducedTrumpVoids(view)
       const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)
-      const allOthersVoid = otherPlayerIds.every(id => voids.has(id))
+      const allOthersVoid = otherPlayerIds.length > 0 && otherPlayerIds.every(id => voids.has(id))
       if (!allOthersVoid) return false
     }
 

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -131,15 +131,48 @@ export function bestVoidBury(hand) {
   return bestPair
 }
 
+// ─── Void analysis (fail suits) ──────────────────────────────────────────────
+
+// Returns { [userId]: Set<suit> } — a map of player IDs to the set of fail suits
+// they are known to be void in, deduced from completed trick history.
+//
+// Logic: for each completed trick where the led card is a visible fail card (not trump),
+// any subsequent player whose played card's effectiveSuit differs from the led suit is
+// marked void in the led suit. This covers both playing off-suit fail AND trumping in
+// (both prove void in the led fail suit).
+//
+// Only view.tricks (completed tricks) are scanned — not view.currentTrick.
+export function deducedNonTrumpVoids(view) {
+  const voids = {}
+  for (const trick of (view.tricks ?? [])) {
+    const plays = trick.plays
+    if (!plays || plays.length === 0) continue
+    const led = plays[0].card
+    if (!led || led.hidden) continue          // hidden led card — skip trick
+    if (isTrump(led)) continue               // trump led — no fail-suit info
+    const ledSuit = effectiveSuit(led)        // fail suit that was led
+    for (let i = 1; i < plays.length; i++) {
+      const play = plays[i]
+      if (!play.card || play.card.hidden) continue  // can't see this card
+      if (effectiveSuit(play.card) !== ledSuit) {
+        // Did not follow the led fail suit → void in that suit
+        if (!voids[play.userId]) voids[play.userId] = new Set()
+        voids[play.userId].add(ledSuit)
+      }
+    }
+  }
+  return voids
+}
+
 // ─── Void analysis (trump) ────────────────────────────────────────────────────
 
 // Returns a Set<userId> of players known to be void in trump based on completed
 // trick history. A player is trump-void if they played a non-trump (non-hidden)
 // card on a trick where the led card was trump (non-hidden).
-// Only completed tricks (view.tricks) are checked — the current trick is excluded
-// to keep this function a pure read of settled history; the led card's effective
-// suit in an in-progress trick may still be subject to `declaredSuit`, making
-// void deduction unreliable mid-trick.
+// Scans view.tricks only (not view.currentTrick) because the current trick is
+// in-progress and not yet committed to state. Under-card leads are safe: the
+// under card has hidden: true, so tricks led by the under card are skipped by
+// the existing hidden-led-card guard and never produce false void deductions.
 export function deducedTrumpVoids(view) {
   const voids = new Set()
   for (const trick of (view.tricks ?? [])) {

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -131,17 +131,95 @@ export function bestVoidBury(hand) {
   return bestPair
 }
 
+// ─── Void analysis (trump) ────────────────────────────────────────────────────
+
+// Returns a Set<userId> of players known to be void in trump based on completed
+// trick history. A player is trump-void if they played a non-trump (non-hidden)
+// card on a trick where the led card was trump (non-hidden).
+// Only completed tricks (view.tricks) are checked — the current trick is excluded.
+export function deducedTrumpVoids(view) {
+  const voids = new Set()
+  for (const trick of (view.tricks ?? [])) {
+    const plays = trick.plays
+    if (!plays || plays.length === 0) continue
+    const led = plays[0].card
+    if (!led || led.hidden) continue           // hidden led card — skip trick
+    if (!isTrump(led)) continue               // fail led — no trump info
+    for (let i = 1; i < plays.length; i++) {
+      const play = plays[i]
+      if (!play.card || play.card.hidden) continue  // can't see this card
+      if (!isTrump(play.card)) voids.add(play.userId)
+    }
+  }
+  return voids
+}
+
 // ─── Guaranteed-winner inference ──────────────────────────────────────────────
 
-// Returns true iff every trump that outranks `card` is visible to userId:
-//   - in userId's own hand
-//   - played in completed tricks (non-hidden)
-//   - played in the current trick (non-hidden)
-//   - in the visible bury (non-hidden; picker-only)
-// Unseen higher trump is always treated as a potential opponent holding.
-// Non-trump cards are never "guaranteed" — callers combine with trumpRemainingElsewhere.
+// Returns true iff `card` cannot be beaten by any opponent:
+//
+// For trump cards: every trump with a strictly lower trumpRank index (i.e. higher
+//   strength) must be accounted for (visible in own hand, played tricks, current
+//   trick, or bury).
+//
+// For non-trump (fail) cards: BOTH conditions must hold:
+//   1. Every same-suit non-trump card with a lower suitRank index (i.e. higher
+//      strength) must be accounted for in: own hand, completed tricks (non-hidden),
+//      current trick (non-hidden), or bury (non-hidden).
+//   2. No opponent can trump it — satisfied if either:
+//      a. trumpRemainingElsewhere(view, userId) === 0 (all trump accounted for), OR
+//      b. Every other player is in the deducedTrumpVoids set.
+//
+// Unseen higher trump / higher same-suit cards are always treated as opponent-held.
 export function isGuaranteedWinner(card, view, userId) {
-  if (!isTrump(card)) return false
+  if (!isTrump(card)) {
+    // ── Condition 1: no higher same-suit card is unaccounted for ─────────────
+    const mySuitRank = suitRank(card)
+    if (mySuitRank === 0) {
+      // Ace is the highest non-trump card; no need to check for higher same-suit
+    } else {
+      // Collect seen suitRank indices for same-suit non-trump cards from all sources.
+      // SUIT_RANK_ORDER = ['A','10','K','9','8','7'] so rank 0 = Ace (strongest).
+      // We need every rank index in 0..mySuitRank-1 to appear at least once.
+      const seenSuitRanks = new Set()
+      for (const c of (view.hands[userId] ?? [])) {
+        if (!c || c.hidden || isTrump(c) || c.suit !== card.suit) continue
+        seenSuitRanks.add(suitRank(c))
+      }
+      for (const trick of (view.tricks ?? [])) {
+        for (const play of trick.plays) {
+          const c = play.card
+          if (!c || c.hidden || isTrump(c) || c.suit !== card.suit) continue
+          seenSuitRanks.add(suitRank(c))
+        }
+      }
+      for (const play of (view.currentTrick ?? [])) {
+        const c = play.card
+        if (!c || c.hidden || isTrump(c) || c.suit !== card.suit) continue
+        seenSuitRanks.add(suitRank(c))
+      }
+      for (const c of (view.buried ?? [])) {
+        if (!c || c.hidden || isTrump(c) || c.suit !== card.suit) continue
+        seenSuitRanks.add(suitRank(c))
+      }
+
+      // Every rank strictly lower than mySuitRank (= stronger fail cards) must be seen.
+      for (let r = 0; r < mySuitRank; r++) {
+        if (!seenSuitRanks.has(r)) return false
+      }
+    }
+
+    // ── Condition 2: no opponent can trump it ─────────────────────────────────
+    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) === 0
+    if (!noTrumpElsewhere) {
+      const voids = deducedTrumpVoids(view)
+      const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)
+      const allOthersVoid = otherPlayerIds.every(id => voids.has(id))
+      if (!allOthersVoid) return false
+    }
+
+    return true
+  }
   const myRank = trumpRank(card)
   if (myRank === 0) return true  // highest trump (Queen of Clubs)
 

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -136,7 +136,10 @@ export function bestVoidBury(hand) {
 // Returns a Set<userId> of players known to be void in trump based on completed
 // trick history. A player is trump-void if they played a non-trump (non-hidden)
 // card on a trick where the led card was trump (non-hidden).
-// Only completed tricks (view.tricks) are checked — the current trick is excluded.
+// Only completed tricks (view.tricks) are checked — the current trick is excluded
+// to keep this function a pure read of settled history; the led card's effective
+// suit in an in-progress trick may still be subject to `declaredSuit`, making
+// void deduction unreliable mid-trick.
 export function deducedTrumpVoids(view) {
   const voids = new Set()
   for (const trick of (view.tricks ?? [])) {
@@ -171,6 +174,12 @@ export function deducedTrumpVoids(view) {
 //      b. Every other player is in the deducedTrumpVoids set.
 //
 // Unseen higher trump / higher same-suit cards are always treated as opponent-held.
+//
+// NOTE — currentTrick is included in the "seen" sources. Callers should use this
+// function either (a) when leading (currentTrick is empty) or (b) when `card` is
+// the currently-winning card in the trick, so that including currentTrick cards in
+// the accounting does not conflate the question "can this card be beaten?" with
+// cards already played against it.
 export function isGuaranteedWinner(card, view, userId) {
   if (!isTrump(card)) {
     // ── Condition 1: no higher same-suit card is unaccounted for ─────────────

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -247,6 +247,36 @@ describe('deducedTrumpVoids', () => {
     const voids = deducedTrumpVoids(view)
     expect(voids.has('p2')).toBe(false)
   })
+
+  it('currentTrick is ignored — trump led + fail follow there does not add to void set', () => {
+    // Even if a player follows with fail on a trump-led currentTrick,
+    // deducedTrumpVoids must not add them: only completed tricks count.
+    const view = baseView({
+      tricks: [],   // no completed tricks
+      currentTrick: [
+        { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } },   // led: trump
+        { userId: 'p2', card: { id: 'AC', suit: 'C', rank: 'A' } },   // fail — but in-progress
+      ],
+    })
+    const voids = deducedTrumpVoids(view)
+    expect(voids.has('p2')).toBe(false)
+  })
+
+  it('hidden non-led play in trump-led trick → NOT added to void set', () => {
+    // p2's play is face-down; we cannot see the card, so no void deduction.
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } },         // led: trump
+          { userId: 'p2', card: { id: 'HIDDEN', hidden: true } },              // can't see this
+          { userId: 'p3', card: { id: 'AC', suit: 'C', rank: 'A' } },         // fail → void
+        ],
+      }],
+    })
+    const voids = deducedTrumpVoids(view)
+    expect(voids.has('p2')).toBe(false)   // hidden — no deduction
+    expect(voids.has('p3')).toBe(true)    // visible fail — deduced void
+  })
 })
 
 describe('isGuaranteedWinner – non-trump extension', () => {
@@ -431,5 +461,87 @@ describe('isGuaranteedWinner – non-trump extension', () => {
       buried: [],
     })
     expect(isGuaranteedWinner(jc, view, 'p1')).toBe(false)
+  })
+
+  it('buried higher same-suit card satisfies condition 1 — fail 10 with buried ace returns true', () => {
+    // 10C has suitRank 1 → requires AC (suitRank 0) to be accounted for.
+    // AC is in view.buried (picker buried it), so condition 1 is satisfied.
+    // All opponents are trump-void (played fail on a trump-led completed trick).
+    const tenOfClubs = { id: '10C', suit: 'C', rank: '10' }
+    const aceOfClubs = { id: 'AC', suit: 'C', rank: 'A' }
+    const view = baseView({
+      hands: { p1: [tenOfClubs], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } }, // led trump
+          { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } }, // fail → void
+          { userId: 'p3', card: { id: '9S', suit: 'S', rank: '9' } }, // fail → void
+          { userId: 'p4', card: { id: '8S', suit: 'S', rank: '8' } }, // fail → void
+          { userId: 'p5', card: { id: '7S', suit: 'S', rank: '7' } }, // fail → void
+        ],
+      }],
+      currentTrick: [],
+      buried: [aceOfClubs],   // AC buried — satisfies condition 1 for 10C
+    })
+    expect(isGuaranteedWinner(tenOfClubs, view, 'p1')).toBe(true)
+  })
+
+  it('fail King (suitRank 2) — false when only AC played (10C still outstanding)', () => {
+    // KC requires both AC (rank 0) and 10C (rank 1) to be accounted for.
+    // Only AC has been played → 10C is unaccounted → returns false.
+    const kingOfClubs = { id: 'KC', suit: 'C', rank: 'K' }
+    const view = baseView({
+      hands: { p1: [kingOfClubs], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [
+        {
+          // Trump led — all followers play fail → trump-void
+          plays: [
+            { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } }, // led trump
+            { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } }, // fail → void
+            { userId: 'p3', card: { id: '9H', suit: 'H', rank: '9' } }, // fail → void
+            { userId: 'p4', card: { id: '8H', suit: 'H', rank: '8' } }, // fail → void
+            { userId: 'p5', card: { id: '7H', suit: 'H', rank: '7' } }, // fail → void
+          ],
+        },
+        {
+          // AC played — only rank 0 seen; rank 1 (10C) still outstanding
+          plays: [
+            { userId: 'p2', card: { id: 'AC', suit: 'C', rank: 'A' } },
+            { userId: 'p3', card: { id: '9S', suit: 'S', rank: '9' } },
+            { userId: 'p4', card: { id: '8S', suit: 'S', rank: '8' } },
+            { userId: 'p5', card: { id: '7S', suit: 'S', rank: '7' } },
+            { userId: 'p1', card: { id: 'QD', suit: 'D', rank: 'Q' } },
+          ],
+        },
+      ],
+      currentTrick: [],
+      buried: [],
+    })
+    expect(isGuaranteedWinner(kingOfClubs, view, 'p1')).toBe(false)
+  })
+
+  it('fail King (suitRank 2) — true when both AC and 10C played and all others trump-void', () => {
+    // KC requires AC (rank 0) and 10C (rank 1) both seen; all opponents must be void in trump.
+    // Both AC and 10C were played in tricks; trump-void established via trump-led trick.
+    const kingOfClubs = { id: 'KC', suit: 'C', rank: 'K' }
+    const view = baseView({
+      hands: { p1: [kingOfClubs], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [
+        {
+          // Trump led — p2/p3/p4/p5 all play fail → all trump-void
+          plays: [
+            { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } }, // led trump
+            { userId: 'p2', card: { id: 'AC', suit: 'C', rank: 'A' } }, // fail (clubs) → void
+            { userId: 'p3', card: { id: '10C', suit: 'C', rank: '10' } }, // fail (clubs) → void
+            { userId: 'p4', card: { id: '8H', suit: 'H', rank: '8' } }, // fail → void
+            { userId: 'p5', card: { id: '7H', suit: 'H', rank: '7' } }, // fail → void
+          ],
+        },
+      ],
+      currentTrick: [],
+      buried: [],
+    })
+    // Both AC (rank 0) and 10C (rank 1) seen in tricks; all opponents are trump-void.
+    expect(isGuaranteedWinner(kingOfClubs, view, 'p1')).toBe(true)
   })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner } from './botInference.js'
+import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids } from './botInference.js'
 
 const c = (id, suit, rank) => ({ id, suit, rank })
 
@@ -560,5 +560,161 @@ describe('isGuaranteedWinner – non-trump extension', () => {
     // trumpRemainingElsewhere = 14 - ownTrump(0) - tricksTrump(0) - buriedTrump(0) = 14
     // With the vacuous-truth bug this returned true; with the fix it returns false.
     expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(false)
+  })
+})
+
+// ─── deducedNonTrumpVoids ─────────────────────────────────────────────────────
+// Fail cards: suit ∈ {C,H,S}, rank ≠ Q/J; trump = all Qs, all Js, all diamonds.
+
+describe('deducedNonTrumpVoids', () => {
+  it('empty tricks → empty object (no voids)', () => {
+    const view = baseView({ tricks: [] })
+    const result = deducedNonTrumpVoids(view)
+    expect(Object.keys(result)).toHaveLength(0)
+  })
+
+  it('fail suit led, one player played a different fail suit → that player void in led suit', () => {
+    // p1 leads AC (clubs fail). p2 plays KH (hearts fail) — not clubs → void in clubs.
+    // p3 plays 9C (follows clubs) → NOT void.
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'AC', suit: 'C', rank: 'A' } },   // led: clubs fail
+          { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } },   // off-suit fail → void in C
+          { userId: 'p3', card: { id: '9C', suit: 'C', rank: '9' } },   // followed suit → not void
+          { userId: 'p4', card: { id: '7C', suit: 'C', rank: '7' } },   // followed suit → not void
+          { userId: 'p5', card: { id: '8C', suit: 'C', rank: '8' } },   // followed suit → not void
+        ],
+      }],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2'] instanceof Set).toBe(true)
+    expect(result['p2'].has('C')).toBe(true)
+    expect(result['p3']).toBeUndefined()
+    expect(result['p4']).toBeUndefined()
+    expect(result['p5']).toBeUndefined()
+  })
+
+  it('fail suit led, player followed suit → NOT void in that suit', () => {
+    // p1 leads KH; p2 plays 7H (hearts fail) → followed suit → not void.
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'KH', suit: 'H', rank: 'K' } },   // led: hearts fail
+          { userId: 'p2', card: { id: '7H', suit: 'H', rank: '7' } },   // followed hearts → not void
+          { userId: 'p3', card: { id: '9H', suit: 'H', rank: '9' } },   // followed hearts → not void
+        ],
+      }],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2']).toBeUndefined()
+    expect(result['p3']).toBeUndefined()
+  })
+
+  it('fail suit led, player trumped in → void in led fail suit', () => {
+    // p1 leads KH (hearts fail). p2 plays 7D (diamond trump) — not hearts → void in hearts.
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'KH', suit: 'H', rank: 'K' } },   // led: hearts fail
+          { userId: 'p2', card: { id: '7D', suit: 'D', rank: '7' } },   // trump → void in H
+          { userId: 'p3', card: { id: 'QC', suit: 'C', rank: 'Q' } },   // queen trump → void in H
+        ],
+      }],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2'] instanceof Set).toBe(true)
+    expect(result['p2'].has('H')).toBe(true)
+    expect(result['p3'] instanceof Set).toBe(true)
+    expect(result['p3'].has('H')).toBe(true)
+  })
+
+  it('trump led → no void deduction for any player', () => {
+    // 7D (diamond = trump) is led. p2 plays AC (fail) — but trump led means we learn
+    // nothing about fail-suit voids. deducedNonTrumpVoids skips the trick.
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } },   // led: trump
+          { userId: 'p2', card: { id: 'AC', suit: 'C', rank: 'A' } },   // fail
+          { userId: 'p3', card: { id: 'KH', suit: 'H', rank: 'K' } },   // fail
+        ],
+      }],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2']).toBeUndefined()
+    expect(result['p3']).toBeUndefined()
+  })
+
+  it('hidden led card → skip that trick', () => {
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'HIDDEN', hidden: true } },        // led: hidden
+          { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } },   // could be anything
+        ],
+      }],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2']).toBeUndefined()
+  })
+
+  it('multiple tricks accumulate voids across suits', () => {
+    // Trick 1: AC (clubs fail) led; p2 plays KH → void in C.
+    // Trick 2: KH (hearts fail) led; p3 plays 7D (trump) → void in H.
+    const view = baseView({
+      tricks: [
+        {
+          plays: [
+            { userId: 'p1', card: { id: 'AC', suit: 'C', rank: 'A' } },
+            { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } },  // void in C
+            { userId: 'p3', card: { id: '9C', suit: 'C', rank: '9' } },  // follows
+          ],
+        },
+        {
+          plays: [
+            { userId: 'p1', card: { id: 'KH', suit: 'H', rank: 'K' } },
+            { userId: 'p3', card: { id: '7D', suit: 'D', rank: '7' } },  // trump → void in H
+            { userId: 'p2', card: { id: '9H', suit: 'H', rank: '9' } },  // follows hearts
+          ],
+        },
+      ],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2'] instanceof Set).toBe(true)
+    expect(result['p2'].has('C')).toBe(true)
+    expect(result['p2'].has('H')).toBe(false)   // p2 followed hearts in trick 2
+    expect(result['p3'] instanceof Set).toBe(true)
+    expect(result['p3'].has('H')).toBe(true)
+    expect(result['p3'].has('C')).toBe(false)   // p3 followed clubs in trick 1
+  })
+
+  it('currentTrick is ignored — only completed tricks are scanned', () => {
+    // Clubs fail led in currentTrick; p2 plays hearts. Should NOT be deduced void.
+    const view = baseView({
+      tricks: [],
+      currentTrick: [
+        { userId: 'p1', card: { id: 'AC', suit: 'C', rank: 'A' } },
+        { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } },  // would imply void
+      ],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2']).toBeUndefined()
+  })
+
+  it('hidden non-led play in fail-led trick → skip that play, no void deduction', () => {
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'AC', suit: 'C', rank: 'A' } },       // led: clubs
+          { userId: 'p2', card: { id: 'HIDDEN', hidden: true } },            // hidden → skip
+          { userId: 'p3', card: { id: 'KH', suit: 'H', rank: 'K' } },       // visible off-suit → void in C
+        ],
+      }],
+    })
+    const result = deducedNonTrumpVoids(view)
+    expect(result['p2']).toBeUndefined()   // hidden → no deduction
+    expect(result['p3'] instanceof Set).toBe(true)
+    expect(result['p3'].has('C')).toBe(true)
   })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { knownNonPartners, deducedPartner } from './botInference.js'
+import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner } from './botInference.js'
 
 const c = (id, suit, rank) => ({ id, suit, rank })
 
@@ -165,5 +165,271 @@ describe('deducedPartner', () => {
   it('leaster: returns null', () => {
     const view = baseView({ isLeaster: true, picker: null, callMode: null })
     expect(deducedPartner(view, 'p3')).toBeNull()
+  })
+})
+
+// ─── Trump card helpers ───────────────────────────────────────────────────────
+// QC is the highest trump (trumpRank 0). Fail cards: suit ∈ {C,H,S}, rank ≠ Q/J
+// Diamond pip cards (suit D, rank not Q/J) are trump.
+// For these tests: trump = QC, QH, JS, 7D (diamond pip = trump)
+// Fail = AC (suit C, rank A), KH (suit H, rank K), 10S (suit S, rank 10)
+
+const trump = (id) => ({ id, suit: 'D', rank: '7' })       // generic trump (7D)
+const trumpQ = (id) => ({ id, suit: 'C', rank: 'Q' })      // Queen = trump
+const failAce = (suit) => ({ id: `A${suit}`, suit, rank: 'A' })
+const fail10 = (suit) => ({ id: `10${suit}`, suit, rank: '10' })
+const failKing = (suit) => ({ id: `K${suit}`, suit, rank: 'K' })
+const fail9 = (suit) => ({ id: `9${suit}`, suit, rank: '9' })
+
+describe('deducedTrumpVoids', () => {
+  it('empty tricks → empty set', () => {
+    const view = baseView({ tricks: [] })
+    expect(deducedTrumpVoids(view)).toEqual(new Set())
+  })
+
+  it('trump led, one player played fail → that player in set', () => {
+    // Trump (7D) led; p2 follows with trump (fine); p3 follows with fail (void)
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } },   // led: trump
+          { userId: 'p2', card: { id: 'QD', suit: 'D', rank: 'Q' } },   // trump: fine
+          { userId: 'p3', card: { id: 'AC', suit: 'C', rank: 'A' } },   // fail: void!
+          { userId: 'p4', card: { id: 'KH', suit: 'H', rank: 'K' } },   // fail: void!
+          { userId: 'p5', card: { id: '9S', suit: 'S', rank: '9' } },   // fail: void!
+        ],
+      }],
+    })
+    const voids = deducedTrumpVoids(view)
+    expect(voids.has('p3')).toBe(true)
+    expect(voids.has('p4')).toBe(true)
+    expect(voids.has('p5')).toBe(true)
+    expect(voids.has('p1')).toBe(false)
+    expect(voids.has('p2')).toBe(false)
+  })
+
+  it('trump led, player played trump (followed suit) → NOT in set', () => {
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } },   // led: trump
+          { userId: 'p2', card: { id: 'QC', suit: 'C', rank: 'Q' } },   // trump: fine
+        ],
+      }],
+    })
+    const voids = deducedTrumpVoids(view)
+    expect(voids.has('p2')).toBe(false)
+  })
+
+  it('fail led, player played off-suit → NOT in set (only trump-led tricks count)', () => {
+    // Fail (AC) led; p2 plays a different fail suit — that tells us nothing about trump
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'AC', suit: 'C', rank: 'A' } },   // led: fail
+          { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } },   // off-suit fail
+        ],
+      }],
+    })
+    const voids = deducedTrumpVoids(view)
+    expect(voids.has('p2')).toBe(false)
+  })
+
+  it('hidden led card → skip that trick', () => {
+    const view = baseView({
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'HIDDEN', hidden: true } },        // led: hidden
+          { userId: 'p2', card: { id: 'AC', suit: 'C', rank: 'A' } },   // fail, but led card unknown
+        ],
+      }],
+    })
+    const voids = deducedTrumpVoids(view)
+    expect(voids.has('p2')).toBe(false)
+  })
+})
+
+describe('isGuaranteedWinner – non-trump extension', () => {
+  // Helper: build a view where `trumpRemainingElsewhere(view, userId)` is exactly 0.
+  // Formula: 14 − ownTrump − countTrumpPlayed − buriedTrump = 0
+  // Put 6 trump in own hand, 6 trump in one completed trick, 2 in buried → 14 total.
+  function allTrumpAccountedView(userId, extraOverrides = {}) {
+    const ownTrumpCards = [
+      { id: 'QC', suit: 'C', rank: 'Q' },
+      { id: 'QH', suit: 'H', rank: 'Q' },
+      { id: 'QS', suit: 'S', rank: 'Q' },
+      { id: 'QD', suit: 'D', rank: 'Q' },
+      { id: 'JC', suit: 'C', rank: 'J' },
+      { id: 'JH', suit: 'H', rank: 'J' },
+    ]
+    const tricksCards = [
+      { id: 'JS', suit: 'S', rank: 'J' },
+      { id: 'JD', suit: 'D', rank: 'J' },
+      { id: 'AD', suit: 'D', rank: 'A' },
+      { id: '10D', suit: 'D', rank: '10' },
+      { id: 'KD', suit: 'D', rank: 'K' },
+      { id: '9D', suit: 'D', rank: '9' },
+    ]
+    const buriedCards = [
+      { id: '8D', suit: 'D', rank: '8' },
+      { id: '7D', suit: 'D', rank: '7' },
+    ]
+    const hands = { p1: [], p2: [], p3: [], p4: [], p5: [] }
+    hands[userId] = ownTrumpCards
+    return {
+      phase: 'playing',
+      picker: 'p1',
+      partner: null,
+      partnerRevealed: false,
+      callMode: 'ace',
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,
+      isLeaster: false,
+      hands,
+      tricks: [{
+        plays: tricksCards.map((card, i) => ({ userId: `p${(i % 5) + 1}`, card })),
+      }],
+      currentTrick: [],
+      buried: buriedCards,
+      ...extraOverrides,
+    }
+  }
+
+  it('fail ace, all other players trump-void → returns true', () => {
+    // AC (suit C, rank A) = highest fail card in clubs
+    // No other clubs exist as non-trump in the game
+    // Make all others trump-void via completed trick history
+    const aceOfClubs = { id: 'AC', suit: 'C', rank: 'A' }
+    // Trump led in trick, p2/p3/p4/p5 all played fail
+    const view = baseView({
+      hands: { p1: [aceOfClubs], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } },   // led trump
+          { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } },   // fail → void
+          { userId: 'p3', card: { id: '9S', suit: 'S', rank: '9' } },   // fail → void
+          { userId: 'p4', card: { id: '8S', suit: 'S', rank: '8' } },   // fail → void
+          { userId: 'p5', card: { id: '7S', suit: 'S', rank: '7' } },   // fail → void
+        ],
+      }],
+      currentTrick: [],
+      buried: [],
+    })
+    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(true)
+  })
+
+  it('fail ace, trump still unaccounted for and not all void → returns false', () => {
+    const aceOfClubs = { id: 'AC', suit: 'C', rank: 'A' }
+    // No tricks played, no trump exhausted, nobody is void
+    const view = baseView({
+      hands: { p1: [aceOfClubs], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+    })
+    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(false)
+  })
+
+  it('fail ace, trumpRemainingElsewhere === 0 (all trump played) → returns true even without void deduction', () => {
+    const aceOfClubs = { id: 'AC', suit: 'C', rank: 'A' }
+    // Build a view where all 14 trump are accounted for; add AC to p1's hand
+    const view = allTrumpAccountedView('p1', {
+      hands: {
+        p1: [
+          aceOfClubs,
+          { id: 'QC', suit: 'C', rank: 'Q' },
+          { id: 'QH', suit: 'H', rank: 'Q' },
+          { id: 'QS', suit: 'S', rank: 'Q' },
+          { id: 'QD', suit: 'D', rank: 'Q' },
+          { id: 'JC', suit: 'C', rank: 'J' },
+          { id: 'JH', suit: 'H', rank: 'J' },
+        ],
+        p2: [], p3: [], p4: [], p5: [],
+      },
+    })
+    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(true)
+  })
+
+  it('fail 10 where ace has been played, all others trump-void → returns true', () => {
+    const tenOfClubs = { id: '10C', suit: 'C', rank: '10' }
+    // AC (higher-rank same suit) has been played in a completed trick
+    // All other players are trump-void (played fail on trump-led trick)
+    const view = baseView({
+      hands: { p1: [tenOfClubs], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [
+        {
+          // Trump led, others played fail → all void
+          plays: [
+            { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } }, // led trump
+            { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } }, // fail → void
+            { userId: 'p3', card: { id: '9H', suit: 'H', rank: '9' } }, // fail → void
+            { userId: 'p4', card: { id: '8H', suit: 'H', rank: '8' } }, // fail → void
+            { userId: 'p5', card: { id: '7H', suit: 'H', rank: '7' } }, // fail → void
+          ],
+        },
+        {
+          // AC was played in a completed trick (now accounted for)
+          plays: [
+            { userId: 'p2', card: { id: 'AC', suit: 'C', rank: 'A' } },
+            { userId: 'p3', card: { id: '9S', suit: 'S', rank: '9' } },
+            { userId: 'p4', card: { id: '8S', suit: 'S', rank: '8' } },
+            { userId: 'p5', card: { id: '7S', suit: 'S', rank: '7' } },
+            { userId: 'p1', card: { id: 'KS', suit: 'S', rank: 'K' } },
+          ],
+        },
+      ],
+      currentTrick: [],
+      buried: [],
+    })
+    expect(isGuaranteedWinner(tenOfClubs, view, 'p1')).toBe(true)
+  })
+
+  it('fail 10 where ace NOT yet played → returns false (higher card outstanding)', () => {
+    const tenOfClubs = { id: '10C', suit: 'C', rank: '10' }
+    // AC exists in game but hasn't been played; make all others trump-void so that
+    // only condition 1 (no higher same-suit unseen) is failing
+    const view = baseView({
+      hands: { p1: [tenOfClubs], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: '7D', suit: 'D', rank: '7' } }, // led trump
+          { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } }, // fail → void
+          { userId: 'p3', card: { id: '9H', suit: 'H', rank: '9' } }, // fail → void
+          { userId: 'p4', card: { id: '8H', suit: 'H', rank: '8' } }, // fail → void
+          { userId: 'p5', card: { id: '7H', suit: 'H', rank: '7' } }, // fail → void
+        ],
+      }],
+      currentTrick: [],
+      buried: [],
+    })
+    // AC has not been seen → condition 1 fails → not a guaranteed winner
+    expect(isGuaranteedWinner(tenOfClubs, view, 'p1')).toBe(false)
+  })
+
+  it('trump card (existing behavior unchanged) — QC (rank 0) is always a guaranteed winner', () => {
+    const qc = { id: 'QC', suit: 'C', rank: 'Q' }
+    const view = baseView({
+      hands: { p1: [qc], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+    })
+    expect(isGuaranteedWinner(qc, view, 'p1')).toBe(true)
+  })
+
+  it('trump card (existing behavior unchanged) — lower trump returns false when higher trump unseen', () => {
+    // JC is a trump card but higher trumps (QC etc.) are not yet seen
+    const jc = { id: 'JC', suit: 'C', rank: 'J' }
+    const view = baseView({
+      hands: { p1: [jc], p2: [], p3: [], p4: [], p5: [] },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+    })
+    expect(isGuaranteedWinner(jc, view, 'p1')).toBe(false)
   })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -544,4 +544,21 @@ describe('isGuaranteedWinner – non-trump extension', () => {
     // Both AC (rank 0) and 10C (rank 1) seen in tricks; all opponents are trump-void.
     expect(isGuaranteedWinner(kingOfClubs, view, 'p1')).toBe(true)
   })
+
+  it('degenerate view with no other players in hands → returns false even when trumpRemainingElsewhere > 0', () => {
+    // Regression guard: when view.hands only contains the bot's entry (e.g. some test helpers
+    // only populate the bot's hand), otherPlayerIds is [] and [].every(...) is vacuously true.
+    // isGuaranteedWinner must NOT claim the card is unbeatable in that case.
+    const aceOfClubs = { id: 'AC', suit: 'C', rank: 'A' }
+    const view = baseView({
+      // Only the bot's own hand — no other player entries
+      hands: { p1: [aceOfClubs] },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+    })
+    // trumpRemainingElsewhere = 14 - ownTrump(0) - tricksTrump(0) - buriedTrump(0) = 14
+    // With the vacuous-truth bug this returned true; with the fix it returns false.
+    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(false)
+  })
 })

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner, deducedNonTrumpVoids } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -320,8 +320,21 @@ export function decidePlay(view, userId) {
         return fails.length > 0 ? lowestCard(fails).id : lowestCard(realCards).id
       }
 
-      // No trump; lead highest-value fail card
-      return highestValueCard(realCards).id
+      // No trump; lead highest-value fail card — but avoid suits where an opponent
+      // is known void (Wire 1: they could trump in). Prefer a safe suit if available.
+      // Wire 1 applies to the picker (not the partner, who follows a different lead-back strategy).
+      {
+        const allIds = Object.keys(view.hands)
+        const opponentIds = allIds.filter(id => id !== picker && id !== partner)
+        const nonTrumpVoids = deducedNonTrumpVoids(view)
+        const failCards = realCards.filter(c => !isTrump(c))
+        const safeFails = failCards.filter(card => {
+          const suit = effectiveSuit(card)
+          return !opponentIds.some(id => nonTrumpVoids[id]?.has(suit))
+        })
+        if (safeFails.length > 0) return highestValueCard(safeFails).id
+        return highestValueCard(realCards).id
+      }
     } else {
       // Cash any guaranteed non-trump winner (excluding the called card which can't be led before reveal)
       {
@@ -339,6 +352,26 @@ export function decidePlay(view, userId) {
       if (deducedPartner(view, userId) === null && calledSuit) {
         const calledSuitCards = nonTrump.filter(c => effectiveSuit(c) === calledSuit)
         if (calledSuitCards.length > 0) return lowestCard(calledSuitCards).id
+      }
+      // Wire 2: when the partner identity is known, lead into a picker-team member's
+      // known fail-suit void to force them to trump or waste a card.
+      // Only fires when deducedPartner !== null (otherwise the called-suit flush above handles it).
+      {
+        const { calledAce: ca, calledTen: ct, calledKing: ck } = view
+        const calledCardId = ca?.aceId ?? ct?.tenId ?? ck?.kingId
+        const knownPartner = deducedPartner(view, userId)
+        if (knownPartner !== null) {
+          const nonTrumpVoids = deducedNonTrumpVoids(view)
+          const pickerTeamIds = [picker, knownPartner].filter(Boolean)
+          // Candidate fail cards: non-trump, not the called card
+          const failLeads = nonTrump.filter(c => c.id !== calledCardId)
+          // Find cards in suits where at least one picker-team member is void
+          const voidSuitCards = failLeads.filter(card => {
+            const suit = effectiveSuit(card)
+            return pickerTeamIds.some(id => nonTrumpVoids[id]?.has(suit))
+          })
+          if (voidSuitCards.length > 0) return lowestCard(voidSuitCards).id
+        }
       }
       // Otherwise: lead lowest non-trump to avoid burning trump
       if (nonTrump.length > 0) return lowestCard(nonTrump).id
@@ -411,6 +444,9 @@ export function decidePlay(view, userId) {
           !playedIdsNT.has(id) && id !== userId && id !== picker && id !== partner
         ).length
         const bestNonTrumpWin = highestValueCard(nonTrumpWins)
+        // Checking only the best non-trump winner is sufficient: in a fail-led trick
+        // all nonTrumpWins are the same suit, so if the highest-value card isn't
+        // guaranteed (a higher same-suit rank is unaccounted for), none of them are.
         const safeFromTrumpIn = opponentsRemainingNT === 0 ||
           isGuaranteedWinner(bestNonTrumpWin, view, userId)
         if (safeFromTrumpIn) {

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, trumpRemainingElsewhere, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -298,12 +298,11 @@ export function decidePlay(view, userId) {
 
   if (isLeading) {
     if (isPickerTeam) {
-      // Cash a fail Ace when opponents are likely trump-exhausted
-      if (trumpRemainingElsewhere(view, userId) <= 2) {
-        const failAces = realCards.filter(c => !isTrump(c) && c.rank === 'A')
-                                   .sort((a, b) => cardPoints(b) - cardPoints(a))
-        if (failAces.length > 0) return failAces[0].id
-      }
+      // Cash any guaranteed non-trump winner: play highest-value first
+      const guaranteedFails = realCards
+        .filter(c => !isTrump(c) && isGuaranteedWinner(c, view, userId))
+        .sort((a, b) => cardPoints(b) - cardPoints(a))
+      if (guaranteedFails.length > 0) return guaranteedFails[0].id
       // Lead strongest trump to win tricks and accumulate points
       const best = highestTrump(realCards)
       if (best) return best.id
@@ -324,14 +323,14 @@ export function decidePlay(view, userId) {
       // No trump; lead highest-value fail card
       return highestValueCard(realCards).id
     } else {
-      // Cash a fail Ace only when picker team is completely out of trump
-      if (trumpRemainingElsewhere(view, userId) === 0) {
+      // Cash any guaranteed non-trump winner (excluding the called card which can't be led before reveal)
+      {
         const { calledAce, calledTen, calledKing } = view
         const calledCardId = calledAce?.aceId ?? calledTen?.tenId ?? calledKing?.kingId
-        const failAces = realCards
-          .filter(c => !isTrump(c) && c.rank === 'A' && c.id !== calledCardId)
+        const guaranteedFails = realCards
+          .filter(c => !isTrump(c) && c.id !== calledCardId && isGuaranteedWinner(c, view, userId))
           .sort((a, b) => cardPoints(b) - cardPoints(a))
-        if (failAces.length > 0) return failAces[0].id
+        if (guaranteedFails.length > 0) return guaranteedFails[0].id
       }
       // Lead called suit to flush out the partner whose identity is not yet deduced —
       // skipped if partner identity is already known from public information (crack/recrack/elimination).
@@ -411,10 +410,11 @@ export function decidePlay(view, userId) {
         const opponentsRemainingNT = allIdsNT.filter(id =>
           !playedIdsNT.has(id) && id !== userId && id !== picker && id !== partner
         ).length
+        const bestNonTrumpWin = highestValueCard(nonTrumpWins)
         const safeFromTrumpIn = opponentsRemainingNT === 0 ||
-          trumpRemainingElsewhere(view, userId) === 0
+          isGuaranteedWinner(bestNonTrumpWin, view, userId)
         if (safeFromTrumpIn) {
-          return highestValueCard(nonTrumpWins).id
+          return bestNonTrumpWin.id
         }
         return lowestCard(nonTrumpWins).id
       }

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -549,3 +549,408 @@ describe('decidePlay — regression: no behavior change when no deduction signal
     expect(decidePlay(view, 'u4')).toBe('7H')
   })
 })
+
+// ─── Call Site 1: picker-team leading ─────────────────────────────────────────
+// The new code uses isGuaranteedWinner instead of trumpRemainingElsewhere <= 2.
+// This means the bot can now cash guaranteed non-trump winners beyond just aces
+// (e.g. a 10 when its ace has been played and all trump are accounted for).
+
+describe('decidePlay — picker-team leading: guaranteed fail cards (call site 1)', () => {
+  // Build a view where the picker team bot is leading.
+  // bot = u1 (picker). partner = u3.
+  // 14 trump = QC,QS,QH,QD,JC,JS,JH,JD,AD,10D,KD,9D,8D,7D
+  // We place 12 trump in a completed trick (others play them); bot holds 2 (7D, 8D).
+  // trumpRemainingElsewhere = 14 - 2 (bot) - 12 (tricks) = 0.
+  function pickerLeadingAllTrumpSeenView(hand) {
+    return {
+      phase: 'playing',
+      hands: {
+        u1: hand,
+        u2: [], u3: [], u4: [], u5: [],
+      },
+      currentTrick: [],
+      tricks: [
+        {
+          plays: [
+            { userId: 'u2', card: c('QC', 'C', 'Q') },
+            { userId: 'u3', card: c('QS', 'S', 'Q') },
+            { userId: 'u4', card: c('QH', 'H', 'Q') },
+            { userId: 'u5', card: c('QD', 'D', 'Q') },
+            { userId: 'u1', card: c('JC', 'C', 'J') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u2', card: c('JS', 'S', 'J') },
+            { userId: 'u3', card: c('JH', 'H', 'J') },
+            { userId: 'u4', card: c('JD', 'D', 'J') },
+            { userId: 'u5', card: c('AD', 'D', 'A') },
+            { userId: 'u1', card: c('10D', 'D', '10') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u2', card: c('KD', 'D', 'K') },
+            { userId: 'u3', card: c('9D', 'D', '9') },
+          ],
+        },
+      ],
+      // Also place AC (ace of clubs) in a completed trick so 10C is guaranteed top of suit
+      // (No — we need AC played too; let's add it to tricks[2])
+      picker: 'u1',
+      partner: 'u3',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+  }
+
+  it('cashes a fail 10 (not just ace) when its ace has been played and all trump are accounted for', () => {
+    // Bot holds 10C (fail 10 clubs, 10 pts) + 7D + 8D (low trump).
+    // AC was played in a completed trick → 10C is top of clubs.
+    // All 14 trump accounted for (12 in tricks above + 7D + 8D in bot's hand).
+    // isGuaranteedWinner(10C) should be true → bot cashes it.
+    const hand = [
+      c('10C', 'C', '10'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = pickerLeadingAllTrumpSeenView(hand)
+    // Add AC played in an earlier trick so 10C is top of clubs
+    view.tricks[2].plays.push({ userId: 'u4', card: c('AC', 'C', 'A') })
+    expect(decidePlay(view, 'u1')).toBe('10C')
+  })
+
+  it('does NOT cash a fail 10 when trump remains elsewhere (falls back to highest trump)', () => {
+    // Bot holds 10C + 7D + 8D. AC has been played so 10C is top of clubs.
+    // But only 10 trump are in tricks (not all 14 accounted for) → not guaranteed.
+    // Trump remains = 14 - 2 (bot) - 10 (tricks) = 2 → NOT zero → not guaranteed.
+    // Falls back to highestTrump(realCards) = 8D.
+    const hand = [
+      c('10C', 'C', '10'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = {
+      phase: 'playing',
+      hands: { u1: hand, u2: [], u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks: [
+        {
+          plays: [
+            { userId: 'u2', card: c('QC', 'C', 'Q') },
+            { userId: 'u3', card: c('QS', 'S', 'Q') },
+            { userId: 'u4', card: c('QH', 'H', 'Q') },
+            { userId: 'u5', card: c('QD', 'D', 'Q') },
+            { userId: 'u1', card: c('JC', 'C', 'J') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u2', card: c('JS', 'S', 'J') },
+            { userId: 'u3', card: c('JH', 'H', 'J') },
+            { userId: 'u4', card: c('JD', 'D', 'J') },
+            // Only 9 trump in tricks + 2 in bot = 11, leaving 3 elsewhere
+            { userId: 'u5', card: c('AC', 'C', 'A') }, // AC played but trump not yet exhausted
+          ],
+        },
+      ],
+      picker: 'u1',
+      partner: 'u3',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+    // trumpRemainingElsewhere = 14 - 2(bot) - 9(tricks) = 3 → not zero
+    // deducedTrumpVoids won't help because u2..u5 played trump in the trump-led trick
+    // → not void. So isGuaranteedWinner(10C) = false.
+    // Next branch: highestTrump(realCards) = 8D.
+    expect(decidePlay(view, 'u1')).toBe('8D')
+  })
+
+  it('cashes a fail ace when trumpRemainingElsewhere is 0', () => {
+    // Classic case: bot holds AC (ace of clubs, 11 pts) + 2 low trump.
+    // All 12 other trump are in completed tricks → all accounted for.
+    // isGuaranteedWinner(AC) = true (suitRank 0, all trump seen).
+    const hand = [
+      c('AC', 'C', 'A'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = pickerLeadingAllTrumpSeenView(hand)
+    expect(decidePlay(view, 'u1')).toBe('AC')
+  })
+})
+
+// ─── Call Site 2: opponent-team leading ───────────────────────────────────────
+// The new code uses isGuaranteedWinner instead of trumpRemainingElsewhere === 0.
+// Bot can now cash guaranteed non-trump winners including fail 10s (not just aces).
+
+describe('decidePlay — opponent-team leading: guaranteed fail cards (call site 2)', () => {
+  // Bot = u2 (opponent). Picker = u1. Partner = u3 (but unknown to u2; partner: null).
+  // All 14 trump accounted for (12 in tricks + 2 in bot's hand via 7D, 8D).
+  function oppLeadingAllTrumpSeenView(hand) {
+    return {
+      phase: 'playing',
+      hands: {
+        u1: [], u2: hand, u3: [], u4: [], u5: [],
+      },
+      currentTrick: [],
+      tricks: [
+        {
+          plays: [
+            { userId: 'u1', card: c('QC', 'C', 'Q') },
+            { userId: 'u3', card: c('QS', 'S', 'Q') },
+            { userId: 'u4', card: c('QH', 'H', 'Q') },
+            { userId: 'u5', card: c('QD', 'D', 'Q') },
+            { userId: 'u2', card: c('JC', 'C', 'J') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u1', card: c('JS', 'S', 'J') },
+            { userId: 'u3', card: c('JH', 'H', 'J') },
+            { userId: 'u4', card: c('JD', 'D', 'J') },
+            { userId: 'u5', card: c('AD', 'D', 'A') },
+            { userId: 'u2', card: c('10D', 'D', '10') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u1', card: c('KD', 'D', 'K') },
+            { userId: 'u3', card: c('9D', 'D', '9') },
+          ],
+        },
+      ],
+      picker: 'u1',
+      partner: null,   // masked from opponent view
+      partnerRevealed: false,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,
+      isLeaster: false,
+      lastTrick: [],
+    }
+  }
+
+  it('cashes a fail 10 when its ace has been played and all trump are accounted for', () => {
+    // Bot holds 10C + 7D + 8D. AC played in a completed trick → 10C is guaranteed.
+    // All 14 trump seen. Opponent leads → bot should cash 10C.
+    const hand = [
+      c('10C', 'C', '10'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = oppLeadingAllTrumpSeenView(hand)
+    view.tricks[2].plays.push({ userId: 'u4', card: c('AC', 'C', 'A') })
+    expect(decidePlay(view, 'u2')).toBe('10C')
+  })
+
+  it('does NOT cash the called card even when it appears guaranteed (called card excluded from leading)', () => {
+    // Defensive test: artificially place the called card (AH) in the bot's hand.
+    // Even if AH were a guaranteed winner, the call-site filter excludes the called card.
+    // This guards the `c.id !== calledCardId` filter in the new code.
+    // Note: this is an artificial scenario — in a real game the called card is held
+    // by the partner, not an opponent.
+    const hand = [
+      c('AH', 'H', 'A'),  // the called card itself — must NOT be cashed
+      c('10C', 'C', '10'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = oppLeadingAllTrumpSeenView(hand)
+    // Put AC in tricks so 10C is also guaranteed, giving the bot a valid alternative
+    view.tricks[2].plays.push({ userId: 'u4', card: c('AC', 'C', 'A') })
+    // AH is in bot's hand so it cannot be played (calledCard restriction when !partnerRevealed)
+    // Expect 10C (the other guaranteed card), NOT AH
+    const played = decidePlay(view, 'u2')
+    expect(played).not.toBe('AH')
+    expect(played).toBe('10C')
+  })
+
+  it('does NOT cash a guaranteed fail card when trump remains elsewhere', () => {
+    // Bot holds AC + 7D + 8D. Only 9 trump in tricks → trumpRemainingElsewhere = 3.
+    // Opponents not all trump-void (they played trump in trick 0).
+    // isGuaranteedWinner(AC) = false → skip guaranteed-cash branch.
+    // Falls through: deducedPartner is null (no signals) → lead called-suit-to-flush.
+    // Bot holds no hearts → no called-suit cards → falls to lowest non-trump = AC (11pts)
+    // since no other fail card. Actually: last branch is lowestCard(nonTrump).
+    const hand = [
+      c('AC', 'C', 'A'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = {
+      phase: 'playing',
+      hands: { u1: [], u2: hand, u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks: [
+        {
+          plays: [
+            { userId: 'u1', card: c('QC', 'C', 'Q') },
+            { userId: 'u3', card: c('QS', 'S', 'Q') },
+            { userId: 'u4', card: c('QH', 'H', 'Q') },
+            { userId: 'u5', card: c('QD', 'D', 'Q') },
+            { userId: 'u2', card: c('JC', 'C', 'J') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u1', card: c('JS', 'S', 'J') },
+            { userId: 'u3', card: c('JH', 'H', 'J') },
+            { userId: 'u4', card: c('JD', 'D', 'J') },
+            // Only 9 trump in tricks + 2 in bot = 11, leaving 3 elsewhere
+          ],
+        },
+      ],
+      picker: 'u1',
+      partner: null,
+      partnerRevealed: false,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,
+      isLeaster: false,
+      lastTrick: [],
+    }
+    // trumpRemainingElsewhere = 14 - 2 - 9 = 3 → not zero → isGuaranteedWinner = false
+    // Falls through to called-suit flush logic (no hearts in hand → no calledSuitCards)
+    // → lowestCard(nonTrump) = AC (only non-trump card)
+    expect(decidePlay(view, 'u2')).toBe('AC')
+  })
+})
+
+// ─── Call Site 3: picker-team following ────────────────────────────────────────
+// New code: use isGuaranteedWinner(bestNonTrumpWin) instead of
+// trumpRemainingElsewhere === 0 to decide whether to play high or low.
+
+describe('decidePlay — picker-team following: guaranteed non-trump win (call site 3)', () => {
+  // Picker = u1. Partner = u3. Bot = u1 (picker, following a fail-led trick).
+  // Trick led by u2 (opponent) with a low club. Bot holds 10C (wins the trick)
+  // and KS (also wins because it's higher than what's been played).
+
+  it('plays highest-value non-trump winner when that card is a guaranteed winner', () => {
+    // Trick: u2 led 9C, u4 played 7C. Bot u1 must follow clubs.
+    // Bot holds 10C (10pts) and 8C (0pts) — both beat everything in the trick.
+    // AC has been played, so 10C is the guaranteed top club.
+    // All trump accounted for (12 in tricks + 2 in bot hand = 14).
+    // → bestNonTrumpWin = 10C, isGuaranteedWinner(10C) = true → return 10C.
+    const botHand = [
+      c('10C', 'C', '10'),
+      c('8C', 'C', '8'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = {
+      phase: 'playing',
+      hands: {
+        u1: botHand, u2: [], u3: [], u4: [], u5: [],
+      },
+      currentTrick: [
+        { userId: 'u2', card: c('9C', 'C', '9') },
+        { userId: 'u4', card: c('7C', 'C', '7') },
+      ],
+      tricks: [
+        {
+          plays: [
+            { userId: 'u2', card: c('QC', 'C', 'Q') },
+            { userId: 'u3', card: c('QS', 'S', 'Q') },
+            { userId: 'u4', card: c('QH', 'H', 'Q') },
+            { userId: 'u5', card: c('QD', 'D', 'Q') },
+            { userId: 'u1', card: c('JC', 'C', 'J') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u2', card: c('JS', 'S', 'J') },
+            { userId: 'u3', card: c('JH', 'H', 'J') },
+            { userId: 'u4', card: c('JD', 'D', 'J') },
+            { userId: 'u5', card: c('AD', 'D', 'A') },
+            { userId: 'u1', card: c('10D', 'D', '10') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u2', card: c('KD', 'D', 'K') },
+            { userId: 'u3', card: c('9D', 'D', '9') },
+            { userId: 'u4', card: c('AC', 'C', 'A') }, // AC played → 10C is top of clubs
+          ],
+        },
+      ],
+      picker: 'u1',
+      partner: 'u3',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+    // trumpRemainingElsewhere = 14 - 2(bot) - 12(tricks) = 0
+    // isGuaranteedWinner(10C) = true → safeFromTrumpIn = true → return highestValueCard = 10C
+    expect(decidePlay(view, 'u1')).toBe('10C')
+  })
+
+  it('falls back to lowest non-trump winner when not guaranteed and opponents remain', () => {
+    // Trick: u2 led 7C. Bot holds 10C (10pts, best) and KC (4pts) — both beat 7C.
+    // AC has been played, so 10C is top of clubs.
+    // But trump NOT exhausted: only 9 trump in tricks + 2 in bot = 11 (3 remain elsewhere).
+    // Opponent u5 still to play → opponentsRemainingNT = 1 > 0.
+    // isGuaranteedWinner(10C) = false (trump remains, opponents not all trump-void).
+    // safeFromTrumpIn = false → lowestCard([10C, KC]) = KC (4pts < 10pts).
+    const botHand = [
+      c('10C', 'C', '10'),
+      c('KC', 'C', 'K'),
+      c('7D', 'D', '7'),
+      c('8D', 'D', '8'),
+    ]
+    const view = {
+      phase: 'playing',
+      hands: {
+        u1: botHand, u2: [], u3: [], u4: [], u5: [],
+      },
+      currentTrick: [
+        { userId: 'u2', card: c('7C', 'C', '7') },
+      ],
+      tricks: [
+        {
+          plays: [
+            { userId: 'u2', card: c('QC', 'C', 'Q') },
+            { userId: 'u3', card: c('QS', 'S', 'Q') },
+            { userId: 'u4', card: c('QH', 'H', 'Q') },
+            { userId: 'u5', card: c('QD', 'D', 'Q') },
+            { userId: 'u1', card: c('JC', 'C', 'J') },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'u2', card: c('JS', 'S', 'J') },
+            { userId: 'u3', card: c('JH', 'H', 'J') },
+            { userId: 'u4', card: c('JD', 'D', 'J') },
+            { userId: 'u5', card: c('AC', 'C', 'A') }, // AC played → 10C is top of clubs
+          ],
+        },
+        // Only 9 trump in tricks (+ 2 in bot = 11); trumpRemainingElsewhere = 3
+      ],
+      picker: 'u1',
+      partner: 'u3',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+    // u5 is in view.hands and hasn't played in currentTrick → opponentsRemainingNT = 1
+    // trumpRemainingElsewhere = 3 → isGuaranteedWinner(10C) = false (trump elsewhere)
+    // safeFromTrumpIn = false → lowestCard([10C, KC]) = KC (4pts < 10pts)
+    expect(decidePlay(view, 'u1')).toBe('KC')
+  })
+})

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -776,14 +776,15 @@ describe('decidePlay — opponent-team leading: guaranteed fail cards (call site
   })
 
   it('does NOT cash a guaranteed fail card when trump remains elsewhere', () => {
-    // Bot holds AC + 7D + 8D. Only 9 trump in tricks → trumpRemainingElsewhere = 3.
+    // Bot holds AC + 9C + 7D + 8D. Only 9 trump in tricks → trumpRemainingElsewhere = 3.
     // Opponents not all trump-void (they played trump in trick 0).
     // isGuaranteedWinner(AC) = false → skip guaranteed-cash branch.
     // Falls through: deducedPartner is null (no signals) → lead called-suit-to-flush.
-    // Bot holds no hearts → no called-suit cards → falls to lowest non-trump = AC (11pts)
-    // since no other fail card. Actually: last branch is lowestCard(nonTrump).
+    // Bot holds no hearts → no called-suit cards → falls to lowestCard(nonTrump).
+    // lowestCard([AC, 9C]) = 9C (0pts < 11pts) — NOT AC, proving the cash path was skipped.
     const hand = [
       c('AC', 'C', 'A'),
+      c('9C', 'C', '9'),
       c('7D', 'D', '7'),
       c('8D', 'D', '8'),
     ]
@@ -822,10 +823,299 @@ describe('decidePlay — opponent-team leading: guaranteed fail cards (call site
       isLeaster: false,
       lastTrick: [],
     }
-    // trumpRemainingElsewhere = 14 - 2 - 9 = 3 → not zero → isGuaranteedWinner = false
-    // Falls through to called-suit flush logic (no hearts in hand → no calledSuitCards)
-    // → lowestCard(nonTrump) = AC (only non-trump card)
-    expect(decidePlay(view, 'u2')).toBe('AC')
+    // trumpRemainingElsewhere = 14 - 2 - 9 = 3 → not zero → isGuaranteedWinner(AC) = false
+    // Cash path is skipped → falls through to called-suit flush logic (no hearts → no calledSuitCards)
+    // → lowestCard([AC, 9C]) = 9C (0pts) — confirms AC was NOT cashed
+    const result = decidePlay(view, 'u2')
+    expect(result).not.toBe('AC')
+    expect(result).toBe('9C')
+  })
+})
+
+// ─── Wire 1: picker-team leading — avoid risky suit leads ─────────────────────
+// When the picker-team bot has no trump, avoid leading into a suit where an opponent
+// is known void (they could trump it). Prefer a safe suit if one exists. Fall back
+// to highestValueCard when all suits are risky.
+
+describe('decidePlay — Wire 1: picker-team avoids leading into known opponent voids', () => {
+  // Bot = u1 (picker). Partner = u3. No trump in bot's hand.
+  // Opponent u4 is known void in clubs (trick 1: clubs led, u4 played hearts).
+  // Bot has clubs and spades fail cards. Clubs is risky (u4 void), spades is safe.
+
+  function wire1BaseView({ hand, tricks = [] }) {
+    return {
+      phase: 'playing',
+      hands: { u1: hand, u2: [], u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks,
+      picker: 'u1',
+      partner: 'u3',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,
+      isLeaster: false,
+      lastTrick: [],
+    }
+  }
+
+  it('avoids leading into a known opponent void when a safe suit exists (even if risky card has higher value)', () => {
+    // Prior trick: AC (clubs) led; u4 played KH (not clubs) → u4 void in C.
+    // Bot has: AC (11pts, risky suit C — u4 will trump it), 7S (0pts, safe suit S).
+    // Without Wire 1: highestValueCard = AC (11pts > 0pts).
+    // With Wire 1: AC is in risky suit → skip; prefer safe suit → 7S.
+    const tricks = [{
+      plays: [
+        { userId: 'u2', card: c('9C', 'C', '9') },  // led clubs
+        { userId: 'u4', card: c('KH', 'H', 'K') },  // off-suit → void in C
+        { userId: 'u3', card: c('8C', 'C', '8') },  // followed
+        { userId: 'u5', card: c('7C', 'C', '7') },  // followed
+        { userId: 'u1', card: c('8S', 'S', '8') },  // bot plays spades (not clubs)
+      ],
+    }]
+    const hand = [
+      c('AC', 'C', 'A'),   // risky suit (u4 void in C) — 11pts but dangerous
+      c('7S', 'S', '7'),   // safe suit — 0pts but safe
+    ]
+    const view = wire1BaseView({ hand, tricks })
+    // Wire 1: u4 (opponent) is void in C → AC is risky. 7S is safe. Prefer 7S.
+    expect(decidePlay(view, 'u1')).toBe('7S')
+  })
+
+  it('falls back to highestValueCard when all suits are risky', () => {
+    // Prior tricks: u4 void in C and S. Bot has only C and S fail cards.
+    // All suits risky → fall through to highestValueCard(realCards).
+    // KS (4pts) > 9C (0pts) → highestValueCard = KS.
+    const tricks = [
+      {
+        plays: [
+          { userId: 'u2', card: c('AC', 'C', 'A') },  // led clubs
+          { userId: 'u4', card: c('KH', 'H', 'K') },  // void in C
+          { userId: 'u1', card: c('9C', 'C', '9') },
+          { userId: 'u3', card: c('8C', 'C', '8') },
+          { userId: 'u5', card: c('7C', 'C', '7') },
+        ],
+      },
+      {
+        plays: [
+          { userId: 'u2', card: c('AS', 'S', 'A') },  // led spades
+          { userId: 'u4', card: c('9H', 'H', '9') },  // void in S
+          { userId: 'u1', card: c('7S', 'S', '7') },
+          { userId: 'u3', card: c('8S', 'S', '8') },
+          { userId: 'u5', card: c('KS', 'S', 'K') },
+        ],
+      },
+    ]
+    const hand = [
+      c('KS', 'S', 'K'),   // risky suit S
+      c('9C', 'C', '9'),   // risky suit C
+    ]
+    const view = wire1BaseView({ hand, tricks })
+    // All suits risky → highestValueCard = KS (4pts > 0pts)
+    expect(decidePlay(view, 'u1')).toBe('KS')
+  })
+})
+
+// ─── Wire 2: opponent-team leading — lead into picker-team void ────────────────
+// When the opponent-team bot knows the partner's identity AND a picker-team member
+// is void in a fail suit the bot holds, lead that suit to force the picker-team to
+// trump or waste a high card.
+
+describe('decidePlay — Wire 2: opponent leads into picker-team void to flush trump', () => {
+  // Bot = u4 (opponent). Picker = u2. Partner deduced via recrackerId = u3.
+  // Prior trick: spades led; u3 (partner) played hearts (off-suit) → void in S.
+  // Bot holds spades fail cards. Should lead spades to force u3 to trump.
+
+  function wire2BaseView({ hand, tricks = [], recrackerId = 'u3' }) {
+    return {
+      phase: 'playing',
+      hands: { u1: [], u2: [], u3: [], u4: hand, u5: [] },
+      currentTrick: [],
+      tricks,
+      picker: 'u2',
+      partner: null,       // masked from opponent view
+      partnerRevealed: false,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId,
+      isLeaster: false,
+      lastTrick: [],
+    }
+  }
+
+  it('leads into picker-team (partner) known void to flush trump', () => {
+    // Prior trick: AS (spades) led; u3 (partner, deduced via recrack) played KH → void in S.
+    // Bot holds: KS (4pts), 8C (0pts). KS is in risky suit for the opponent team goal:
+    // we WANT to lead spades here (partner is void → will have to trump or discard).
+    // Wire 2: lead KS (spades, suit where picker-team member is void).
+    const tricks = [{
+      plays: [
+        { userId: 'u1', card: c('AS', 'S', 'A') },  // led spades
+        { userId: 'u3', card: c('KH', 'H', 'K') },  // off-suit → void in S
+        { userId: 'u2', card: c('7S', 'S', '7') },
+        { userId: 'u4', card: c('8S', 'S', '8') },
+        { userId: 'u5', card: c('9S', 'S', '9') },
+      ],
+    }]
+    const hand = [
+      c('KS', 'S', 'K'),   // spades → suits where partner (u3) is void
+      c('8C', 'C', '8'),   // clubs
+    ]
+    const view = wire2BaseView({ hand, tricks })
+    expect(decidePlay(view, 'u4')).toBe('KS')
+  })
+
+  it('does NOT fire Wire 2 when partner identity is unknown', () => {
+    // No crack/recrack signals → deducedPartner = null.
+    // Wire 2 must not fire. Should fall through to lowestCard(nonTrump).
+    // Prior trick: AS led; u3 played KH → would imply void in S, but we don't know u3 is partner.
+    // Bot holds: KS, 8C. lowestCard(nonTrump) = 8C (0pts < 4pts).
+    const tricks = [{
+      plays: [
+        { userId: 'u1', card: c('AS', 'S', 'A') },  // led spades
+        { userId: 'u3', card: c('KH', 'H', 'K') },  // off-suit (but u3 is not yet deduced as partner)
+        { userId: 'u2', card: c('7S', 'S', '7') },
+        { userId: 'u4', card: c('8S', 'S', '8') },
+        { userId: 'u5', card: c('9S', 'S', '9') },
+      ],
+    }]
+    const hand = [
+      c('KS', 'S', 'K'),
+      c('8C', 'C', '8'),
+    ]
+    const view = wire2BaseView({ hand, tricks, recrackerId: null })
+    // No crack/recrack → deducedPartner null → Wire 2 does not fire
+    // Falls to lowestCard(nonTrump) = 8C
+    expect(decidePlay(view, 'u4')).toBe('8C')
+  })
+
+  it('leads the lowest-value card across all void-suit candidates (not highest)', () => {
+    // Partner (u3) void in both C and S.
+    // Bot holds: 9C (0pts), KC (4pts) in clubs; 7S (0pts) in spades.
+    // All three qualify (their suits are picker-team voids).
+    // lowestCard([9C, KC, 7S]) = 9C or 7S (both 0pts); lowestCard picks 9C because it
+    // iterates left-to-right and 9C appears first with 0pts, then 7S ties but doesn't
+    // displace it. The key assertion is that the expensive KC is NOT chosen.
+    const tricks = [
+      {
+        plays: [
+          { userId: 'u1', card: c('AC', 'C', 'A') },  // led clubs
+          { userId: 'u3', card: c('KH', 'H', 'K') },  // off-suit → void in C
+          { userId: 'u2', card: c('7C', 'C', '7') },
+          { userId: 'u4', card: c('8C', 'C', '8') },
+          { userId: 'u5', card: c('9C', 'C', '9') },
+        ],
+      },
+      {
+        plays: [
+          { userId: 'u1', card: c('AS', 'S', 'A') },  // led spades
+          { userId: 'u3', card: c('9H', 'H', '9') },  // off-suit → void in S
+          { userId: 'u2', card: c('7S', 'S', '7') },
+          { userId: 'u4', card: c('8S', 'S', '8') },
+          { userId: 'u5', card: c('6S', 'S', '6') },
+        ],
+      },
+    ]
+    const hand = [
+      c('9C', 'C', '9'),   // clubs (0pts)
+      c('KC', 'C', 'K'),   // clubs (4pts) — must NOT be chosen
+      c('7S', 'S', '7'),   // spades (0pts)
+    ]
+    const view = wire2BaseView({ hand, tricks })
+    // Wire 2 fires; lowestCard picks from [9C, KC, 7S]: KC (4pts) is skipped;
+    // 9C and 7S both 0pts, 9C wins the reduce as the initial accumulator.
+    expect(decidePlay(view, 'u4')).not.toBe('KC')
+  })
+
+  it('fires Wire 2 when only the partner (not the picker) is void in a suit', () => {
+    // Picker (u2) followed all suits normally — no void in spades.
+    // Partner (u3, deduced via recrack) is void in spades.
+    // Bot holds: KS (spades, partner void) and 8H (hearts, no void).
+    // Wire 2 should fire because pickerTeamIds.some(id => nonTrumpVoids[id]?.has('S'))
+    // is satisfied by u3 (partner), even though u2 (picker) is not void.
+    const tricks = [{
+      plays: [
+        { userId: 'u1', card: c('AS', 'S', 'A') },  // led spades
+        { userId: 'u2', card: c('7S', 'S', '7') },  // picker follows → NOT void in S
+        { userId: 'u3', card: c('KH', 'H', 'K') },  // partner off-suit → void in S
+        { userId: 'u4', card: c('8S', 'S', '8') },
+        { userId: 'u5', card: c('9S', 'S', '9') },
+      ],
+    }]
+    const hand = [
+      c('KS', 'S', 'K'),   // spades (partner u3 void) → Wire 2 candidate
+      c('8H', 'H', '8'),   // hearts (no picker-team void)
+    ]
+    const view = wire2BaseView({ hand, tricks })
+    // deducedPartner = u3 (recrack). nonTrumpVoids[u3] has 'S'. Picker u2 NOT void.
+    // Wire 2 fires on 'S'. voidSuitCards = [KS]. lowestCard([KS]) = KS.
+    expect(decidePlay(view, 'u4')).toBe('KS')
+  })
+
+  it('fires Wire 2 when partner is deduced by seat-elimination (knownNonPartners path)', () => {
+    // 5 seats. Picker = u2. Bot = u4 (opponent). view.partner = null, partnerRevealed = false.
+    // Ace call on hearts.
+    // Elimination: u2 (picker), u4 (self), u1 (played non-called on called-suit-led trick)
+    // rule out 3 seats → u5 is the deduced partner.
+    // Completed trick 1: hearts led by u1, u1 plays 9H (non-called; AH is called card)
+    //   → u1 added to knownNonPartners. u5 plays AH (called card) → loop stops.
+    // Completed trick 2: spades led; u5 (deduced partner) plays 7H (off-suit) → void in S.
+    // Bot holds: KS (spades, u5 void) and 9C (clubs, no void).
+    // Wire 2 should fire and lead KS (lowest of [KS]).
+    const tricks = [
+      {
+        // Trick 1: hearts led — eliminates u1 (plays non-called before AH)
+        plays: [
+          { userId: 'u1', card: c('9H', 'H', '9') },  // leads hearts (non-called)
+          { userId: 'u3', card: c('KH', 'H', 'K') },  // follows hearts (non-called) → also eliminated
+          { userId: 'u5', card: c('AH', 'H', 'A') },  // plays called card → partner, stops scan
+          { userId: 'u2', card: c('7H', 'H', '7') },
+          { userId: 'u4', card: c('8H', 'H', '8') },
+        ],
+      },
+      {
+        // Trick 2: spades led — u5 (deduced partner) plays off-suit → void in S
+        plays: [
+          { userId: 'u1', card: c('AS', 'S', 'A') },  // led spades
+          { userId: 'u5', card: c('7H', 'H', '7') },  // off-suit → void in S
+          { userId: 'u2', card: c('7S', 'S', '7') },
+          { userId: 'u3', card: c('8S', 'S', '8') },
+          { userId: 'u4', card: c('9S', 'S', '9') },
+        ],
+      },
+    ]
+    const hand = [
+      c('KS', 'S', 'K'),   // spades (u5 deduced partner is void in S)
+      c('9C', 'C', '9'),   // clubs (no picker-team void)
+    ]
+    const view = {
+      phase: 'playing',
+      hands: { u1: [], u2: [], u3: [], u4: hand, u5: [] },
+      currentTrick: [],
+      tricks,
+      picker: 'u2',
+      partner: null,        // masked — must deduce via elimination
+      partnerRevealed: false,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,    // no recrack — must use elimination path
+      isLeaster: false,
+      lastTrick: [],
+    }
+    // knownNonPartners: u2 (picker), u4 (self), u1 (played non-called before AH), u3 (same)
+    // → 4 ruled out of 5 non-picker seats? Wait: 5 seats total, picker=u2, non-picker = u1,u3,u4,u5.
+    // ruled = {u2, u4, u1, u3} → candidates = [u5] → deducedPartner = u5.
+    // nonTrumpVoids[u5] has 'S'. pickerTeamIds = [u2, u5]. Wire 2 fires on KS.
+    expect(decidePlay(view, 'u4')).toBe('KS')
   })
 })
 


### PR DESCRIPTION
## Summary

- **Case 1**: Extended `isGuaranteedWinner` to non-trump cards — returns true when all higher same-suit cards are accounted for AND all other players are deduced trump-void (via trick history) or all trump is globally exhausted. Replaces the imprecise `trumpRemainingElsewhere <= 2` heuristic at 3 call sites.
- **Case 3**: Added `deducedNonTrumpVoids` primitive — tracks which players are void in which fail suits from trick history. Wired into two leading decisions: picker-team avoids leading into known opponent voids; opponent-team leads into known picker-team voids (lowest-value card) to draw trump cheaply.
- **BOTS.md** synced to match all strategy changes.

## What changed

### `shared/botInference.js`
- `deducedTrumpVoids(view)` — new export: Set of players confirmed trump-void from trick history (played fail on a trump-led trick)
- `isGuaranteedWinner(card, view, userId)` — extended non-trump branch: checks all higher same-suit ranks are seen + no opponent can trump; vacuous-truth guard added for single-player views
- `deducedNonTrumpVoids(view)` — new export: `{[playerId]: Set<suit>}` tracking per-player fail-suit voids from trick history

### `shared/botStrategy.js`
- **Picker-team leading**: cash any guaranteed non-trump winner (was: cash fail ace only, with `<= 2` trump threshold)
- **Opponent-team leading**: same generalization; excludes called card
- **Picker-team following**: use `isGuaranteedWinner` on best non-trump winner (was: `trumpRemainingElsewhere === 0`)
- **Picker-team leading (no trump)**: avoid suits where opponents are known void (Wire 1)
- **Opponent-team leading**: lead into known picker-team voids to flush trump, lowest-value card (Wire 2)

## Test plan
- [ ] `npx vitest run shared/` — 331 tests, all passing
- [ ] Inference unit tests: `deducedTrumpVoids`, `deducedNonTrumpVoids`, non-trump `isGuaranteedWinner` (fail ace, fail 10, fail king, trump unchanged)
- [ ] Strategy integration tests: cash-fail-10 (not just ace), opponent-team generalization, follow safe non-trump win, Wire 1 safe/risky leads, Wire 2 flush into void

Closes #132 (cases 1 and 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)