### PR TITLE
fix(hooks): handle current/worktree branch marker in post-merge gone detection

### DIFF
--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -2,7 +2,7 @@
 
 # Auto-delete local branches whose remote tracking branch is gone
 git fetch --prune
-gone=$(git branch -vv | awk '/: gone\]/ {print $1}')
+gone=$(git branch -vv | awk '/: gone\]/ {print ($1=="*"||$1=="+") ? $2 : $1}')
 [ -n "$gone" ] && echo "$gone" | xargs git branch -d
 
 # Pull main down to latest when we're on a different branch


### PR DESCRIPTION
## Summary
- `git branch -vv` prefixes the current branch with `*` and worktree branches with `+`
- The previous awk `{print $1}` captured the marker character instead of the branch name
- Fixed by checking if `$1` is `*` or `+` and printing `$2` (the actual branch name) instead

## Test plan
- [ ] Merge a PR while on a branch that has its remote deleted — confirm the gone branch is cleaned up without errors
- [ ] Verify no regression when merging while on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)