### PR TITLE
fix(inference): schmear to teammate when picker goes alone

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -140,7 +140,9 @@ A recurring concept below is a **guaranteed winner**: a card the bot holds that 
 3. **Can't win**: on a trump-led trick, shed the *weakest* trump (highest rank index — least future utility), using points as a secondary tiebreak. On a fail-led trick where no card can win, play the lowest card.
 
 #### Opponent bot following
-1. **Schmear** (a confirmed teammate — partner identity is known directly or by deduction — is currently winning):
+1. **Schmear** (a confirmed teammate is currently winning):
+   - Teammate identity rules: (a) if a partner identity has been deduced from public information, any non-picker-team winner is a teammate; (b) if the **picker went alone** (`goingAlone === true`), any non-picker winner is automatically a teammate (there is no partner to flush out); (c) if the partner is still unknown in a normal call, teammate status cannot be confirmed — skip the schmear branch.
+
    - **Safe** (no picker or partner remains to play, or the teammate's winning card is itself a guaranteed winner): dump the highest-priority non-trump per the **schmear priority** (see below). If only trump available, play the lowest card.
    - **Not safe**: if the bot can take the trick with a guaranteed-winning card, play the lowest-point such card. Else, if the **picker-team overtake is forced** (called suit led, called card not yet played this trick, no trump played in this trick yet), fall through to the trump-in branch below — the partner's forced called card will overtake any current fail-suit winner, so schmearing high points just donates them to the picker team. Otherwise schmear anyway — no speculative trump burn when a guaranteed takeover isn't available.
 2. **Force-take to enable called-suit lead-back**: When the partner is **not yet known** (neither revealed nor deducible), the current trick is **not** led with the called suit, the bot holds **at least one non-trump card of the called suit** in hand (a card that can be led back next trick), and the bot can take the current trick:

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -417,7 +417,7 @@ export function knownNonPartners(view, userId) {
 //
 // Returns null in alone/leaster/no-picker modes regardless of signals.
 export function deducedPartner(view, userId) {
-  if (!view.picker || view.callMode === 'alone' || view.isLeaster) return null
+  if (!view.picker || view.goingAlone || view.isLeaster) return null
   if (view.partner) return view.partner
   if (view.recrackerId && view.recrackerId !== view.picker) return view.recrackerId
 
@@ -449,7 +449,11 @@ export function teammateWinning(view, userId) {
   if (onPickerTeam) {
     return winnerId === picker || winnerId === partner
   } else {
-    if (partner === null) return false
+    if (partner === null) {
+      // When picker went alone there is no partner — any non-picker winner is a teammate.
+      if (view.goingAlone) return winnerId !== picker
+      return false  // partner identity unknown — cannot confirm teammate
+    }
     return winnerId !== picker && winnerId !== partner
   }
 }

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -152,8 +152,8 @@ describe('deducedPartner', () => {
     expect(deducedPartner(view, 'p3')).toBeNull()
   })
 
-  it('returns null when picker goes alone (callMode === alone)', () => {
-    const view = baseView({ callMode: 'alone', calledSuit: null, calledAce: null, recrackerId: 'p2' })
+  it('returns null when picker goes alone (goingAlone === true)', () => {
+    const view = baseView({ goingAlone: true, calledSuit: null, calledAce: null, recrackerId: 'p2' })
     expect(deducedPartner(view, 'p3')).toBeNull()
   })
 

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1681,6 +1681,30 @@ describe('teammateWinning', () => {
     expect(teammateWinning(view, 'p3')).toBe(false)
   })
 
+  it('returns true when fellow opponent is winning and picker went alone', () => {
+    const view = {
+      currentTrick: [{ userId: 'p3', card: c('A','S') }],
+      picker: 'p1',
+      partner: null,
+      goingAlone: true,
+      isLeaster: false,
+    }
+    // p4 is an opponent; p3 (non-picker) is winning → teammate
+    expect(teammateWinning(view, 'p4')).toBe(true)
+  })
+
+  it('returns false when picker is winning and picker went alone', () => {
+    const view = {
+      currentTrick: [{ userId: 'p1', card: c('Q','C') }],
+      picker: 'p1',
+      partner: null,
+      goingAlone: true,
+      isLeaster: false,
+    }
+    // picker winning → not a teammate for p4
+    expect(teammateWinning(view, 'p4')).toBe(false)
+  })
+
   it('returns false when trick is empty (leading)', () => {
     const view = {
       currentTrick: [],
@@ -1977,6 +2001,24 @@ describe('decidePlay schmearing', () => {
       handCards: [c('A','S'), c('K','S'), c('9','S'), c('A','C')],
     })
     expect(decidePlay(view, 'p3')).toBe('AC')
+  })
+
+  it('opponent schmears 10H to fellow opponent winning when picker went alone', () => {
+    // Picker (p1) went alone. p3 is winning with AC (11 pts, clubs lead).
+    // Bot p4 has 10H (10 pts, fail) and 9S (0 pts, fail) — no clubs, so any card is legal.
+    // teammateWinning should be true (p3 is non-picker → teammate) → schmearOpp → 10H.
+    const view = {
+      ...makeFollowView({
+        userId: 'p4',
+        picker: 'p1',
+        partner: null,
+        trickWinner: 'p3',
+        trickCard: c('A','C'),
+        handCards: [c('10','H'), c('9','S')],
+      }),
+      goingAlone: true,
+    }
+    expect(decidePlay(view, 'p4')).toBe('10H')
   })
 })
 


### PR DESCRIPTION
## Summary
- `teammateWinning()` returned `false` whenever `deducedPartner()` was null, conflating "partner unknown" with "picker went alone." When `goingAlone` is true, any non-picker winner is a teammate — the schmear branch now fires correctly instead of falling through to `lowestCard`.
- Discovered that `deducedPartner()` was checking `view.callMode === 'alone'`, a string the game engine never sets (`goAlone()` uses `goingAlone: true`). Both inference functions now read `view.goingAlone`, matching the actual state shape from `getPlayerView`.
- Updated the fabricated `callMode: 'alone'` test in `botInference.test.js` to use `goingAlone: true`.

## Test plan
- [ ] New unit tests: `teammateWinning` returns `true` when fellow opponent is winning and `goingAlone: true`; returns `false` when picker is winning and `goingAlone: true`
- [ ] New integration test: `decidePlay` recommends `10H` (schmear) to a fellow opponent's winning trick when picker went alone
- [ ] All 360 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)