### PR TITLE
feat(inference): blitz-aware guaranteed-winner inference (#150)

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -194,6 +194,8 @@ of bot team.
 
 | Function | Purpose |
 |---|---|
+| `knownCardLocations` | Returns `Map<userId, Array<card>>` of card objects known by public announcement to be in a player's hand. Phase 1: populated from `view.blitzes` — black blitz → picker holds QC + QS; red blitz → picker holds QH + QD. |
+| `resolveView` | Pre-computation wrapper called once per play decision in `decidePlay`. Returns `{ ...view, knownLocations }`. All downstream inference calls receive the enriched view. Phase 2 (#176) will add more pre-computed fields. |
 | `countTrumpPlayed` | Count visible trump in completed tricks and the current trick |
 | `trumpRemainingElsewhere` | Estimate trump still held by other players: `14 − own trump − seen trump − buried trump` |
 | `handScore` | Combined pick-quality score: `schwanzerPts × 4 + 3×(non-trump aces) + 2×(non-trump tens) + 5 if QC held` |
@@ -203,7 +205,7 @@ of bot team.
 | `teammateWinning` | Returns true if the current trick leader is on the same team as the bot |
 | `deducedTrumpVoids` | Returns the set of players known to be void in trump, based on completed trick history. A player is trump-void if they played a non-trump card on a trick where trump was led. |
 | `deducedNonTrumpVoids` | Returns a map of `{ [userId]: Set<suit> }` — the fail suits each player is known void in, deduced from completed trick history. A player is void in a fail suit if, on a trick where that fail suit was led, they played a card of a different suit (including trump). Only scans completed tricks. |
-| `isGuaranteedWinner` | Returns true iff a card cannot be beaten by any opponent. For trump: every higher-rank trump has been seen (own hand, played tricks, current trick, visible bury). For non-trump: every higher same-suit card has been seen AND no opponent can trump (all trump accounted for, or all others are deduced trump-void). |
+| `isGuaranteedWinner` | Returns true iff a card cannot be beaten by any opponent. For trump: every higher-rank trump has been seen (own hand, played tricks, current trick, visible bury) or is known to be in a teammate's hand via `knownLocations`. For non-trump: every higher same-suit card has been seen AND no opponent can trump (`trumpRemainingElsewhere − knownTeammateTrump === 0` after subtracting known unplayed teammate trump, or all others are deduced trump-void). |
 | `cheapestGuaranteedWin` | From a set of candidate cards, returns the lowest-point card that satisfies `isGuaranteedWinner` (tiebreak: weaker trump first). Returns null if none qualify. |
 | `pickBySchmearPriority` | Pick the least-painful winning card to spend, walking a rank-priority list (`A,10,K,9,8,7,J,Q` for trump; `A,10,K,9,8,7` for fail). Trump tiebreak: weakest trump rank. Fail tiebreak: shortest non-trump suit in hand, then alphabetical. |
 | `knownNonPartners` | Returns the set of userIds known not to be the partner from public information: picker, self (if non-picker-team), cracker, players who played non-called on a called-suit-led trick before the called card was played. |

--- a/docs/superpowers/plans/2026-05-01-blitz-inference-plan.md
+++ b/docs/superpowers/plans/2026-05-01-blitz-inference-plan.md
@@ -1,0 +1,614 @@
+# Blitz Inference for Bots Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach partner bots to use public blitz declarations to make smarter play decisions via a new `resolveView` pre-computation layer.
+
+**Architecture:** Add `knownCardLocations(view)` and `resolveView(view, userId)` to `botInference.js`. Extend `isGuaranteedWinner` to read `view.knownLocations` — treating known-teammate trump as accounted for in both the trump and fail-card cases. Wire `resolveView` into `decidePlay` in `botStrategy.js` so all downstream inference calls automatically benefit.
+
+**Tech Stack:** JavaScript (ES modules), Vitest, shared game engine
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `shared/botInference.js` | Add `knownCardLocations`, `resolveView`; extend `isGuaranteedWinner` (trump + fail cases) |
+| `shared/botInference.test.js` | Add describe blocks for `knownCardLocations`, `resolveView`, blitz-aware `isGuaranteedWinner` |
+| `shared/botStrategy.js` | Add `resolveView` to import; add `const rv = resolveView(view, userId)` in `decidePlay`; update all inference calls to pass `rv` |
+| `docs/BOTS.md` | Add `knownCardLocations` and `resolveView` rows to Inference Helpers table; update `isGuaranteedWinner` description |
+
+---
+
+## Task 1: Branch setup and design doc commit
+
+**Files:**
+- Commit: `docs/superpowers/specs/2026-05-01-blitz-inference-design.md`
+- Commit: `docs/superpowers/specs/2026-05-01-blitz-inference-design-for-PMs.md`
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout -b feat/blitz-inference
+```
+
+- [ ] **Step 2: Stage and commit design docs**
+
+```bash
+git add docs/superpowers/specs/2026-05-01-blitz-inference-design.md docs/superpowers/specs/2026-05-01-blitz-inference-design-for-PMs.md
+git commit -m "docs: add blitz inference design docs (issue #150)"
+```
+
+---
+
+## Task 2: Add `knownCardLocations` and `resolveView` with tests
+
+**Files:**
+- Modify: `shared/botInference.js`
+- Modify: `shared/botInference.test.js`
+
+- [ ] **Step 1: Add failing tests for `knownCardLocations`**
+
+Update the import line at the top of `shared/botInference.test.js`:
+
+```javascript
+import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids, knownCardLocations, resolveView } from './botInference.js'
+```
+
+Append a new describe block at the end of `shared/botInference.test.js`:
+
+```javascript
+describe('knownCardLocations', () => {
+  it('no blitzes → empty Map', () => {
+    const view = { blitzes: [] }
+    expect(knownCardLocations(view).size).toBe(0)
+  })
+
+  it('black blitz → picker entry contains QC and QS card objects', () => {
+    const view = { blitzes: [{ userId: 'p1', type: 'black' }] }
+    const result = knownCardLocations(view)
+    expect(result.has('p1')).toBe(true)
+    const ids = result.get('p1').map(c => c.id)
+    expect(ids).toContain('QC')
+    expect(ids).toContain('QS')
+    expect(ids).toHaveLength(2)
+  })
+
+  it('red blitz → picker entry contains QH and QD card objects', () => {
+    const view = { blitzes: [{ userId: 'p1', type: 'red' }] }
+    const result = knownCardLocations(view)
+    expect(result.has('p1')).toBe(true)
+    const ids = result.get('p1').map(c => c.id)
+    expect(ids).toContain('QH')
+    expect(ids).toContain('QD')
+    expect(ids).toHaveLength(2)
+  })
+
+  it('missing blitzes field → empty Map', () => {
+    expect(knownCardLocations({}).size).toBe(0)
+  })
+})
+
+describe('resolveView', () => {
+  it('returns view with knownLocations populated from blitzes', () => {
+    const view = { blitzes: [{ userId: 'p1', type: 'black' }], hands: { p1: [], p2: [] } }
+    const rv = resolveView(view, 'p2')
+    expect(rv.knownLocations).toBeDefined()
+    expect(rv.knownLocations.has('p1')).toBe(true)
+    const ids = rv.knownLocations.get('p1').map(c => c.id)
+    expect(ids).toContain('QC')
+    expect(ids).toContain('QS')
+  })
+
+  it('other view fields are unchanged', () => {
+    const view = { blitzes: [], hands: { p1: [], p2: [] }, picker: 'p1' }
+    const rv = resolveView(view, 'p2')
+    expect(rv.picker).toBe('p1')
+    expect(rv.hands).toBe(view.hands)
+  })
+
+  it('no blitzes → knownLocations is an empty Map', () => {
+    const view = { blitzes: [], hands: {} }
+    const rv = resolveView(view, 'p1')
+    expect(rv.knownLocations.size).toBe(0)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run shared/botInference.test.js
+```
+
+Expected: FAIL — `knownCardLocations is not a function` and `resolveView is not a function`.
+
+- [ ] **Step 3: Implement `knownCardLocations` and `resolveView` in `shared/botInference.js`**
+
+Add the following block immediately before the `// ─── Trump tracking ───` section (at the very top of the file body, after the import):
+
+```javascript
+// ─── Public knowledge ─────────────────────────────────────────────────────────
+
+// Card objects for each blitz type. Blitz publicly reveals which queens the picker holds.
+const BLITZ_CARDS = {
+  black: [{ id: 'QC', rank: 'Q', suit: 'C' }, { id: 'QS', rank: 'Q', suit: 'S' }],
+  red:   [{ id: 'QH', rank: 'Q', suit: 'H' }, { id: 'QD', rank: 'Q', suit: 'D' }],
+}
+
+// Returns Map<userId, Array<card>> of cards known by public announcement to be in a player's hand.
+// Phase 1: populated from view.blitzes only.
+export function knownCardLocations(view) {
+  const map = new Map()
+  for (const { userId, type } of (view.blitzes ?? [])) {
+    map.set(userId, [...(BLITZ_CARDS[type] ?? [])])
+  }
+  return map
+}
+
+// Pre-computation wrapper. Returns { ...view, knownLocations } for use by all inference calls
+// in a single play decision. _userId is unused in Phase 1; included for Phase 2 API symmetry.
+export function resolveView(view, _userId) {
+  return { ...view, knownLocations: knownCardLocations(view) }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run shared/botInference.test.js
+```
+
+Expected: all existing tests pass, all new `knownCardLocations` and `resolveView` tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/botInference.js shared/botInference.test.js
+git commit -m "feat(inference): add knownCardLocations and resolveView (#150)"
+```
+
+---
+
+## Task 3: Extend `isGuaranteedWinner` — trump case with blitz inference
+
+**Files:**
+- Modify: `shared/botInference.js`
+- Modify: `shared/botInference.test.js`
+
+- [ ] **Step 1: Add failing tests**
+
+Append a new describe block at the end of `shared/botInference.test.js`:
+
+```javascript
+describe('isGuaranteedWinner – blitz inference (trump case)', () => {
+  it('partner holds QH; picker black-blitzed (QC+QS); neither played → true with resolveView', () => {
+    // Without blitz inference: QC and QS are unaccounted for → false.
+    // With resolveView: QC and QS are known to be in teammate's (picker's) hand → true.
+    const qh = { id: 'QH', rank: 'Q', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p2: [qh],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+      isLeaster: false,
+    }
+    // Plain view: QC (rank 0) and QS (rank 1) unseen → false
+    expect(isGuaranteedWinner(qh, view, 'p2')).toBe(false)
+    // Enriched view: QC and QS known in teammate's hand → true
+    const rv = resolveView(view, 'p2')
+    expect(isGuaranteedWinner(qh, rv, 'p2')).toBe(true)
+  })
+
+  it('opponent bot does NOT benefit from blitz: QH is false for p3 regardless of resolveView', () => {
+    const qh = { id: 'QH', rank: 'Q', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p2: [], p3: [qh], p4: [], p5: [],
+      },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p3')
+    // p3 is an opponent; picker's blitzed queens are opponent threats → still false
+    expect(isGuaranteedWinner(qh, rv, 'p3')).toBe(false)
+  })
+
+  it('picker holds QS; partner red-blitzed (QH+QD in partner hand); QH+QD unseen in tricks → QS true for picker', () => {
+    // Picker (p1) holds QS. Partner (p2) declared red blitz (QH + QD in p2's hand).
+    // QC (rank 0) still unaccounted for → QS still false even with blitz inference.
+    // This tests that only higher-ranked trump in teammate's hand count, and QC is not there.
+    const qs = { id: 'QS', rank: 'Q', suit: 'S' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p2', type: 'red' }],
+      hands: {
+        p1: [qs],
+        p2: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p1')
+    // QC (rank 0) still unaccounted for → false
+    expect(isGuaranteedWinner(qs, rv, 'p1')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run shared/botInference.test.js
+```
+
+Expected: FAIL — new tests fail because `isGuaranteedWinner` ignores `view.knownLocations`.
+
+- [ ] **Step 3: Extend `isGuaranteedWinner` for the trump case in `shared/botInference.js`**
+
+In the trump branch of `isGuaranteedWinner` (the section starting with `const myRank = trumpRank(card)`), add the following block immediately after the four existing `noteIfHigherTrump` loops and before the final `for (let r = 0; r < myRank; r++)` loop:
+
+```javascript
+  // Also treat trump in a known teammate's hand as accounted for
+  if (view.knownLocations) {
+    const onPickerTeam = userId === view.picker || userId === view.partner
+    if (onPickerTeam) {
+      const teammateId = userId === view.picker ? view.partner : view.picker
+      if (teammateId) {
+        for (const c of (view.knownLocations.get(teammateId) ?? [])) {
+          if (isTrump(c)) seenRanks.add(trumpRank(c))
+        }
+      }
+    }
+  }
+```
+
+The surrounding context for placement (the full trump branch after the change):
+
+```javascript
+  const myRank = trumpRank(card)
+  if (myRank === 0) return true  // highest trump (Queen of Clubs)
+
+  const seenRanks = new Set()
+  const noteIfHigherTrump = (c) => {
+    if (!c || c.hidden) return
+    if (!isTrump(c)) return
+    seenRanks.add(trumpRank(c))
+  }
+
+  for (const c of (view.hands[userId] ?? [])) noteIfHigherTrump(c)
+  for (const trick of (view.tricks ?? [])) {
+    for (const play of trick.plays) noteIfHigherTrump(play.card)
+  }
+  for (const play of (view.currentTrick ?? [])) noteIfHigherTrump(play.card)
+  for (const c of (view.buried ?? [])) noteIfHigherTrump(c)
+
+  // Also treat trump in a known teammate's hand as accounted for
+  if (view.knownLocations) {
+    const onPickerTeam = userId === view.picker || userId === view.partner
+    if (onPickerTeam) {
+      const teammateId = userId === view.picker ? view.partner : view.picker
+      if (teammateId) {
+        for (const c of (view.knownLocations.get(teammateId) ?? [])) {
+          if (isTrump(c)) seenRanks.add(trumpRank(c))
+        }
+      }
+    }
+  }
+
+  // Every rank strictly lower than myRank must be seen somewhere.
+  for (let r = 0; r < myRank; r++) {
+    if (!seenRanks.has(r)) return false
+  }
+  return true
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+npx vitest run shared/botInference.test.js
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/botInference.js shared/botInference.test.js
+git commit -m "feat(inference): extend isGuaranteedWinner trump case with blitz inference (#150)"
+```
+
+---
+
+## Task 4: Extend `isGuaranteedWinner` — fail case (condition 2) with blitz inference
+
+**Files:**
+- Modify: `shared/botInference.js`
+- Modify: `shared/botInference.test.js`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `shared/botInference.test.js`:
+
+```javascript
+describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () => {
+  it('partner holds AH; 1 trump unaccounted for but known to be in picker\'s hand via blitz → true', () => {
+    // Setup: 13 of 14 trump accounted for in tricks/hand/buried; the 14th (QC) is the
+    // picker's black-blitzed card. trumpRemainingElsewhere = 1, but it's a teammate's card.
+    // Condition 1 (no higher same-suit card): AH is the ace → always satisfied.
+    // Condition 2 with blitz: knownTeammateTrump = 1, so 1 - 1 = 0 opponent trump → true.
+    const ah = { id: 'AH', rank: 'A', suit: 'H' }
+    const qs = { id: 'QS', rank: 'Q', suit: 'S' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }], // QC + QS known to p1
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }],
+        p2: [ah, qs],  // p2 holds AH (the card being tested) and QS (1 own trump)
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+            { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+            { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+            { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+            { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+            { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+            { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+            { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+            { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+          ],
+        },
+      ],
+      // Trump accounting:
+      // own (p2): QS = 1. Tricks: QH, QD, JC, JS, JH, JD, AD, 10D, KD, 9D = 10. Buried: 8D, 7D = 2.
+      // trumpRemainingElsewhere = 14 - 1 - 10 - 2 = 1 (that 1 is QC, in p1's hand via blitz)
+      currentTrick: [],
+      buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
+      isLeaster: false,
+    }
+    // Plain view: 1 trump remaining, not all others trump-void → false
+    expect(isGuaranteedWinner(ah, view, 'p2')).toBe(false)
+    // Enriched view: that 1 trump is in teammate's hand → 0 opponent trump → true
+    const rv = resolveView(view, 'p2')
+    expect(isGuaranteedWinner(ah, rv, 'p2')).toBe(true)
+  })
+
+  it('opponent bot does NOT benefit: same scenario, p3 holding AH → false even with resolveView', () => {
+    const ah = { id: 'AH', rank: 'A', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }],
+        p2: [],
+        p3: [ah, { id: 'QS', rank: 'Q', suit: 'S' }],
+        p4: [], p5: [],
+      },
+      tricks: [
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+            { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+            { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+            { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+            { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+            { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+            { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+            { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+            { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+          ],
+        },
+      ],
+      currentTrick: [],
+      buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p3')
+    // p3 is an opponent; QC is in an opponent's (picker's) hand → still a threat → false
+    expect(isGuaranteedWinner(ah, rv, 'p3')).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+npx vitest run shared/botInference.test.js
+```
+
+Expected: FAIL — the new fail-case tests fail.
+
+- [ ] **Step 3: Extend condition 2 in `isGuaranteedWinner` in `shared/botInference.js`**
+
+Replace the existing condition 2 block (the lines starting `// ── Condition 2` through the closing `if (!allOthersVoid) return false`) with:
+
+```javascript
+    // ── Condition 2: no opponent can trump it ─────────────────────────────────
+    let knownTeammateTrump = 0
+    if (view.knownLocations) {
+      const onPickerTeam = userId === view.picker || userId === view.partner
+      if (onPickerTeam) {
+        const teammateId = userId === view.picker ? view.partner : view.picker
+        if (teammateId) {
+          knownTeammateTrump = (view.knownLocations.get(teammateId) ?? []).filter(c => isTrump(c)).length
+        }
+      }
+    }
+    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) - knownTeammateTrump === 0
+    if (!noTrumpElsewhere) {
+      const voids = deducedTrumpVoids(view)
+      const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)
+      const allOthersVoid = otherPlayerIds.length > 0 && otherPlayerIds.every(id => voids.has(id))
+      if (!allOthersVoid) return false
+    }
+```
+
+- [ ] **Step 4: Run all botInference tests**
+
+```bash
+npx vitest run shared/botInference.test.js
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/botInference.js shared/botInference.test.js
+git commit -m "feat(inference): extend isGuaranteedWinner fail case with blitz inference (#150)"
+```
+
+---
+
+## Task 5: Wire `resolveView` into `decidePlay` in `botStrategy.js`
+
+**Files:**
+- Modify: `shared/botStrategy.js`
+
+- [ ] **Step 1: Add `resolveView` to the import**
+
+Update line 9 of `shared/botStrategy.js`. Current:
+
+```javascript
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner, deducedNonTrumpVoids } from './botInference.js'
+```
+
+New:
+
+```javascript
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner, deducedNonTrumpVoids, resolveView } from './botInference.js'
+```
+
+- [ ] **Step 2: Add `resolveView` call at the top of `decidePlay`**
+
+In `decidePlay`, add `const rv = resolveView(view, userId)` immediately after the `if (realCards.length === 0)` guard (before the leaster check). The top of `decidePlay` should become:
+
+```javascript
+export function decidePlay(view, userId) {
+  const legal = getLegalCards(view, userId)
+  if (legal.length === 0) throw new Error(`Bot ${userId} has no legal cards to play`)
+
+  const realCards = legal.filter(c => !c.isUnderCard)
+
+  // Under card is the only option
+  if (realCards.length === 0) return 'UNDER_CARD'
+
+  const rv = resolveView(view, userId)
+
+  const { currentTrick, picker, partner, isLeaster } = view
+```
+
+- [ ] **Step 3: Replace inference calls throughout `decidePlay` to use `rv`**
+
+Run these sed commands from the repo root. They target the specific function-call patterns; function declarations are not affected.
+
+```bash
+sed -i '' 's/isGuaranteedWinner(\([^,]*\), view, userId)/isGuaranteedWinner(\1, rv, userId)/g' shared/botStrategy.js
+sed -i '' 's/cheapestGuaranteedWin(\([^,]*\), view, userId)/cheapestGuaranteedWin(\1, rv, userId)/g' shared/botStrategy.js
+sed -i '' 's/deducedNonTrumpVoids(view)/deducedNonTrumpVoids(rv)/g' shared/botStrategy.js
+sed -i '' 's/deducedPartner(view, userId)/deducedPartner(rv, userId)/g' shared/botStrategy.js
+sed -i '' 's/teammateWinning(view, userId)/teammateWinning(rv, userId)/g' shared/botStrategy.js
+```
+
+- [ ] **Step 4: Verify the replacements**
+
+```bash
+grep -n "isGuaranteedWinner\|cheapestGuaranteedWin\|deducedNonTrumpVoids\|deducedPartner\|teammateWinning" shared/botStrategy.js
+```
+
+Expected output: all inference calls inside `decidePlay` now use `rv`; function declarations (`decidePlay(view, userId)` etc.) are unchanged. Confirm no line still shows `, view, userId)` or `(view)` or `(view, userId)` for these five functions.
+
+- [ ] **Step 5: Run the full test suite**
+
+```bash
+npm test
+```
+
+Expected: all tests pass (existing and new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/botStrategy.js
+git commit -m "feat(strategy): wire resolveView into decidePlay for blitz-aware inference (#150)"
+```
+
+---
+
+## Task 6: Update `docs/BOTS.md`
+
+**Files:**
+- Modify: `docs/BOTS.md`
+
+- [ ] **Step 1: Add `knownCardLocations` and `resolveView` rows to the Inference Helpers table**
+
+The Inference Helpers table starts at line 195 of `docs/BOTS.md`. Add two rows and update the `isGuaranteedWinner` row. Find the existing table block ending at the `deducedPartner` row and replace it with:
+
+```markdown
+| Function | Purpose |
+|---|---|
+| `knownCardLocations` | Returns `Map<userId, Array<card>>` of card objects known by public announcement to be in a player's hand. Phase 1: populated from `view.blitzes` — black blitz → picker holds QC + QS; red blitz → picker holds QH + QD. |
+| `resolveView` | Pre-computation wrapper called once per play decision in `decidePlay`. Returns `{ ...view, knownLocations }`. All downstream inference calls receive the enriched view. Phase 2 (#176) will add more pre-computed fields. |
+| `countTrumpPlayed` | Count visible trump in completed tricks and the current trick |
+| `trumpRemainingElsewhere` | Estimate trump still held by other players: `14 − own trump − seen trump − buried trump` |
+| `handScore` | Combined pick-quality score: `schwanzerPts × 4 + 3×(non-trump aces) + 2×(non-trump tens) + 5 if QC held` |
+| `beats` | Returns true if a challenger card beats the current winner given led suit |
+| `currentWinner` | Returns the play object currently winning a trick |
+| `bestVoidBury` | Finds the best 2-card bury that voids a non-trump suit with ≥11 combined card points |
+| `teammateWinning` | Returns true if the current trick leader is on the same team as the bot |
+| `deducedTrumpVoids` | Returns the set of players known to be void in trump, based on completed trick history. A player is trump-void if they played a non-trump card on a trick where trump was led. |
+| `deducedNonTrumpVoids` | Returns a map of `{ [userId]: Set<suit> }` — the fail suits each player is known void in, deduced from completed trick history. A player is void in a fail suit if, on a trick where that fail suit was led, they played a card of a different suit (including trump). Only scans completed tricks. |
+| `isGuaranteedWinner` | Returns true iff a card cannot be beaten by any opponent. For trump: every higher-rank trump has been seen (own hand, played tricks, current trick, visible bury) or is known to be in a teammate's hand via `knownLocations`. For non-trump: every higher same-suit card has been seen AND no opponent can trump (all trump accounted for after subtracting known teammate trump from `trumpRemainingElsewhere`, or all others are deduced trump-void). |
+| `cheapestGuaranteedWin` | From a set of candidate cards, returns the lowest-point card that satisfies `isGuaranteedWinner` (tiebreak: weaker trump first). Returns null if none qualify. |
+| `pickBySchmearPriority` | Pick the least-painful winning card to spend, walking a rank-priority list (`A,10,K,9,8,7,J,Q` for trump; `A,10,K,9,8,7` for fail). Trump tiebreak: weakest trump rank. Fail tiebreak: shortest non-trump suit in hand, then alphabetical. |
+| `knownNonPartners` | Returns the set of userIds known not to be the partner from public information: picker, self (if non-picker-team), cracker, players who played non-called on a called-suit-led trick before the called card was played. |
+| `deducedPartner` | Returns the partner's userId if known (`view.partner` set, recrack identifies them, or full elimination via `knownNonPartners`), else `null`. Returns `null` in alone/leaster modes regardless of signals. |
+```
+
+- [ ] **Step 2: Run full test suite to confirm no regressions**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/BOTS.md
+git commit -m "docs: update BOTS.md with blitz inference helpers (#150)"
+```

--- a/docs/superpowers/specs/2026-05-01-blitz-inference-design-for-PMs.md
+++ b/docs/superpowers/specs/2026-05-01-blitz-inference-design-for-PMs.md
@@ -1,0 +1,49 @@
+# Blitz Inference for Bots — PM Design (Issue #150)
+
+## What We're Building
+
+When a player declares a blitz in Sheepshead, they publicly announce which two queens they're holding before play begins. This is public information — all players at the table can see it. Currently the game's bots ignore this announcement entirely.
+
+This feature teaches bots to use blitz declarations to make smarter play decisions.
+
+## Why It Matters
+
+Without this feature, a bot in the "partner" role (on the same team as the picker who blitzed) doesn't realize its teammate is holding those two queens. This leads to suboptimal play: the partner bot may avoid leading a card it should confidently win with, or play defensively when it should commit, simply because it can't reason about cards its teammate publicly declared.
+
+The fix is targeted: we're not overhauling how bots think — we're adding one piece of public knowledge they were previously ignoring.
+
+## What Changes
+
+We're introducing a pre-processing step in the bot's reasoning pipeline called `resolveView`. Before making any play decision, the bot now packages up everything it publicly knows — starting with blitz declarations — into a structured summary. This summary (`knownLocations`) tells the bot which cards are confirmed to be in a specific player's hand, based on public announcements made at the start of the hand.
+
+With this in place, two key improvements follow:
+
+**1. Stronger trump recognition**
+
+A partner bot can now correctly identify cards it holds as guaranteed winners when the missing stronger cards are known to be in a teammate's hand. For example: if the picker declared a black blitz (holding QC + QS), the partner holding QH should recognize QH as the highest trump available to any opponent — because QC and QS are locked in a teammate's hand. Previously the bot would incorrectly assume those queens might be held by an opponent, causing it to undervalue QH.
+
+**2. Safer fail-card leads**
+
+When evaluating whether a non-trump card is safe to lead, the bot discounts trump held by a teammate. If the only unaccounted-for trump is in the picker's hand (and the picker is on the bot's team), there is no opponent trump threat — and the bot now correctly recognizes that.
+
+## Who Benefits
+
+Only **picker-team bots** (specifically the partner) benefit from this change. For opponent-team bots, blitzed queens are in an opponent's hand — the existing logic already treats them correctly as threats.
+
+## Architecture Note: Built for Extension
+
+The `resolveView` wrapper is deliberately designed as a foundation. In a follow-up task (#176), we'll move additional pre-computations (partner identity, trump-void deductions) into this same layer. The bot will get faster and more consistent reasoning across all inference functions, with no change to the external calling interface.
+
+## Out of Scope
+
+- Opponent bot behavior is unchanged.
+- No UI changes — this is purely internal bot reasoning.
+- Leasters cannot follow a blitz (game rule), so no edge case handling is needed there.
+- The #176 pre-computation migration is tracked separately.
+
+## Success Criteria
+
+- The partner bot correctly uses blitz declarations when deciding which cards it can safely lead or commit to winning tricks.
+- No change in opponent bot behavior.
+- All existing automated tests continue to pass; new tests verify the three main functions added by this feature.
+- The bot strategy documentation is updated to reflect the new reasoning layer.

--- a/docs/superpowers/specs/2026-05-01-blitz-inference-design.md
+++ b/docs/superpowers/specs/2026-05-01-blitz-inference-design.md
@@ -1,0 +1,120 @@
+# Design: Blitz Inference for Bots (Issue #150)
+
+## Problem
+
+When a player declares a blitz, they publicly announce which two queens they hold (black blitz = QC + QS, red blitz = QH + QD). Since the blitzer is always the picker (enforced by the engine), this is visible to all players. Currently `botInference.js` ignores it.
+
+The practical gap: a partner bot holding QH cannot recognize it as a guaranteed winner when the picker black-blitzed, because QC and QS haven't appeared in tricks yet — the "are all stronger trump accounted for?" check fails even though those queens are in a teammate's hand.
+
+## Background
+
+- `view.blitzes` is already present in the redacted player view: `Array<{ userId, type: 'black'|'red' }>`.
+- The blitzer is always the picker — enforced by the engine; a leaster can never follow a blitz.
+- Black blitz → picker holds QC and QS. Red blitz → picker holds QH and QD.
+- Only picker-team bots benefit: for opponent-team bots, blitzed queens are in an opponent's hand and remain correctly treated as threats.
+
+## Approach: resolveView (Phase 1)
+
+Rather than threading extra state through individual inference calls, we introduce a thin pre-computation wrapper: `resolveView(view, userId)` enriches the player view with derived facts and returns a new view object. `decidePlay` in `botStrategy.js` calls `resolveView` once and passes the enriched view downstream to all inference functions.
+
+Phase 1 adds only `knownLocations`. Phase 2 (#176) will migrate `deducedPartner`, `deducedTrumpVoids`, and `deducedNonTrumpVoids` into the same step.
+
+## Data Shape
+
+```
+knownLocations: Map<userId, Array<card>>
+```
+
+A map from userId to an array of card objects `{ id, rank, suit }` known — by public announcement — to be in that player's hand. Populated only from blitz declarations in Phase 1.
+
+## New Functions (botInference.js)
+
+### `knownCardLocations(view)` → `Map<userId, Array<card>>`
+
+Derives `knownLocations` from `view.blitzes`:
+- Black blitz entry → picker's array includes `{ id: 'QC', rank: 'Q', suit: 'C' }` and `{ id: 'QS', rank: 'Q', suit: 'S' }`.
+- Red blitz entry → picker's array includes `{ id: 'QH', rank: 'Q', suit: 'H' }` and `{ id: 'QD', rank: 'Q', suit: 'D' }`.
+
+No blitzes → returns an empty Map.
+
+### `resolveView(view, userId)` → enriched view
+
+Returns `{ ...view, knownLocations: knownCardLocations(view) }`. The `userId` parameter is included for Phase 2 API symmetry; it is unused in Phase 1.
+
+## Modified Functions (botInference.js)
+
+### `isGuaranteedWinner(card, view, userId)`
+
+No signature change. Reads `view.knownLocations` when present.
+
+**Team membership check (internal)**
+
+"On picker team" means `userId === view.picker || userId === view.partner`. Teammate IDs are the other picker-team member(s) not including `userId`. If the bot is not on the picker team, `knownLocations` is not consulted and behavior is unchanged.
+
+**Trump case — higher-rank trump check**
+
+Currently: every trump with a lower rank index (stronger trump) must appear in the bot's own hand, played tricks, current trick, or bury.
+
+With `knownLocations`: trump in a known **teammate's** hand is also treated as accounted for, since a teammate cannot play it against us. Concretely, for each entry in `view.knownLocations` where the key is a teammate ID, every trump card in that array has its `trumpRank` added to the "seen ranks" set.
+
+**Non-trump (fail) case — condition 2 (no opponent can trump)**
+
+Currently: satisfied if `trumpRemainingElsewhere(view, userId) === 0` OR all other players are trump-void.
+
+With `knownLocations`: compute `knownTeammateTrump` (count of trump in known teammate entries). Use `trumpRemainingElsewhere - knownTeammateTrump` for the zero check. If the adjusted count is 0, condition 2 is satisfied regardless of raw `trumpRemainingElsewhere`.
+
+`trumpRemainingElsewhere` itself is not modified; the subtraction is inline in `isGuaranteedWinner`.
+
+## botStrategy.js Change
+
+At the top of `decidePlay`, before any inference calls:
+
+```javascript
+const rv = resolveView(view, userId)
+```
+
+All calls that currently receive `view` are updated to receive `rv`. This covers:
+- `isGuaranteedWinner(c, view, userId)` calls (direct and via `cheapestGuaranteedWin`)
+- `deducedNonTrumpVoids(view)`
+- `deducedTrumpVoids(view)`
+- `deducedPartner(view, userId)`
+- `teammateWinning(view, userId)`
+- `trumpRemainingElsewhere(view, userId)`
+
+Since `rv` is a superset of `view` (only adds `knownLocations`), functions that don't read that field are unaffected.
+
+## Tests (botInference.test.js)
+
+1. **`knownCardLocations`**
+   - No blitzes → empty Map.
+   - Black blitz → picker entry contains QC and QS card objects.
+   - Red blitz → picker entry contains QH and QD card objects.
+
+2. **`resolveView`**
+   - Returns a view with `knownLocations` populated correctly from blitzes.
+   - All other view fields are unchanged.
+
+3. **`isGuaranteedWinner` — trump case with blitz inference**
+   - Partner holds QH; picker black-blitzed (QC+QS in picker's hand); neither played in tricks → `isGuaranteedWinner(QH, rv, partnerId)` returns `true`.
+   - Same setup, userId is an opponent bot → returns `false` (no blitz benefit to opponent).
+
+4. **`isGuaranteedWinner` — fail case with blitz inference**
+   - Partner holds AH; one trump unaccounted for, but known to be the picker's blitzed queen; no other opponent trump → returns `true`.
+
+## docs/BOTS.md Update
+
+Add `knownCardLocations` and `resolveView` to the Inference Helpers table. Document that `resolveView` is the single entry point for pre-computed inference, and that `knownLocations` carries blitz-derived card location knowledge.
+
+## Out of Scope
+
+- Pre-computing `deducedPartner`, `deducedTrumpVoids`, `deducedNonTrumpVoids` into `resolveView` → tracked in #176.
+- Inferences from non-picker blitzers (not possible by game rules).
+- UI changes of any kind.
+
+## Success Criteria
+
+1. Partner bot correctly uses blitz declarations in `isGuaranteedWinner` for both trump and fail cases.
+2. Opponent-team bot behavior is unchanged.
+3. All existing `botInference.test.js` and `botStrategy` tests continue to pass.
+4. New tests cover `knownCardLocations`, `resolveView`, and blitz-aware `isGuaranteedWinner`.
+5. `docs/BOTS.md` accurately reflects the new inference helpers.

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -277,7 +277,17 @@ export function isGuaranteedWinner(card, view, userId) {
     }
 
     // ── Condition 2: no opponent can trump it ─────────────────────────────────
-    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) === 0
+    let knownTeammateTrump = 0
+    if (view.knownLocations) {
+      const onPickerTeam = userId === view.picker || userId === view.partner
+      if (onPickerTeam) {
+        const teammateId = userId === view.picker ? view.partner : view.picker
+        if (teammateId) {
+          knownTeammateTrump = (view.knownLocations.get(teammateId) ?? []).filter(c => isTrump(c)).length
+        }
+      }
+    }
+    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) - knownTeammateTrump <= 0
     if (!noTrumpElsewhere) {
       const voids = deducedTrumpVoids(view)
       const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -239,7 +239,8 @@ function knownTeammateCards(view, userId) {
 //      strength) must be accounted for in: own hand, completed tricks (non-hidden),
 //      current trick (non-hidden), or bury (non-hidden).
 //   2. No opponent can trump it — satisfied if either:
-//      a. trumpRemainingElsewhere(view, userId) === 0 (all trump accounted for), OR
+//      a. trumpRemainingElsewhere(view, userId) − knownTeammateTrump === 0 (all trump
+//         accounted for after subtracting known teammate trump from knownLocations), OR
 //      b. Every other player is in the deducedTrumpVoids set.
 //
 // Unseen higher trump / higher same-suit cards are always treated as opponent-held.

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -215,6 +215,17 @@ export function deducedTrumpVoids(view) {
   return voids
 }
 
+// Returns the array of cards known (via public announcement) to be in the bot's teammate's hand.
+// Returns [] if bot is not on picker team, partner is unknown, or no knownLocations present.
+function knownTeammateCards(view, userId) {
+  if (!view.knownLocations) return []
+  const onPickerTeam = userId === view.picker || userId === view.partner
+  if (!onPickerTeam) return []
+  const teammateId = userId === view.picker ? view.partner : view.picker
+  if (!teammateId) return []
+  return view.knownLocations.get(teammateId) ?? []
+}
+
 // ─── Guaranteed-winner inference ──────────────────────────────────────────────
 
 // Returns true iff `card` cannot be beaten by any opponent:
@@ -277,17 +288,16 @@ export function isGuaranteedWinner(card, view, userId) {
     }
 
     // ── Condition 2: no opponent can trump it ─────────────────────────────────
-    let knownTeammateTrump = 0
-    if (view.knownLocations) {
-      const onPickerTeam = userId === view.picker || userId === view.partner
-      if (onPickerTeam) {
-        const teammateId = userId === view.picker ? view.partner : view.picker
-        if (teammateId) {
-          knownTeammateTrump = (view.knownLocations.get(teammateId) ?? []).filter(c => isTrump(c)).length
-        }
-      }
+    const playedOrBuriedIds = new Set()
+    for (const t of (view.tricks ?? [])) {
+      for (const p of t.plays) { if (p.card?.id) playedOrBuriedIds.add(p.card.id) }
     }
-    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) - knownTeammateTrump <= 0
+    for (const p of (view.currentTrick ?? [])) { if (p.card?.id) playedOrBuriedIds.add(p.card.id) }
+    for (const c of (view.buried ?? [])) { if (c?.id) playedOrBuriedIds.add(c.id) }
+    const knownTeammateTrump = knownTeammateCards(view, userId)
+      .filter(c => isTrump(c) && !playedOrBuriedIds.has(c.id))
+      .length
+    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) - knownTeammateTrump === 0
     if (!noTrumpElsewhere) {
       const voids = deducedTrumpVoids(view)
       const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)
@@ -315,15 +325,7 @@ export function isGuaranteedWinner(card, view, userId) {
   for (const c of (view.buried ?? [])) noteIfHigherTrump(c)
 
   // Also treat trump in a known teammate's hand as accounted for
-  if (view.knownLocations) {
-    const onPickerTeam = userId === view.picker || userId === view.partner
-    if (onPickerTeam) {
-      const teammateId = userId === view.picker ? view.partner : view.picker
-      if (teammateId) {
-        for (const c of (view.knownLocations.get(teammateId) ?? [])) noteIfHigherTrump(c)
-      }
-    }
-  }
+  for (const c of knownTeammateCards(view, userId)) noteIfHigherTrump(c)
 
   // Every rank strictly lower than myRank must be seen somewhere.
   for (let r = 0; r < myRank; r++) {

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -232,7 +232,7 @@ function knownTeammateCards(view, userId) {
 //
 // For trump cards: every trump with a strictly lower trumpRank index (i.e. higher
 //   strength) must be accounted for (visible in own hand, played tricks, current
-//   trick, or bury).
+//   trick, bury, or known to be in a teammate's hand via knownLocations).
 //
 // For non-trump (fail) cards: BOTH conditions must hold:
 //   1. Every same-suit non-trump card with a lower suitRank index (i.e. higher
@@ -243,7 +243,8 @@ function knownTeammateCards(view, userId) {
 //         accounted for after subtracting known teammate trump from knownLocations), OR
 //      b. Every other player is in the deducedTrumpVoids set.
 //
-// Unseen higher trump / higher same-suit cards are always treated as opponent-held.
+// Unseen higher trump / higher same-suit cards not in a known teammate's hand are
+// treated as opponent-held.
 //
 // NOTE — currentTrick is included in the "seen" sources. Callers should use this
 // function either (a) when leading (currentTrick is empty) or (b) when `card` is
@@ -325,7 +326,8 @@ export function isGuaranteedWinner(card, view, userId) {
   for (const play of (view.currentTrick ?? [])) noteIfHigherTrump(play.card)
   for (const c of (view.buried ?? [])) noteIfHigherTrump(c)
 
-  // Also treat trump in a known teammate's hand as accounted for
+  // Also treat trump in a known teammate's hand as accounted for.
+  // No played/buried filter needed: seenRanks is a Set so double-adding a rank is harmless.
   for (const c of knownTeammateCards(view, userId)) noteIfHigherTrump(c)
 
   // Every rank strictly lower than myRank must be seen somewhere.

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -304,6 +304,19 @@ export function isGuaranteedWinner(card, view, userId) {
   for (const play of (view.currentTrick ?? [])) noteIfHigherTrump(play.card)
   for (const c of (view.buried ?? [])) noteIfHigherTrump(c)
 
+  // Also treat trump in a known teammate's hand as accounted for
+  if (view.knownLocations) {
+    const onPickerTeam = userId === view.picker || userId === view.partner
+    if (onPickerTeam) {
+      const teammateId = userId === view.picker ? view.partner : view.picker
+      if (teammateId) {
+        for (const c of (view.knownLocations.get(teammateId) ?? [])) {
+          if (isTrump(c)) seenRanks.add(trumpRank(c))
+        }
+      }
+    }
+  }
+
   // Every rank strictly lower than myRank must be seen somewhere.
   for (let r = 0; r < myRank; r++) {
     if (!seenRanks.has(r)) return false

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -17,7 +17,8 @@ const BLITZ_CARDS = {
 export function knownCardLocations(view) {
   const map = new Map()
   for (const { userId, type } of (view.blitzes ?? [])) {
-    map.set(userId, [...(BLITZ_CARDS[type] ?? [])])
+    const cards = BLITZ_CARDS[type]
+    if (cards) map.set(userId, [...cards])
   }
   return map
 }

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -4,6 +4,30 @@
 
 import { isTrump, cardPoints, schwanzerCardPoints, effectiveSuit, trumpRank, suitRank } from './gameEngine.js'
 
+// ─── Public knowledge ─────────────────────────────────────────────────────────
+
+// Card objects for each blitz type. Blitz publicly reveals which queens the picker holds.
+const BLITZ_CARDS = {
+  black: [{ id: 'QC', rank: 'Q', suit: 'C' }, { id: 'QS', rank: 'Q', suit: 'S' }],
+  red:   [{ id: 'QH', rank: 'Q', suit: 'H' }, { id: 'QD', rank: 'Q', suit: 'D' }],
+}
+
+// Returns Map<userId, Array<card>> of cards known by public announcement to be in a player's hand.
+// Phase 1: populated from view.blitzes only.
+export function knownCardLocations(view) {
+  const map = new Map()
+  for (const { userId, type } of (view.blitzes ?? [])) {
+    map.set(userId, [...(BLITZ_CARDS[type] ?? [])])
+  }
+  return map
+}
+
+// Pre-computation wrapper. Returns { ...view, knownLocations } for use by all inference calls
+// in a single play decision. _userId is unused in Phase 1; included for Phase 2 API symmetry.
+export function resolveView(view, _userId) {
+  return { ...view, knownLocations: knownCardLocations(view) }
+}
+
 // ─── Trump tracking ───────────────────────────────────────────────────────────
 
 // Count trump cards visible in completed tricks and the current trick.

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -310,9 +310,7 @@ export function isGuaranteedWinner(card, view, userId) {
     if (onPickerTeam) {
       const teammateId = userId === view.picker ? view.partner : view.picker
       if (teammateId) {
-        for (const c of (view.knownLocations.get(teammateId) ?? [])) {
-          if (isTrump(c)) seenRanks.add(trumpRank(c))
-        }
+        for (const c of (view.knownLocations.get(teammateId) ?? [])) noteIfHigherTrump(c)
       }
     }
   }

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -888,57 +888,54 @@ describe('isGuaranteedWinner – blitz inference (trump case)', () => {
 })
 
 describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () => {
-  it('partner holds AH; 1 trump unaccounted for but known to be in picker hand via blitz → true', () => {
-    // Setup: 13 of 14 trump accounted for in tricks/own hand/buried; the 14th (QC) is the
-    // picker's black-blitzed card. trumpRemainingElsewhere = 1, but it is a teammate's card.
-    // Condition 1 (no higher same-suit card): AH is an ace → always satisfied.
-    // Condition 2 with blitz: knownTeammateTrump = 1, so 1 - 1 = 0 opponent trump → true.
+  it('partner holds AH; all trump accounted for except QC+QS (both in picker hand via blitz) → true', () => {
+    // Consistent state: p1 (picker) holds QC+QS (black blitz). p2 (partner) holds AH with 0 trump.
+    // 10 trump in tricks + 2 buried = 12. trumpRemainingElsewhere = 14 - 0 - 10 - 2 = 2 (QC+QS).
+    // knownTeammateTrump = 2 (both unplayed). 2 - 2 = 0 → no opponent trump → true.
     const ah = { id: 'AH', rank: 'A', suit: 'H' }
-    const qs = { id: 'QS', rank: 'Q', suit: 'S' }
     const view = {
       picker: 'p1',
       partner: 'p2',
-      blitzes: [{ userId: 'p1', type: 'black' }], // QC + QS known to p1
+      blitzes: [{ userId: 'p1', type: 'black' }],
       hands: {
-        p1: [{ id: 'HIDDEN', hidden: true }],
-        p2: [ah, qs],  // p2 holds AH (tested card) and QS (1 own trump)
+        p1: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p2: [ah],
         p3: [], p4: [], p5: [],
       },
-      tricks: [
-        {
-          plays: [
-            { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
-            { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
-            { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
-            { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
-            { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
-          ],
-        },
-        {
-          plays: [
-            { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
-            { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
-            { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
-            { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
-            { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
-          ],
-        },
-      ],
-      // Trump accounting for p2:
-      // ownTrump = 1 (QS). tricksPlayed = 10 (QH,QD,JC,JS,JH,JD,AD,10D,KD,9D). buried = 2 (8D,7D).
-      // trumpRemainingElsewhere = 14 - 1 - 10 - 2 = 1 (that 1 is QC, in picker's hand via blitz)
+      tricks: [{
+        plays: [
+          { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+          { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+          { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+          { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+          { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+        ],
+      }, {
+        plays: [
+          { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+          { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+          { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+          { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+          { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+        ],
+      }],
       currentTrick: [],
       buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
       isLeaster: false,
     }
-    // Plain view: 1 trump remaining, not all others trump-void → false
+    // Plain view: 2 trump remaining (QC+QS), not all others trump-void → false
     expect(isGuaranteedWinner(ah, view, 'p2')).toBe(false)
-    // Enriched view: that 1 trump is in teammate's hand → 0 opponent trump → true
+    // Enriched view: QC+QS known in teammate's hand, 2-2=0 opponent trump → true
     const rv = resolveView(view, 'p2')
     expect(isGuaranteedWinner(ah, rv, 'p2')).toBe(true)
   })
 
-  it('opponent bot does NOT benefit: same scenario, p3 holding AH → false even with resolveView', () => {
+  it('played blitzed queen is filtered out — AH is still NOT a guaranteed winner when opponent holds residual trump', () => {
+    // p1 black-blitzed (QC+QS). QC was played by p1 into a completed trick.
+    // QS is still in p1's hand. Some opponent holds 8D (unaccounted).
+    // trumpRemainingElsewhere = 14 - 0 - 10(tricks) - 2(buried) = 2 (QS + 8D)
+    // knownTeammateTrump = 1 (QC filtered because it's in tricks; QS unplayed → counts)
+    // 2 - 1 = 1 ≠ 0 → check voids → not all others void → false
     const ah = { id: 'AH', rank: 'A', suit: 'H' }
     const view = {
       picker: 'p1',
@@ -946,36 +943,70 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
       blitzes: [{ userId: 'p1', type: 'black' }],
       hands: {
         p1: [{ id: 'HIDDEN', hidden: true }],
+        p2: [ah],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [{
+        plays: [
+          { userId: 'p1', card: { id: 'QC', rank: 'Q', suit: 'C' } }, // picker plays blitzed QC
+          { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+          { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+          { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+          { userId: 'p2', card: { id: 'JS', rank: 'J', suit: 'S' } },
+        ],
+      }, {
+        plays: [
+          { userId: 'p3', card: { id: 'JH', rank: 'J', suit: 'H' } },
+          { userId: 'p4', card: { id: 'JD', rank: 'J', suit: 'D' } },
+          { userId: 'p5', card: { id: 'AD', rank: 'A', suit: 'D' } },
+          { userId: 'p1', card: { id: '10D', rank: '10', suit: 'D' } },
+          { userId: 'p2', card: { id: 'KD', rank: 'K', suit: 'D' } },
+        ],
+      }],
+      // 10 trump played. buried: 9D, 7D. trumpRemainingElsewhere = 14-0-10-2 = 2 (QS + 8D)
+      currentTrick: [],
+      buried: [{ id: '9D', rank: '9', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p2')
+    // QC already in tricks (filtered); QS not played (counted); 2-1=1 opponent trump remains → false
+    expect(isGuaranteedWinner(ah, rv, 'p2')).toBe(false)
+  })
+
+  it('opponent bot does NOT benefit: AH held by p3 → false even with resolveView', () => {
+    const ah = { id: 'AH', rank: 'A', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
         p2: [],
-        p3: [ah, { id: 'QS', rank: 'Q', suit: 'S' }],
+        p3: [ah],
         p4: [], p5: [],
       },
-      tricks: [
-        {
-          plays: [
-            { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
-            { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
-            { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
-            { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
-            { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
-          ],
-        },
-        {
-          plays: [
-            { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
-            { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
-            { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
-            { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
-            { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
-          ],
-        },
-      ],
+      tricks: [{
+        plays: [
+          { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+          { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+          { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+          { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+          { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+        ],
+      }, {
+        plays: [
+          { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+          { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+          { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+          { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+          { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+        ],
+      }],
       currentTrick: [],
       buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
       isLeaster: false,
     }
     const rv = resolveView(view, 'p3')
-    // p3 is opponent; QC in picker's hand is an opponent threat → still false
     expect(isGuaranteedWinner(ah, rv, 'p3')).toBe(false)
   })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids } from './botInference.js'
+import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids, knownCardLocations, resolveView } from './botInference.js'
 
 const c = (id, suit, rank) => ({ id, suit, rank })
 
@@ -716,5 +716,61 @@ describe('deducedNonTrumpVoids', () => {
     expect(result['p2']).toBeUndefined()   // hidden → no deduction
     expect(result['p3'] instanceof Set).toBe(true)
     expect(result['p3'].has('C')).toBe(true)
+  })
+})
+
+describe('knownCardLocations', () => {
+  it('no blitzes → empty Map', () => {
+    const view = { blitzes: [] }
+    expect(knownCardLocations(view).size).toBe(0)
+  })
+
+  it('black blitz → picker entry contains QC and QS card objects', () => {
+    const view = { blitzes: [{ userId: 'p1', type: 'black' }] }
+    const result = knownCardLocations(view)
+    expect(result.has('p1')).toBe(true)
+    const ids = result.get('p1').map(c => c.id)
+    expect(ids).toContain('QC')
+    expect(ids).toContain('QS')
+    expect(ids).toHaveLength(2)
+  })
+
+  it('red blitz → picker entry contains QH and QD card objects', () => {
+    const view = { blitzes: [{ userId: 'p1', type: 'red' }] }
+    const result = knownCardLocations(view)
+    expect(result.has('p1')).toBe(true)
+    const ids = result.get('p1').map(c => c.id)
+    expect(ids).toContain('QH')
+    expect(ids).toContain('QD')
+    expect(ids).toHaveLength(2)
+  })
+
+  it('missing blitzes field → empty Map', () => {
+    expect(knownCardLocations({}).size).toBe(0)
+  })
+})
+
+describe('resolveView', () => {
+  it('returns view with knownLocations populated from blitzes', () => {
+    const view = { blitzes: [{ userId: 'p1', type: 'black' }], hands: { p1: [], p2: [] } }
+    const rv = resolveView(view, 'p2')
+    expect(rv.knownLocations).toBeDefined()
+    expect(rv.knownLocations.has('p1')).toBe(true)
+    const ids = rv.knownLocations.get('p1').map(c => c.id)
+    expect(ids).toContain('QC')
+    expect(ids).toContain('QS')
+  })
+
+  it('other view fields are unchanged', () => {
+    const view = { blitzes: [], hands: { p1: [], p2: [] }, picker: 'p1' }
+    const rv = resolveView(view, 'p2')
+    expect(rv.picker).toBe('p1')
+    expect(rv.hands).toBe(view.hands)
+  })
+
+  it('no blitzes → knownLocations is an empty Map', () => {
+    const view = { blitzes: [], hands: {} }
+    const rv = resolveView(view, 'p1')
+    expect(rv.knownLocations.size).toBe(0)
   })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -857,6 +857,7 @@ describe('isGuaranteedWinner – blitz inference (trump case)', () => {
   })
 
   it('combined blitz — picker black-blitzed and partner red-blitzed: JC is guaranteed winner for picker', () => {
+    // NOTE: artificial test state — in real games only the picker can blitz, not the partner.
     // Picker (p1) holds JC (rank 4). QC(0)+QS(1) in p1's hand via own-black-blitz would not appear
     // in knownLocations since knownLocations tracks the teammate, not self.
     // But QH(2)+QD(3) are in partner's (p2's) hand via red-blitz → teammate known cards.
@@ -1011,6 +1012,7 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
   })
 
   it('picker holds fail ace; partner known-trump accounts for all remaining trump → true', () => {
+    // NOTE: artificial test state — in real games only the picker can blitz, not the partner.
     // Exercises the picker-as-bot path in knownTeammateCards (teammateId = view.partner).
     // Using artificial partner blitz (invalid in real games) to populate knownLocations for p2.
     // p1 (picker) holds AC. p2's "blitz" puts QH+QD in knownLocations.
@@ -1054,5 +1056,53 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
     const rv = resolveView(view, 'p1')
     expect(isGuaranteedWinner(ac, view, 'p1')).toBe(false)  // plain view: 2 trump remaining → false
     expect(isGuaranteedWinner(ac, rv, 'p1')).toBe(true)     // enriched: partner holds those 2 → true
+  })
+
+  it('blitzed queen played in currentTrick is filtered — does not over-subtract from knownTeammateTrump', () => {
+    // Picker black-blitzed (QC+QS). Picker plays QC as first card of the current trick.
+    // Partner (p2) holds AH. One opponent (unknown) still has an unplayed trump (8D).
+    // QC in currentTrick → filtered from knownTeammateTrump → knownTeammateTrump = 1 (QS only).
+    // trumpRemainingElsewhere = 14 - 0 - 10(tricks+currentTrick) - 2(buried) = 2 (QS + 8D).
+    // Without the filter: knownTeammateTrump=2 (QC+QS) → 2-2=0 (incorrectly true).
+    // With the filter: knownTeammateTrump=1 (QC filtered) → 2-1=1 → false (correct, opponent has 8D).
+    const ah = { id: 'AH', rank: 'A', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }],
+        p2: [ah],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [{
+        plays: [
+          { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+          { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+          { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+          { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+          { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+        ],
+      }, {
+        plays: [
+          { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+          { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+          { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+          { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+          { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+        ],
+      }],
+      currentTrick: [
+        { userId: 'p1', card: { id: 'QC', rank: 'Q', suit: 'C' } },
+      ],
+      buried: [{ id: '8D', rank: '8', suit: 'D' }],
+      isLeaster: false,
+    }
+    // Without resolveView: trumpRemainingElsewhere=2, not all void → false
+    expect(isGuaranteedWinner(ah, view, 'p2')).toBe(false)
+    const rv = resolveView(view, 'p2')
+    // With resolveView: QC in currentTrick (filtered), QS unplayed (counted); 2-1=1 opponent trump remains → false.
+    // (An opponent still holds 8D — AH is correctly identified as NOT a guaranteed winner.)
+    expect(isGuaranteedWinner(ah, rv, 'p2')).toBe(false)
   })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -786,3 +786,73 @@ describe('resolveView', () => {
     expect(rv.knownLocations.size).toBe(0)
   })
 })
+
+describe('isGuaranteedWinner – blitz inference (trump case)', () => {
+  it('partner holds QH; picker black-blitzed (QC+QS); neither played → true with resolveView', () => {
+    // Without blitz inference: QC and QS are unaccounted for → false.
+    // With resolveView: QC and QS are known to be in teammate's (picker's) hand → true.
+    const qh = { id: 'QH', rank: 'Q', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p2: [qh],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+      isLeaster: false,
+    }
+    // Plain view: QC (rank 0) and QS (rank 1) unseen → false
+    expect(isGuaranteedWinner(qh, view, 'p2')).toBe(false)
+    // Enriched view: QC and QS known in teammate's hand → true
+    const rv = resolveView(view, 'p2')
+    expect(isGuaranteedWinner(qh, rv, 'p2')).toBe(true)
+  })
+
+  it('opponent bot does NOT benefit from blitz: QH is false for p3 regardless of resolveView', () => {
+    const qh = { id: 'QH', rank: 'Q', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p2: [], p3: [qh], p4: [], p5: [],
+      },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p3')
+    // p3 is an opponent; picker's blitzed queens are opponent threats → still false
+    expect(isGuaranteedWinner(qh, rv, 'p3')).toBe(false)
+  })
+
+  it('picker holds QS; partner red-blitzed (QH+QD in partner hand); QC still unaccounted → QS false for picker', () => {
+    // Picker (p1) holds QS (rank 1). Partner (p2) declared red blitz (QH+QD in p2's hand).
+    // QC (rank 0) is still unaccounted for and NOT in a teammate's known cards → false.
+    const qs = { id: 'QS', rank: 'Q', suit: 'S' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p2', type: 'red' }],
+      hands: {
+        p1: [qs],
+        p2: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p1')
+    // QC (rank 0) still unaccounted for → false
+    expect(isGuaranteedWinner(qs, rv, 'p1')).toBe(false)
+  })
+})

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -748,6 +748,18 @@ describe('knownCardLocations', () => {
   it('missing blitzes field → empty Map', () => {
     expect(knownCardLocations({}).size).toBe(0)
   })
+
+  it('multiple blitzes → separate entries per userId', () => {
+    const view = { blitzes: [
+      { userId: 'p1', type: 'black' },
+      { userId: 'p2', type: 'red' },
+    ] }
+    const result = knownCardLocations(view)
+    expect(result.has('p1')).toBe(true)
+    expect(result.has('p2')).toBe(true)
+    expect(result.get('p1').map(c => c.id)).toContain('QC')
+    expect(result.get('p2').map(c => c.id)).toContain('QH')
+  })
 })
 
 describe('resolveView', () => {

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -855,4 +855,34 @@ describe('isGuaranteedWinner – blitz inference (trump case)', () => {
     // QC (rank 0) still unaccounted for → false
     expect(isGuaranteedWinner(qs, rv, 'p1')).toBe(false)
   })
+
+  it('combined blitz — picker black-blitzed and partner red-blitzed: JC is guaranteed winner for picker', () => {
+    // Picker (p1) holds JC (rank 4). QC(0)+QS(1) in p1's hand via own-black-blitz would not appear
+    // in knownLocations since knownLocations tracks the teammate, not self.
+    // But QH(2)+QD(3) are in partner's (p2's) hand via red-blitz → teammate known cards.
+    // QC(0), QS(1) are in p1's own hand (visible), so seenRanks covers them from the hands loop.
+    // QH(2), QD(3) come from knownLocations (teammate p2). All four higher-rank trump accounted for → true.
+    const jc = { id: 'JC', rank: 'J', suit: 'C' }
+    const qc = { id: 'QC', rank: 'Q', suit: 'C' }
+    const qs = { id: 'QS', rank: 'Q', suit: 'S' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [
+        { userId: 'p1', type: 'black' },
+        { userId: 'p2', type: 'red' },
+      ],
+      hands: {
+        p1: [jc, qc, qs],
+        p2: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [],
+      currentTrick: [],
+      buried: [],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p1')
+    expect(isGuaranteedWinner(jc, rv, 'p1')).toBe(true)
+  })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -1009,4 +1009,50 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
     const rv = resolveView(view, 'p3')
     expect(isGuaranteedWinner(ah, rv, 'p3')).toBe(false)
   })
+
+  it('picker holds fail ace; partner known-trump accounts for all remaining trump → true', () => {
+    // Exercises the picker-as-bot path in knownTeammateCards (teammateId = view.partner).
+    // Using artificial partner blitz (invalid in real games) to populate knownLocations for p2.
+    // p1 (picker) holds AC. p2's "blitz" puts QH+QD in knownLocations.
+    // All other trump accounted for in tricks. trumpRemainingElsewhere = 2 (QH+QD in partner hand).
+    // knownTeammateTrump = 2 → 2-2=0 → true.
+    const ac = { id: 'AC', rank: 'A', suit: 'C' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p2', type: 'red' }], // artificial: partner declares red blitz (QH+QD)
+      hands: {
+        p1: [ac],
+        p2: [{ id: 'HIDDEN', hidden: true }, { id: 'HIDDEN', hidden: true }],
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [{
+        plays: [
+          { userId: 'p3', card: { id: 'QC', rank: 'Q', suit: 'C' } },
+          { userId: 'p4', card: { id: 'QS', rank: 'Q', suit: 'S' } },
+          { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+          { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+          { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+        ],
+      }, {
+        plays: [
+          { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+          { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+          { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+          { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+          { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+        ],
+      }],
+      // Own trump (p1): 0. Tricks: 10. Buried: 2.
+      // trumpRemainingElsewhere = 14 - 0 - 10 - 2 = 2 (QH+QD in p2's known hand).
+      // knownTeammateCards(p1) → knownLocations.get(view.partner='p2') → [QH, QD].
+      // QH and QD not in tricks/buried → knownTeammateTrump = 2. 2-2=0 → true.
+      currentTrick: [],
+      buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p1')
+    expect(isGuaranteedWinner(ac, view, 'p1')).toBe(false)  // plain view: 2 trump remaining → false
+    expect(isGuaranteedWinner(ac, rv, 'p1')).toBe(true)     // enriched: partner holds those 2 → true
+  })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -886,3 +886,96 @@ describe('isGuaranteedWinner – blitz inference (trump case)', () => {
     expect(isGuaranteedWinner(jc, rv, 'p1')).toBe(true)
   })
 })
+
+describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () => {
+  it('partner holds AH; 1 trump unaccounted for but known to be in picker hand via blitz → true', () => {
+    // Setup: 13 of 14 trump accounted for in tricks/own hand/buried; the 14th (QC) is the
+    // picker's black-blitzed card. trumpRemainingElsewhere = 1, but it is a teammate's card.
+    // Condition 1 (no higher same-suit card): AH is an ace → always satisfied.
+    // Condition 2 with blitz: knownTeammateTrump = 1, so 1 - 1 = 0 opponent trump → true.
+    const ah = { id: 'AH', rank: 'A', suit: 'H' }
+    const qs = { id: 'QS', rank: 'Q', suit: 'S' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }], // QC + QS known to p1
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }],
+        p2: [ah, qs],  // p2 holds AH (tested card) and QS (1 own trump)
+        p3: [], p4: [], p5: [],
+      },
+      tricks: [
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+            { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+            { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+            { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+            { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+            { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+            { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+            { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+            { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+          ],
+        },
+      ],
+      // Trump accounting for p2:
+      // ownTrump = 1 (QS). tricksPlayed = 10 (QH,QD,JC,JS,JH,JD,AD,10D,KD,9D). buried = 2 (8D,7D).
+      // trumpRemainingElsewhere = 14 - 1 - 10 - 2 = 1 (that 1 is QC, in picker's hand via blitz)
+      currentTrick: [],
+      buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
+      isLeaster: false,
+    }
+    // Plain view: 1 trump remaining, not all others trump-void → false
+    expect(isGuaranteedWinner(ah, view, 'p2')).toBe(false)
+    // Enriched view: that 1 trump is in teammate's hand → 0 opponent trump → true
+    const rv = resolveView(view, 'p2')
+    expect(isGuaranteedWinner(ah, rv, 'p2')).toBe(true)
+  })
+
+  it('opponent bot does NOT benefit: same scenario, p3 holding AH → false even with resolveView', () => {
+    const ah = { id: 'AH', rank: 'A', suit: 'H' }
+    const view = {
+      picker: 'p1',
+      partner: 'p2',
+      blitzes: [{ userId: 'p1', type: 'black' }],
+      hands: {
+        p1: [{ id: 'HIDDEN', hidden: true }],
+        p2: [],
+        p3: [ah, { id: 'QS', rank: 'Q', suit: 'S' }],
+        p4: [], p5: [],
+      },
+      tricks: [
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'QH', rank: 'Q', suit: 'H' } },
+            { userId: 'p4', card: { id: 'QD', rank: 'Q', suit: 'D' } },
+            { userId: 'p5', card: { id: 'JC', rank: 'J', suit: 'C' } },
+            { userId: 'p1', card: { id: 'JS', rank: 'J', suit: 'S' } },
+            { userId: 'p2', card: { id: 'JH', rank: 'J', suit: 'H' } },
+          ],
+        },
+        {
+          plays: [
+            { userId: 'p3', card: { id: 'JD', rank: 'J', suit: 'D' } },
+            { userId: 'p4', card: { id: 'AD', rank: 'A', suit: 'D' } },
+            { userId: 'p5', card: { id: '10D', rank: '10', suit: 'D' } },
+            { userId: 'p1', card: { id: 'KD', rank: 'K', suit: 'D' } },
+            { userId: 'p2', card: { id: '9D', rank: '9', suit: 'D' } },
+          ],
+        },
+      ],
+      currentTrick: [],
+      buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
+      isLeaster: false,
+    }
+    const rv = resolveView(view, 'p3')
+    // p3 is opponent; QC in picker's hand is an opponent threat → still false
+    expect(isGuaranteedWinner(ah, rv, 'p3')).toBe(false)
+  })
+})

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -290,12 +290,12 @@ export function decidePlay(view, userId) {
   // Under card is the only option
   if (realCards.length === 0) return 'UNDER_CARD'
 
-  const rv = resolveView(view, userId)
-
   const { currentTrick, picker, partner, isLeaster } = view
 
   // Leaster: minimise trick-taking; play lowest value card
   if (isLeaster) return lowestCard(realCards).id
+
+  const rv = resolveView(view, userId)
 
   const isLeading = !currentTrick || currentTrick.length === 0
   // `view.partner` is set on picker-team views (the picker sees the partner;

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner, deducedNonTrumpVoids } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner, deducedNonTrumpVoids, resolveView } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -290,6 +290,8 @@ export function decidePlay(view, userId) {
   // Under card is the only option
   if (realCards.length === 0) return 'UNDER_CARD'
 
+  const rv = resolveView(view, userId)
+
   const { currentTrick, picker, partner, isLeaster } = view
 
   // Leaster: minimise trick-taking; play lowest value card
@@ -306,7 +308,7 @@ export function decidePlay(view, userId) {
     if (isPickerTeam) {
       // Cash any guaranteed non-trump winner: play highest-value first
       const guaranteedFails = realCards
-        .filter(c => !isTrump(c) && isGuaranteedWinner(c, view, userId))
+        .filter(c => !isTrump(c) && isGuaranteedWinner(c, rv, userId))
         .sort((a, b) => cardPoints(b) - cardPoints(a))
       if (guaranteedFails.length > 0) return guaranteedFails[0].id
       // Lead strongest trump to win tricks and accumulate points.
@@ -316,7 +318,7 @@ export function decidePlay(view, userId) {
       if (best) {
         if (userId === partner) {
           const fails = realCards.filter(c => !isTrump(c))
-          if (realCards.filter(c => isTrump(c)).length >= 2 && fails.length > 0 && !isGuaranteedWinner(best, view, userId)) {
+          if (realCards.filter(c => isTrump(c)).length >= 2 && fails.length > 0 && !isGuaranteedWinner(best, rv, userId)) {
             return lowestCard(fails).id
           }
         }
@@ -342,7 +344,7 @@ export function decidePlay(view, userId) {
       {
         const allIds = Object.keys(view.hands)
         const opponentIds = allIds.filter(id => id !== picker && id !== partner)
-        const nonTrumpVoids = deducedNonTrumpVoids(view)
+        const nonTrumpVoids = deducedNonTrumpVoids(rv)
         const failCards = realCards.filter(c => !isTrump(c))
         const safeFails = failCards.filter(card => {
           const suit = effectiveSuit(card)
@@ -357,7 +359,7 @@ export function decidePlay(view, userId) {
         const { calledAce, calledTen, calledKing } = view
         const calledCardId = calledAce?.aceId ?? calledTen?.tenId ?? calledKing?.kingId
         const guaranteedFails = realCards
-          .filter(c => !isTrump(c) && c.id !== calledCardId && isGuaranteedWinner(c, view, userId))
+          .filter(c => !isTrump(c) && c.id !== calledCardId && isGuaranteedWinner(c, rv, userId))
           .sort((a, b) => cardPoints(b) - cardPoints(a))
         if (guaranteedFails.length > 0) return guaranteedFails[0].id
       }
@@ -365,7 +367,7 @@ export function decidePlay(view, userId) {
       // skipped if partner identity is already known from public information (crack/recrack/elimination).
       const { calledSuit } = view
       const nonTrump = realCards.filter(c => !isTrump(c))
-      if (deducedPartner(view, userId) === null && calledSuit) {
+      if (deducedPartner(rv, userId) === null && calledSuit) {
         const calledSuitCards = nonTrump.filter(c => effectiveSuit(c) === calledSuit)
         if (calledSuitCards.length > 0) return lowestCard(calledSuitCards).id
       }
@@ -375,9 +377,9 @@ export function decidePlay(view, userId) {
       {
         const { calledAce: ca, calledTen: ct, calledKing: ck } = view
         const calledCardId = ca?.aceId ?? ct?.tenId ?? ck?.kingId
-        const knownPartner = deducedPartner(view, userId)
+        const knownPartner = deducedPartner(rv, userId)
         if (knownPartner !== null) {
-          const nonTrumpVoids = deducedNonTrumpVoids(view)
+          const nonTrumpVoids = deducedNonTrumpVoids(rv)
           const pickerTeamIds = [picker, knownPartner].filter(Boolean)
           // Candidate fail cards: non-trump, not the called card
           const failLeads = nonTrump.filter(c => c.id !== calledCardId)
@@ -402,7 +404,7 @@ export function decidePlay(view, userId) {
   if (isPickerTeam) {
     // Schmear: dump highest-point non-trump on teammate's winning trick,
     // unless an opponent still to play could trump over the teammate.
-    if (teammateWinning(view, userId)) {
+    if (teammateWinning(rv, userId)) {
       const schmear = () => {
         const nonTrump = realCards.filter(c => !isTrump(c))
         // Pass the bot's full hand (not realCards) so the suit-count tiebreak counts
@@ -419,7 +421,7 @@ export function decidePlay(view, userId) {
       ).length
 
       const teammateSafe = opponentsRemainingLocal === 0 ||
-        isGuaranteedWinner(winnerPlay.card, view, userId)
+        isGuaranteedWinner(winnerPlay.card, rv, userId)
 
       if (teammateSafe) return schmear()
 
@@ -437,7 +439,7 @@ export function decidePlay(view, userId) {
         }
         return true
       })
-      const takeover = cheapestGuaranteedWin(winningLocal, view, userId)
+      const takeover = cheapestGuaranteedWin(winningLocal, rv, userId)
       if (takeover) return takeover.id
       const highTrump = highestTrump(winningLocal)
       if (highTrump) return highTrump.id  // risk reduction
@@ -464,7 +466,7 @@ export function decidePlay(view, userId) {
         // all nonTrumpWins are the same suit, so if the highest-value card isn't
         // guaranteed (a higher same-suit rank is unaccounted for), none of them are.
         const safeFromTrumpIn = opponentsRemainingNT === 0 ||
-          isGuaranteedWinner(bestNonTrumpWin, view, userId)
+          isGuaranteedWinner(bestNonTrumpWin, rv, userId)
         if (safeFromTrumpIn) {
           return bestNonTrumpWin.id
         }
@@ -481,14 +483,14 @@ export function decidePlay(view, userId) {
       if (ledSuit === 'T') {
         // Scenario 1: Trump trick
         if (opponentsRemaining === 0) return cheapestWinningTrump(winning).id
-        const guaranteed = cheapestGuaranteedWin(winning, view, userId)
+        const guaranteed = cheapestGuaranteedWin(winning, rv, userId)
         if (guaranteed) return guaranteed.id
         return highestTrump(winning).id
       }
 
       // Scenario 2: Fail trick, bot is void, playing trump to contest the lead
       if (userId === picker) {
-        const guaranteed = cheapestGuaranteedWin(winning, view, userId)
+        const guaranteed = cheapestGuaranteedWin(winning, rv, userId)
         if (guaranteed) return guaranteed.id
         return highestTrump(winning).id
       }
@@ -505,7 +507,7 @@ export function decidePlay(view, userId) {
         }
         // Exactly 1 trump: only spend it if guaranteed to win the trick.
         const myOnlyTrump = realCards.find(c => isTrump(c))
-        if (myOnlyTrump && isGuaranteedWinner(myOnlyTrump, view, userId)) {
+        if (myOnlyTrump && isGuaranteedWinner(myOnlyTrump, rv, userId)) {
           return myOnlyTrump.id
         }
         return lowestCard(realCards).id
@@ -513,7 +515,7 @@ export function decidePlay(view, userId) {
 
       // Picker has played but is not winning (schmear intercepts picker-winning case).
       if (myTrumpCount > 1) {
-        const guaranteed = cheapestGuaranteedWin(winning, view, userId)
+        const guaranteed = cheapestGuaranteedWin(winning, rv, userId)
         if (guaranteed) return guaranteed.id
         return highestTrump(winning).id
       }
@@ -530,7 +532,7 @@ export function decidePlay(view, userId) {
   } else {
     // Opponent: schmear on confirmed teammate wins — unless picker-team still to play
     // could trump over the teammate, in which case attempt a guaranteed takeover.
-    if (teammateWinning(view, userId)) {
+    if (teammateWinning(rv, userId)) {
       const schmearOpp = () => {
         const nonTrump = realCards.filter(c => !isTrump(c))
         const pick = pickBySchmearPriority(nonTrump, 'fail', view.hands[userId])
@@ -541,13 +543,13 @@ export function decidePlay(view, userId) {
       const playedIdsOpp = new Set(currentTrick.map(p => p.userId))
       const allIdsOpp = Object.keys(view.hands)
       // From opponent POV, "threats" (could overtake teammate) = picker + partner still to play.
-      const deducedOpp = deducedPartner(view, userId)
+      const deducedOpp = deducedPartner(rv, userId)
       const threatsRemaining = allIdsOpp.filter(id =>
         !playedIdsOpp.has(id) && id !== userId && (id === picker || id === deducedOpp)
       ).length
 
       const teammateSafe = threatsRemaining === 0 ||
-        isGuaranteedWinner(winnerPlay.card, view, userId)
+        isGuaranteedWinner(winnerPlay.card, rv, userId)
 
       if (teammateSafe) return schmearOpp()
 
@@ -558,7 +560,7 @@ export function decidePlay(view, userId) {
         }
         return true
       })
-      const takeover = cheapestGuaranteedWin(winningOpp, view, userId)
+      const takeover = cheapestGuaranteedWin(winningOpp, rv, userId)
       if (takeover) return takeover.id
 
       // Predicted-win override (#163): when the called suit was led by a fellow
@@ -594,7 +596,7 @@ export function decidePlay(view, userId) {
 
       // Skipped if partner has already been deduced from public information —
       // the lead-back goal (flush the unknown partner) is then moot.
-      if (deducedPartner(view, userId) === null && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
+      if (deducedPartner(rv, userId) === null && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
         const winningSet = realCards.filter(card => {
           for (const play of currentTrick) {
             if (!beats(card, play.card, ledSuit)) return false
@@ -652,7 +654,7 @@ export function decidePlay(view, userId) {
     // points along with the partner's high card.
     if (!isTrump(currentTrick[0].card)) {
       const winner = currentWinner(currentTrick)
-      const deducedForPredicted = deducedPartner(view, userId)
+      const deducedForPredicted = deducedPartner(rv, userId)
       const pickerTeamWinning = winner && (winner.userId === picker || winner.userId === deducedForPredicted)
       const { calledSuit, partnerRevealed } = view
       const calledSuitLedUnrevealed = !partnerRevealed && !!calledSuit && ledSuit === calledSuit


### PR DESCRIPTION
## Summary
- Adds `knownCardLocations(view)` and `resolveView(view, userId)` to `botInference.js` — a pre-computation layer that encodes public blitz declarations into `knownLocations: Map<userId, Array<card>>`
- Extends `isGuaranteedWinner` to treat trump in a known teammate's hand as accounted for (both trump case and fail-card condition 2), so the partner bot correctly identifies guaranteed winners when the picker has declared a blitz
- Wires `resolveView` into `decidePlay` in `botStrategy.js` so all downstream inference calls automatically benefit

## Test Plan
- [ ] 357 backend tests pass (`npx vitest run`)
- [ ] 8 frontend tests pass (`npm test -w frontend`)
- [ ] Partner bot holding QH correctly identifies it as a guaranteed winner when picker black-blitzed (QC+QS in picker's hand)
- [ ] Opponent bots are unaffected — blitzed queens in an opponent's hand remain threats
- [ ] Already-played blitzed queens are correctly filtered and do not over-subtract from `trumpRemainingElsewhere`

🤖 Generated with [Claude Code](https://claude.com/claude-code)