### PR TITLE
feat(bot): partner defers trump lead when strongest is not guaranteed (#132 case 4)

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -100,7 +100,7 @@ Play the **lowest-value card** always, to avoid winning tricks.
 
 #### Picker-team bot leading
 1. **Cash any guaranteed non-trump winner** (any rank, not just aces): every higher same-suit card must be accounted for AND no opponent can trump it (all trump exhausted, or every other player is known trump-void). The highest-value qualifying card is played first.
-2. **Lead highest trump** to win tricks and accumulate card points.
+2. **Lead highest trump** to win tricks and accumulate card points. Exception for the **partner** holding 2 or more trump: if the strongest trump is not a guaranteed winner (higher-rank trump may still be in opponents' hands) AND the partner holds at least one fail card, lead the lowest-point fail card instead to preserve trump for later. If the partner has only 1 trump, or no fail cards to defer to, lead trump unconditionally.
 3. If no trump, and the bot is the **partner**:
    - If the last trick had 3 or fewer trump played, lead a called-suit card (lowest of that suit).
    - Otherwise, lead the lowest-point fail card.

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -309,9 +309,8 @@ export function decidePlay(view, userId) {
       const best = highestTrump(realCards)
       if (best) {
         if (userId === partner) {
-          const trumps = realCards.filter(c => isTrump(c))
           const fails = realCards.filter(c => !isTrump(c))
-          if (trumps.length >= 2 && fails.length > 0 && !isGuaranteedWinner(best, view, userId)) {
+          if (realCards.filter(c => isTrump(c)).length >= 2 && fails.length > 0 && !isGuaranteedWinner(best, view, userId)) {
             return lowestCard(fails).id
           }
         }

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -303,9 +303,20 @@ export function decidePlay(view, userId) {
         .filter(c => !isTrump(c) && isGuaranteedWinner(c, view, userId))
         .sort((a, b) => cardPoints(b) - cardPoints(a))
       if (guaranteedFails.length > 0) return guaranteedFails[0].id
-      // Lead strongest trump to win tricks and accumulate points
+      // Lead strongest trump to win tricks and accumulate points.
+      // Partner with 2+ trump: defer to a fail card if the strongest trump is not
+      // a guaranteed winner (preserve trump for later when they can be decisive).
       const best = highestTrump(realCards)
-      if (best) return best.id
+      if (best) {
+        if (userId === partner) {
+          const trumps = realCards.filter(c => isTrump(c))
+          const fails = realCards.filter(c => !isTrump(c))
+          if (trumps.length >= 2 && fails.length > 0 && !isGuaranteedWinner(best, view, userId)) {
+            return lowestCard(fails).id
+          }
+        }
+        return best.id
+      }
 
       // Partner with no trump: lead called suit if previous trick was low on trump,
       // otherwise lead the lowest-point fail card

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -1244,3 +1244,101 @@ describe('decidePlay — picker-team following: guaranteed non-trump win (call s
     expect(decidePlay(view, 'u1')).toBe('KC')
   })
 })
+
+describe('decidePlay — Case 4: partner trump lead-back timing', () => {
+  // Base view factory for partner-leading tests.
+  // u1=picker, u2=partner (leading), u3..u5=opponents
+  // calledSuit='H', no completed tricks, currentTrick=[] (leading)
+  function partnerLeadView({ hand, tricks = [], buried = [] }) {
+    return {
+      phase: 'playing',
+      hands: { u1: [], u2: hand, u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks,
+      buried,
+      picker: 'u1',
+      partner: 'u2',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+  }
+
+  it('defers to lowest-point fail when partner holds 2 weak trump and strongest is not guaranteed', () => {
+    // Partner holds 9D + 8D (weak trump) and fail cards (KS=4pts, 7S=0pts).
+    // No tricks have been played, so all higher-rank trump (ranks 0-10) are unseen.
+    // isGuaranteedWinner(9D) = false (QC through 8D rank 0-10 unaccounted for).
+    // Partner has 2+ trump, fails exist → should defer to lowestCard(fails) = 7S.
+    const hand = [
+      c('9D', 'D', '9'),  // trump rank 11
+      c('8D', 'D', '8'),  // trump rank 12
+      c('KS', 'S', 'K'),  // fail, 4 pts
+      c('7S', 'S', '7'),  // fail, 0 pts
+    ]
+    const view = partnerLeadView({ hand })
+    expect(decidePlay(view, 'u2')).toBe('7S')
+  })
+
+  it('leads highest trump when strongest is a guaranteed winner', () => {
+    // Partner holds QC (rank 0, always guaranteed) + 8D + fail.
+    // isGuaranteedWinner(QC) = true → should cash out with QC.
+    const hand = [
+      c('QC', 'C', 'Q'),  // trump rank 0 — always guaranteed
+      c('8D', 'D', '8'),  // trump rank 12
+      c('KS', 'S', 'K'),  // fail
+    ]
+    const view = partnerLeadView({ hand })
+    expect(decidePlay(view, 'u2')).toBe('QC')
+  })
+
+  it('leads trump unconditionally when partner has exactly 1 trump (even if not guaranteed)', () => {
+    // Partner holds 9D (weak trump, not guaranteed) + fail cards.
+    // Only 1 trump → lead it unconditionally (no deferral).
+    const hand = [
+      c('9D', 'D', '9'),  // trump rank 11, not guaranteed
+      c('KS', 'S', 'K'),  // fail
+      c('7S', 'S', '7'),  // fail
+    ]
+    const view = partnerLeadView({ hand })
+    expect(decidePlay(view, 'u2')).toBe('9D')
+  })
+
+  it('leads highest trump when partner has 2+ trump but no fail cards to defer to', () => {
+    // Partner holds QS (rank 1, not guaranteed — QC unseen) + 8D. No fail cards.
+    // Can't defer when there's nothing to defer to → lead highest trump (QS).
+    const hand = [
+      c('QS', 'S', 'Q'),  // trump rank 1, not guaranteed (QC rank 0 unseen)
+      c('8D', 'D', '8'),  // trump rank 12
+    ]
+    const view = partnerLeadView({ hand })
+    expect(decidePlay(view, 'u2')).toBe('QS')
+  })
+
+  it('does not defer for the picker — picker with 2 weak trump still leads highest trump', () => {
+    // Picker (u1) holds 9D + 8D (weak trump, not guaranteed) and fail cards.
+    // The new deferral logic is partner-only → picker should still lead highest trump (9D).
+    const hand = [
+      c('9D', 'D', '9'),  // trump rank 11
+      c('8D', 'D', '8'),  // trump rank 12
+      c('KS', 'S', 'K'),  // fail
+      c('7S', 'S', '7'),  // fail
+    ]
+    const view = {
+      phase: 'playing',
+      hands: { u1: hand, u2: [], u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks: [],
+      buried: [],
+      picker: 'u1',
+      partner: 'u2',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+    expect(decidePlay(view, 'u1')).toBe('9D')
+  })
+})


### PR DESCRIPTION
## Summary

- When the partner bot leads with 2+ trump, checks `isGuaranteedWinner` on the strongest trump before committing to it
- If the strongest trump is NOT a guaranteed winner AND fail cards are available, leads the lowest-point fail card instead (preserves trump for later)
- Falls back to leading trump unconditionally when holding only 1 trump or no fail cards; picker (non-partner) is unaffected

## Test Plan

- [ ] 5 new strategy tests cover: guaranteed-winner lead, non-guaranteed defer, 1-trump unconditional, no-fail fallback, picker-unaffected regression
- [ ] All 336 tests pass (`npx vitest run shared/`)
- [ ] `docs/BOTS.md` item 2 updated under "Picker-team bot leading"

Closes #132 (case 4)

🤖 Claude did this work