### PR TITLE
feat(inference): pre-compute shared inference state in resolveView (#176)

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -197,7 +197,7 @@ of bot team.
 | Function | Purpose |
 |---|---|
 | `knownCardLocations` | Returns `Map<userId, Array<card>>` of card objects known by public announcement to be in a player's hand. Phase 1: populated from `view.blitzes` — black blitz → picker holds QC + QS; red blitz → picker holds QH + QD. |
-| `resolveView` | Pre-computation wrapper called once per play decision in `decidePlay`. Returns `{ ...view, knownLocations }`. All downstream inference calls receive the enriched view. Phase 2 (#176) will add more pre-computed fields. |
+| `resolveView` | Pre-computation wrapper called once per play decision in `decidePlay`. Returns the view enriched with: `knownLocations` (card locations from blitz declarations), `resolvedPartner` (inferred partner userId or null — distinct from engine-set `view.partner`), `resolvedTrumpVoids` (Set of userIds with no trump remaining), `resolvedNonTrumpVoids` (map of userId → Set of fail suits they cannot follow), and `resolvedTrumpRemaining` (integer count of trump still held by other players). All downstream inference calls receive the enriched view. |
 | `countTrumpPlayed` | Count visible trump in completed tricks and the current trick |
 | `trumpRemainingElsewhere` | Estimate trump still held by other players: `14 − own trump − seen trump − buried trump` |
 | `handScore` | Combined pick-quality score: `schwanzerPts × 4 + 3×(non-trump aces) + 2×(non-trump tens) + 5 if QC held` |

--- a/docs/superpowers/plans/2026-05-02-resolveview-precompute-inference.md
+++ b/docs/superpowers/plans/2026-05-02-resolveview-precompute-inference.md
@@ -1,0 +1,382 @@
+# resolveView Pre-compute Inference State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extend `resolveView` to pre-compute `resolvedPartner`, `trumpVoids`, `nonTrumpVoids`, and `resolvedTrumpRemaining` once per play decision, then replace all redundant inline calls in `botStrategy.js` and `isGuaranteedWinner` with property reads.
+
+**Architecture:** `resolveView` in `botInference.js` calls the four helpers once and attaches results to the view object. `isGuaranteedWinner` reads `view.trumpVoids` and `view.resolvedTrumpRemaining` directly instead of calling the helpers internally. `botStrategy.js` reads `rv.resolvedPartner` and `rv.nonTrumpVoids` instead of calling helpers inline.
+
+**Tech Stack:** JavaScript (ES modules), Vitest
+
+---
+
+## File Map
+
+- **Modify:** `shared/botInference.js` — extend `resolveView` (lines 28–30), update `isGuaranteedWinner` internals (lines 302–307)
+- **Modify:** `shared/botInference.test.js` — add 5 new `resolveView` tests; wrap ~11 Group 1 plain-view `isGuaranteedWinner` calls with `resolveView`; delete 4 Group 2 "without resolveView" first-assertions (now unrepresentable)
+- **Modify:** `shared/botStrategy.js` — replace 5 `deducedPartner` calls + 2 `deducedNonTrumpVoids` calls with `rv.*` reads; clean imports
+- **Modify:** `docs/BOTS.md` — update `resolveView` entry at line 200
+
+---
+
+## Task 1: Extend `resolveView` with the four new pre-computed fields
+
+**Files:**
+- Modify: `shared/botInference.js:28-30`
+- Modify: `shared/botInference.test.js` (after the existing `resolveView` describe block at line 765)
+
+- [ ] **Step 1: Add `trumpRemainingElsewhere` to the import in `botInference.test.js`**
+
+Current line 2:
+```js
+import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids, knownCardLocations, resolveView } from './botInference.js'
+```
+
+Replace with:
+```js
+import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids, knownCardLocations, resolveView, trumpRemainingElsewhere } from './botInference.js'
+```
+
+- [ ] **Step 2: Write the failing tests for the new resolveView fields**
+
+Add this new `describe` block immediately after the closing `})` of the existing `describe('resolveView', ...)` block (currently ending around line 788):
+
+```js
+describe('resolveView pre-computed inference fields', () => {
+  const buildView = () => ({
+    blitzes: [],
+    picker: 'p1',
+    goingAlone: false,
+    isLeaster: false,
+    partner: null,
+    recrackerId: null,
+    hands: { p1: [], p2: [], p3: [], p4: [], p5: [] },
+    tricks: [],
+    currentTrick: [],
+    buried: [],
+  })
+
+  it('resolvedPartner equals deducedPartner(view, userId)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.resolvedPartner).toBe(deducedPartner(view, 'p2'))
+  })
+
+  it('trumpVoids equals deducedTrumpVoids(view)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.trumpVoids).toEqual(deducedTrumpVoids(view))
+  })
+
+  it('nonTrumpVoids equals deducedNonTrumpVoids(view)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.nonTrumpVoids).toEqual(deducedNonTrumpVoids(view))
+  })
+
+  it('resolvedTrumpRemaining equals trumpRemainingElsewhere(view, userId)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.resolvedTrumpRemaining).toBe(trumpRemainingElsewhere(view, 'p2'))
+  })
+
+  it('resolvedTrumpRemaining is userId-sensitive — differs between two userIds with different hand contents', () => {
+    const view = {
+      ...buildView(),
+      hands: {
+        p1: [{ id: 'QC', rank: 'Q', suit: 'C', hidden: false }],
+        p2: [],
+        p3: [],
+        p4: [],
+        p5: [],
+      },
+    }
+    const rv1 = resolveView(view, 'p1')
+    const rv2 = resolveView(view, 'p2')
+    expect(rv1.resolvedTrumpRemaining).toBe(trumpRemainingElsewhere(view, 'p1'))
+    expect(rv2.resolvedTrumpRemaining).toBe(trumpRemainingElsewhere(view, 'p2'))
+    expect(rv1.resolvedTrumpRemaining).not.toBe(rv2.resolvedTrumpRemaining)
+  })
+})
+```
+
+- [ ] **Step 3: Run the new tests to confirm they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "pre-computed inference"
+```
+
+Expected: 5 failures with messages like `expected undefined to be null` for `resolvedPartner`, etc.
+
+- [ ] **Step 4: Implement the `resolveView` change in `botInference.js`**
+
+Current code (lines 28–30):
+```js
+export function resolveView(view, _userId) {
+  return { ...view, knownLocations: knownCardLocations(view) }
+}
+```
+
+Replace with:
+```js
+export function resolveView(view, userId) {
+  return {
+    ...view,
+    knownLocations: knownCardLocations(view),
+    resolvedPartner: deducedPartner(view, userId),
+    trumpVoids: deducedTrumpVoids(view),
+    nonTrumpVoids: deducedNonTrumpVoids(view),
+    resolvedTrumpRemaining: trumpRemainingElsewhere(view, userId),
+  }
+}
+```
+
+- [ ] **Step 5: Run the new tests to confirm they pass**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -A 3 "pre-computed inference"
+```
+
+Expected: 5 passing tests.
+
+- [ ] **Step 6: Run all tests to confirm no regressions**
+
+```bash
+npm test 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add shared/botInference.js shared/botInference.test.js
+git commit -m "feat(inference): pre-compute resolvedPartner, trumpVoids, nonTrumpVoids, resolvedTrumpRemaining in resolveView"
+```
+
+---
+
+## Task 2: Update `isGuaranteedWinner` to read from resolved view
+
+**Files:**
+- Modify: `shared/botInference.js:302-307`
+- Modify: `shared/botInference.test.js` (14 plain-view call sites)
+
+- [ ] **Step 1: Change the two internal calls in `isGuaranteedWinner`**
+
+In `shared/botInference.js`, find lines 302–307 (inside the fail-card Condition 2 block):
+
+```js
+    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) - knownTeammateTrump === 0
+    if (!noTrumpElsewhere) {
+      const voids = deducedTrumpVoids(view)
+      const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)
+      const allOthersVoid = otherPlayerIds.length > 0 && otherPlayerIds.every(id => voids.has(id))
+      if (!allOthersVoid) return false
+    }
+```
+
+Replace with:
+```js
+    const noTrumpElsewhere = view.resolvedTrumpRemaining - knownTeammateTrump === 0
+    if (!noTrumpElsewhere) {
+      const voids = view.trumpVoids
+      const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)
+      const allOthersVoid = otherPlayerIds.length > 0 && otherPlayerIds.every(id => voids.has(id))
+      if (!allOthersVoid) return false
+    }
+```
+
+- [ ] **Step 2: Run all tests to identify which ones now fail**
+
+```bash
+npm test 2>&1 | grep "FAIL\|×\|✗" | head -30
+```
+
+Expected: 14 tests in `botInference.test.js` fail — these are the tests that pass a plain view (without `resolveView`) to `isGuaranteedWinner`. The failing tests are located at approximately these lines:
+
+**Group 1 — non-trump/trump guaranteed-winner tests (lines ~282–564):**
+- ~352: "fail ace, all other players trump-void → returns true"
+- ~364: "fail ace, trump still unaccounted for and not all void → returns false"
+- ~384: "fail ace, trumpRemainingElsewhere === 0 → returns true even without void deduction"
+- ~418: "fail 10 where ace has been played, all others trump-void → returns true"
+- ~440: "fail 10 where ace NOT yet played → returns false"
+- ~451: "QC (rank 0) is always a guaranteed winner"
+- ~463: "lower trump returns false when higher trump unseen"
+- ~486: "buried higher same-suit card satisfies condition 1"
+- ~520: "fail King — false when only AC played"
+- ~545: "fail King — true when both AC and 10C played and all others trump-void"
+- ~562: "degenerate view with no other players in hands → returns false"
+
+**Group 2 — blitz inference tests (first assertion in pairs, lines ~790–1108):**
+- ~810: first assertion "partner holds QH; picker black-blitzed → false without resolveView"
+- ~928: first assertion "partner holds AH; → false without resolveView"
+- ~1057: first assertion "picker holds fail ace; → false without resolveView"
+- ~1102: first assertion "blitzed queen played in currentTrick → false without resolveView"
+
+- [ ] **Step 3: Fix Group 1 plain-view calls — wrap with `resolveView`**
+
+For each Group 1 failing test (~11 tests at lines ~352, ~364, ~384, ~418, ~440, ~451, ~463, ~486, ~520, ~545, ~562), the fix is the same. Find the call:
+```js
+isGuaranteedWinner(someCard, someView, someUserId)
+```
+and replace it with:
+```js
+isGuaranteedWinner(someCard, resolveView(someView, someUserId), someUserId)
+```
+
+The expected values (`true`/`false`) do not change — these tests don't involve blitzes, so `knownLocations` stays empty and `trumpVoids`/`resolvedTrumpRemaining` are computed from the same trick data as before.
+
+- [ ] **Step 4: Fix Group 2 blitz-test first assertions — delete them**
+
+For the 4 Group 2 tests (~lines ~810, ~928, ~1057, ~1102), the first assertion in each pair tests the plain-view baseline (expected `false`), and the second uses `resolveView` (expected `true`). **Do not wrap the first assertion.** Instead, delete it.
+
+Reason: wrapping the first assertion with `resolveView` would populate `knownLocations` with blitz data, causing `isGuaranteedWinner` to return `true` — making it a duplicate of the second assertion. The "without blitz accounting" baseline is no longer representable once `isGuaranteedWinner` requires a resolved view.
+
+After deletion, each pair becomes a single assertion using `resolveView` with the expected `true` result. The test name and the second assertion are unchanged.
+
+- [ ] **Step 5: Run all tests to confirm all pass**
+
+```bash
+npm test 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add shared/botInference.js shared/botInference.test.js
+git commit -m "refactor(inference): isGuaranteedWinner reads trumpVoids/resolvedTrumpRemaining from resolved view"
+```
+
+---
+
+## Task 3: Replace inline helper calls in `botStrategy.js`
+
+**Files:**
+- Modify: `shared/botStrategy.js`
+
+- [ ] **Step 1: Replace the 5 `deducedPartner` call sites**
+
+Make each substitution in `shared/botStrategy.js`:
+
+**Line ~370:**
+```js
+// Before:
+if (deducedPartner(rv, userId) === null && calledSuit) {
+// After:
+if (rv.resolvedPartner === null && calledSuit) {
+```
+
+**Line ~380:**
+```js
+// Before:
+const knownPartner = deducedPartner(rv, userId)
+// After:
+const knownPartner = rv.resolvedPartner
+```
+
+**Line ~546:**
+```js
+// Before:
+const deducedOpp = deducedPartner(rv, userId)
+// After:
+const deducedOpp = rv.resolvedPartner
+```
+
+**Line ~599:**
+```js
+// Before:
+if (deducedPartner(rv, userId) === null && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
+// After:
+if (rv.resolvedPartner === null && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
+```
+
+**Line ~657:**
+```js
+// Before:
+const deducedForPredicted = deducedPartner(rv, userId)
+// After:
+const deducedForPredicted = rv.resolvedPartner
+```
+
+- [ ] **Step 2: Replace the 2 `deducedNonTrumpVoids` call sites**
+
+**Line ~347:**
+```js
+// Before:
+const nonTrumpVoids = deducedNonTrumpVoids(rv)
+// After:
+const nonTrumpVoids = rv.nonTrumpVoids
+```
+
+**Line ~382:**
+```js
+// Before:
+const nonTrumpVoids = deducedNonTrumpVoids(rv)
+// After:
+const nonTrumpVoids = rv.nonTrumpVoids
+```
+
+- [ ] **Step 3: Remove now-unused imports from `botStrategy.js`**
+
+Current import line (line 9):
+```js
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner, deducedNonTrumpVoids, resolveView } from './botInference.js'
+```
+
+Replace with (removing `deducedPartner` and `deducedNonTrumpVoids`):
+```js
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, resolveView } from './botInference.js'
+```
+
+- [ ] **Step 4: Run all tests to confirm no behavioral change**
+
+```bash
+npm test 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared/botStrategy.js
+git commit -m "refactor(strategy): replace inline deducedPartner/deducedNonTrumpVoids calls with rv.* reads"
+```
+
+---
+
+## Task 4: Update `docs/BOTS.md`
+
+**Files:**
+- Modify: `docs/BOTS.md`
+
+- [ ] **Step 1: Update the `resolveView` entry**
+
+Find the current `resolveView` row (around line 200) in the inference helpers table:
+
+```
+| `resolveView` | Pre-computation wrapper called once per play decision in `decidePlay`. Returns `{ ...view, knownLocations }`. All downstream inference calls receive the enriched view. Phase 2 (#176) will add more pre-computed fields. |
+```
+
+Replace with:
+```
+| `resolveView` | Pre-computation wrapper called once per play decision in `decidePlay`. Returns the view enriched with: `knownLocations` (card locations from blitz declarations), `resolvedPartner` (inferred partner userId or null — distinct from engine-set `view.partner`), `trumpVoids` (Set of userIds with no trump remaining), `nonTrumpVoids` (map of userId → Set of fail suits they cannot follow), and `resolvedTrumpRemaining` (integer count of trump still held by other players). All downstream inference calls receive the enriched view. |
+```
+
+- [ ] **Step 2: Run all tests one final time to confirm clean state**
+
+```bash
+npm test 2>&1 | tail -20
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/BOTS.md
+git commit -m "docs(bots): update resolveView entry with all five pre-computed fields"
+```

--- a/docs/superpowers/specs/2026-05-02-resolveview-precompute-inference-design-for-PMs.md
+++ b/docs/superpowers/specs/2026-05-02-resolveview-precompute-inference-design-for-PMs.md
@@ -1,0 +1,43 @@
+# Pre-compute Shared Inference State in resolveView (Issue #176)
+
+## What We're Building
+
+Every time a bot makes a play decision, it currently re-calculates the same four pieces of information — who the partner likely is, which players can't follow trump, which players can't follow non-trump suits, and how much trump is left — on every branch of a 400-line decision function. Some of these calculations are repeated 5–7 times in a single decision.
+
+This work pre-computes all four results once, upfront, and makes them available as simple property reads throughout the rest of the decision logic.
+
+## Why It Matters
+
+**Efficiency:** In late-game scenarios (5+ tricks played), each inference helper scans the full trick history. Pre-computing reduces approximately 14–15 trick-history scans per play decision to one scan each. The absolute time savings are small, but the savings compound as bot strategy grows more sophisticated.
+
+**Code clarity:** The `decidePlay` function is already ~400 lines. Removing 10+ scattered inference calls and replacing them with property lookups makes the decision logic significantly easier to read and audit. Intent becomes clearer when a condition reads `rv.resolvedPartner !== null` instead of `deducedPartner(rv, userId) !== null`.
+
+**Future strategy improvements:** Currently, adding an inference check at a new decision point inside `decidePlay` implicitly adds a full trick-history scan. That cost discourages using these signals in more places. Once pre-computed, they are free to read anywhere — which opens the door to richer bot decisions without architectural friction.
+
+## What Changes
+
+A single function, `resolveView`, acts as the bot's "prepare to think" step. It already pre-computes one field (card locations from blitz declarations, added in a prior release). This work adds four more:
+
+- **Who the partner likely is** — computed once via elimination logic instead of 4–5 times during the decision
+- **Which players have no trump left** — computed once instead of being re-derived inside every guaranteed-winner check
+- **Which players can't follow specific non-trump suits** — computed once instead of twice in leading-play branches
+- **How much trump remains elsewhere** — computed once instead of multiple inline calls
+
+All existing helper functions remain unchanged and available. This is purely an architectural improvement — bot decision-making behavior is identical.
+
+## What Does Not Change
+
+- Bot play decisions — no strategy logic is altered
+- Game rules or scoring
+- Any UI or player-facing behavior
+
+## Out of Scope
+
+- Expanding what the bot *knows* from inference (e.g., using crack/recrack patterns to deduce card locations) — tracked separately in issue #180
+- Cleanup of the inference module's public API — tracked separately in issue #181
+
+## Success Criteria
+
+1. All existing bot strategy tests continue to pass without modification
+2. Two new tests verify that `resolveView` correctly wires the pre-computed fields
+3. Bot documentation (`docs/BOTS.md`) is updated to reflect the new output shape of `resolveView`

--- a/docs/superpowers/specs/2026-05-02-resolveview-precompute-inference-design.md
+++ b/docs/superpowers/specs/2026-05-02-resolveview-precompute-inference-design.md
@@ -1,0 +1,100 @@
+# Design: Pre-compute Shared Inference State in resolveView (Issue #176)
+
+## Problem
+
+`resolveView(view, userId)` was introduced in #150 to pre-compute `knownLocations` (cards pinned to specific hands via blitz declarations). Several other inference helpers are still called redundantly on every invocation of `decidePlay`:
+
+- `deducedPartner(view, userId)` — 4–5 call sites per play decision
+- `deducedNonTrumpVoids(view)` — 2 call sites in leading-play branches
+- `deducedTrumpVoids(view)` — called internally inside `isGuaranteedWinner`, which is itself called ~7 times per play decision
+- `trumpRemainingElsewhere(view, userId)` — called at multiple points in `decidePlay`
+
+All of these scan `view.tricks` (up to 30 plays in late-game) and/or `view.currentTrick` on every invocation. The cumulative result is approximately 14–15 redundant trick-history scans per play decision.
+
+## Approach
+
+Extend `resolveView` to call these helpers once each and attach results to the returned view object. All consumers in `botStrategy.js` replace inline helper calls with property reads on the resolved view. `isGuaranteedWinner` replaces its internal `deducedTrumpVoids` call with a read from `view.trumpVoids`.
+
+The standalone helper functions remain exported and behaviorally unchanged.
+
+## Data Shape
+
+`resolveView(view, userId)` returns:
+
+```
+{
+  ...view,
+  knownLocations: Map<userId, Array<card>>,    // from blitzes — existing (#150)
+  resolvedPartner: userId | null,              // from deducedPartner
+  trumpVoids: Set<userId>,                     // from deducedTrumpVoids
+  nonTrumpVoids: { [userId]: Set<suit> },      // from deducedNonTrumpVoids (plain object, unchanged)
+  resolvedTrumpRemaining: number,              // from trumpRemainingElsewhere
+}
+```
+
+**Key naming note:** `resolvedPartner` is intentionally distinct from the engine-set `view.partner`. The engine sets `view.partner` only when the called card is played in a trick. `deducedPartner` can be non-null earlier — via elimination logic — before the engine confirms it. The two fields carry different meanings and both may be needed simultaneously by a caller. Using `resolvedPartner` preserves this distinction.
+
+## Changes to `resolveView` (botInference.js)
+
+The function currently returns `{ ...view, knownLocations: knownCardLocations(view) }`.
+
+It will be updated to also call:
+- `deducedPartner(view, userId)` → `resolvedPartner`
+- `deducedTrumpVoids(view)` → `trumpVoids`
+- `deducedNonTrumpVoids(view)` → `nonTrumpVoids`
+- `trumpRemainingElsewhere(view, userId)` → `resolvedTrumpRemaining`
+
+Note: `trumpRemainingElsewhere` itself calls `countTrumpPlayed(view, userId)` which scans `view.tricks`. Pre-computing it here eliminates those repeated scans.
+
+## Changes to `isGuaranteedWinner` (botInference.js)
+
+No signature change. The function currently calls two helpers internally on every invocation:
+
+- `deducedTrumpVoids(view)` (to check which players are trump-void)
+- `trumpRemainingElsewhere(view, userId)` (to check if any trump is left elsewhere)
+
+Both callers already pass `rv`, so replace both with reads from the resolved view:
+- `deducedTrumpVoids(view)` → `view.trumpVoids`
+- `trumpRemainingElsewhere(view, userId)` → `view.resolvedTrumpRemaining`
+
+This removes the most expensive redundancies: ~7 re-scans of `deducedTrumpVoids` and ~7 re-calls of `trumpRemainingElsewhere` per play decision, reduced to zero.
+
+Note: `trumpRemainingElsewhere` is only called from inside `isGuaranteedWinner` — it has no direct call sites in `botStrategy.js`.
+
+## Changes to `botStrategy.js`
+
+Only `deducedPartner` and `deducedNonTrumpVoids` have direct call sites in `decidePlay`. Replace them with property reads on `rv`:
+
+| Current call | Replacement |
+|---|---|
+| `deducedPartner(rv, userId)` (5 sites) | `rv.resolvedPartner` |
+| `deducedNonTrumpVoids(rv)` (2 sites) | `rv.nonTrumpVoids` |
+
+No logic changes. `rv` is already the resolved view at all call sites.
+
+## Tests (botInference.test.js)
+
+1. **`resolveView` pre-computation consistency** — construct a view with known trick history; assert that all four new fields match the values returned by the individual helpers for the same view. Verifies the wiring, not the helper logic.
+
+2. **`userId` threading** — call `resolveView` with two different userIds; assert that `resolvedPartner` and `resolvedTrumpRemaining` (which are userId-sensitive) differ appropriately. Verifies that `userId` is correctly forwarded.
+
+3. **Existing `isGuaranteedWinner` tests** — since `isGuaranteedWinner` will now read `view.trumpVoids` and `view.resolvedTrumpRemaining` without fallbacks, any test that currently passes a plain `view` to `isGuaranteedWinner` must be updated to wrap it with `resolveView(view, userId)` first. Behavior is unchanged; only the setup changes.
+
+Existing `deducedPartner`, `deducedTrumpVoids`, `deducedNonTrumpVoids`, and `trumpRemainingElsewhere` tests are unchanged — the helpers themselves are unmodified.
+
+## docs/BOTS.md Update
+
+Update the `resolveView` entry to list all five pre-computed fields (adding the four new ones). No other BOTS.md changes needed — the underlying helper behaviors are unchanged.
+
+## Out of Scope
+
+- Internalizing helper functions (removing exports) — tracked in #181
+- Normalizing `nonTrumpVoids` to ES6 `Map` — tracked in #181
+- Extending `knownCardLocations` with new inference sources (crack/recrack, elimination) — tracked in #180
+
+## Success Criteria
+
+1. `resolveView` returns all five pre-computed fields, each matching the corresponding helper's output for the same inputs.
+2. All `botInference.test.js` tests pass, including two new tests per above.
+3. All `botStrategy` tests pass — no behavioral change.
+4. `docs/BOTS.md` accurately reflects the updated `resolveView` output.

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -25,8 +25,15 @@ export function knownCardLocations(view) {
 
 // Pre-computation wrapper. Returns { ...view, knownLocations } for use by all inference calls
 // in a single play decision. _userId is unused in Phase 1; included for Phase 2 API symmetry.
-export function resolveView(view, _userId) {
-  return { ...view, knownLocations: knownCardLocations(view) }
+export function resolveView(view, userId) {
+  return {
+    ...view,
+    knownLocations: knownCardLocations(view),
+    resolvedPartner: deducedPartner(view, userId),
+    trumpVoids: deducedTrumpVoids(view),
+    nonTrumpVoids: deducedNonTrumpVoids(view),
+    resolvedTrumpRemaining: trumpRemainingElsewhere(view, userId),
+  }
 }
 
 // ─── Trump tracking ───────────────────────────────────────────────────────────

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -258,6 +258,11 @@ function knownTeammateCards(view, userId) {
 // the currently-winning card in the trick, so that including currentTrick cards in
 // the accounting does not conflate the question "can this card be beaten?" with
 // cards already played against it.
+//
+// NOTE — For non-trump cards, Condition 2 reads `view.resolvedTrumpRemaining` and
+// `view.resolvedTrumpVoids` directly. `view` must be a resolved view produced by
+// `resolveView(rawView, userId)` — plain views will crash on non-trump cards.
+// The trump branch does not read these fields and is safe with plain views.
 export function isGuaranteedWinner(card, view, userId) {
   if (!isTrump(card)) {
     // ── Condition 1: no higher same-suit card is unaccounted for ─────────────

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -306,9 +306,9 @@ export function isGuaranteedWinner(card, view, userId) {
     const knownTeammateTrump = knownTeammateCards(view, userId)
       .filter(c => isTrump(c) && !playedOrBuriedIds.has(c.id))
       .length
-    const noTrumpElsewhere = trumpRemainingElsewhere(view, userId) - knownTeammateTrump === 0
+    const noTrumpElsewhere = view.resolvedTrumpRemaining - knownTeammateTrump === 0
     if (!noTrumpElsewhere) {
-      const voids = deducedTrumpVoids(view)
+      const voids = view.resolvedTrumpVoids
       const otherPlayerIds = Object.keys(view.hands).filter(id => id !== userId)
       const allOthersVoid = otherPlayerIds.length > 0 && otherPlayerIds.every(id => voids.has(id))
       if (!allOthersVoid) return false

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -23,15 +23,15 @@ export function knownCardLocations(view) {
   return map
 }
 
-// Pre-computation wrapper. Returns { ...view, knownLocations } for use by all inference calls
-// in a single play decision. _userId is unused in Phase 1; included for Phase 2 API symmetry.
+// Pre-computation wrapper. Runs four inference helpers once and attaches their results
+// so downstream consumers in a single play decision can read them as property lookups.
 export function resolveView(view, userId) {
   return {
     ...view,
     knownLocations: knownCardLocations(view),
     resolvedPartner: deducedPartner(view, userId),
-    trumpVoids: deducedTrumpVoids(view),
-    nonTrumpVoids: deducedNonTrumpVoids(view),
+    resolvedTrumpVoids: deducedTrumpVoids(view),
+    resolvedNonTrumpVoids: deducedNonTrumpVoids(view),
     resolvedTrumpRemaining: trumpRemainingElsewhere(view, userId),
   }
 }

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids, knownCardLocations, resolveView } from './botInference.js'
+import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids, knownCardLocations, resolveView, trumpRemainingElsewhere } from './botInference.js'
 
 const c = (id, suit, rank) => ({ id, suit, rank })
 
@@ -784,6 +784,63 @@ describe('resolveView', () => {
     const view = { blitzes: [], hands: {} }
     const rv = resolveView(view, 'p1')
     expect(rv.knownLocations.size).toBe(0)
+  })
+})
+
+describe('resolveView pre-computed inference fields', () => {
+  const buildView = () => ({
+    blitzes: [],
+    picker: 'p1',
+    goingAlone: false,
+    isLeaster: false,
+    partner: null,
+    recrackerId: null,
+    hands: { p1: [], p2: [], p3: [], p4: [], p5: [] },
+    tricks: [],
+    currentTrick: [],
+    buried: [],
+  })
+
+  it('resolvedPartner equals deducedPartner(view, userId)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.resolvedPartner).toBe(deducedPartner(view, 'p2'))
+  })
+
+  it('trumpVoids equals deducedTrumpVoids(view)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.trumpVoids).toEqual(deducedTrumpVoids(view))
+  })
+
+  it('nonTrumpVoids equals deducedNonTrumpVoids(view)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.nonTrumpVoids).toEqual(deducedNonTrumpVoids(view))
+  })
+
+  it('resolvedTrumpRemaining equals trumpRemainingElsewhere(view, userId)', () => {
+    const view = buildView()
+    const rv = resolveView(view, 'p2')
+    expect(rv.resolvedTrumpRemaining).toBe(trumpRemainingElsewhere(view, 'p2'))
+  })
+
+  it('resolvedTrumpRemaining is userId-sensitive — differs between two userIds with different hand contents', () => {
+    const view = {
+      ...buildView(),
+      hands: {
+        p1: [{ id: 'QC', rank: 'Q', suit: 'C', hidden: false }],
+        p2: [],
+        p3: [],
+        p4: [],
+        p5: [],
+      },
+    }
+    const rv1 = resolveView(view, 'p1')
+    const rv2 = resolveView(view, 'p2')
+    expect(rv1.resolvedTrumpRemaining).toBe(trumpRemainingElsewhere(view, 'p1'))
+    expect(rv2.resolvedTrumpRemaining).toBe(trumpRemainingElsewhere(view, 'p2'))
+    expect(rv1.resolvedTrumpRemaining).not.toBe(rv2.resolvedTrumpRemaining)
   })
 })
 

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -559,7 +559,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
     })
     // trumpRemainingElsewhere = 14 - ownTrump(0) - tricksTrump(0) - buriedTrump(0) = 14
     // With the vacuous-truth bug this returned true; with the fix it returns false.
-    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(false)
+    expect(isGuaranteedWinner(aceOfClubs, resolveView(view, 'p1'), 'p1')).toBe(false)
   })
 })
 

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -807,16 +807,16 @@ describe('resolveView pre-computed inference fields', () => {
     expect(rv.resolvedPartner).toBe(deducedPartner(view, 'p2'))
   })
 
-  it('trumpVoids equals deducedTrumpVoids(view)', () => {
+  it('resolvedTrumpVoids equals deducedTrumpVoids(view)', () => {
     const view = buildView()
     const rv = resolveView(view, 'p2')
-    expect(rv.trumpVoids).toEqual(deducedTrumpVoids(view))
+    expect(rv.resolvedTrumpVoids).toEqual(deducedTrumpVoids(view))
   })
 
-  it('nonTrumpVoids equals deducedNonTrumpVoids(view)', () => {
+  it('resolvedNonTrumpVoids equals deducedNonTrumpVoids(view)', () => {
     const view = buildView()
     const rv = resolveView(view, 'p2')
-    expect(rv.nonTrumpVoids).toEqual(deducedNonTrumpVoids(view))
+    expect(rv.resolvedNonTrumpVoids).toEqual(deducedNonTrumpVoids(view))
   })
 
   it('resolvedTrumpRemaining equals trumpRemainingElsewhere(view, userId)', () => {

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -349,7 +349,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
       currentTrick: [],
       buried: [],
     })
-    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(true)
+    expect(isGuaranteedWinner(aceOfClubs, resolveView(view, 'p1'), 'p1')).toBe(true)
   })
 
   it('fail ace, trump still unaccounted for and not all void → returns false', () => {
@@ -361,7 +361,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
       currentTrick: [],
       buried: [],
     })
-    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(false)
+    expect(isGuaranteedWinner(aceOfClubs, resolveView(view, 'p1'), 'p1')).toBe(false)
   })
 
   it('fail ace, trumpRemainingElsewhere === 0 (all trump played) → returns true even without void deduction', () => {
@@ -381,7 +381,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
         p2: [], p3: [], p4: [], p5: [],
       },
     })
-    expect(isGuaranteedWinner(aceOfClubs, view, 'p1')).toBe(true)
+    expect(isGuaranteedWinner(aceOfClubs, resolveView(view, 'p1'), 'p1')).toBe(true)
   })
 
   it('fail 10 where ace has been played, all others trump-void → returns true', () => {
@@ -415,7 +415,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
       currentTrick: [],
       buried: [],
     })
-    expect(isGuaranteedWinner(tenOfClubs, view, 'p1')).toBe(true)
+    expect(isGuaranteedWinner(tenOfClubs, resolveView(view, 'p1'), 'p1')).toBe(true)
   })
 
   it('fail 10 where ace NOT yet played → returns false (higher card outstanding)', () => {
@@ -483,7 +483,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
       currentTrick: [],
       buried: [aceOfClubs],   // AC buried — satisfies condition 1 for 10C
     })
-    expect(isGuaranteedWinner(tenOfClubs, view, 'p1')).toBe(true)
+    expect(isGuaranteedWinner(tenOfClubs, resolveView(view, 'p1'), 'p1')).toBe(true)
   })
 
   it('fail King (suitRank 2) — false when only AC played (10C still outstanding)', () => {
@@ -542,7 +542,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
       buried: [],
     })
     // Both AC (rank 0) and 10C (rank 1) seen in tricks; all opponents are trump-void.
-    expect(isGuaranteedWinner(kingOfClubs, view, 'p1')).toBe(true)
+    expect(isGuaranteedWinner(kingOfClubs, resolveView(view, 'p1'), 'p1')).toBe(true)
   })
 
   it('degenerate view with no other players in hands → returns false even when trumpRemainingElsewhere > 0', () => {
@@ -981,8 +981,6 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
       buried: [{ id: '8D', rank: '8', suit: 'D' }, { id: '7D', rank: '7', suit: 'D' }],
       isLeaster: false,
     }
-    // Plain view: 2 trump remaining (QC+QS), not all others trump-void → false
-    expect(isGuaranteedWinner(ah, view, 'p2')).toBe(false)
     // Enriched view: QC+QS known in teammate's hand, 2-2=0 opponent trump → true
     const rv = resolveView(view, 'p2')
     expect(isGuaranteedWinner(ah, rv, 'p2')).toBe(true)
@@ -1111,7 +1109,6 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
       isLeaster: false,
     }
     const rv = resolveView(view, 'p1')
-    expect(isGuaranteedWinner(ac, view, 'p1')).toBe(false)  // plain view: 2 trump remaining → false
     expect(isGuaranteedWinner(ac, rv, 'p1')).toBe(true)     // enriched: partner holds those 2 → true
   })
 
@@ -1155,8 +1152,6 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
       buried: [{ id: '8D', rank: '8', suit: 'D' }],
       isLeaster: false,
     }
-    // Without resolveView: trumpRemainingElsewhere=2, not all void → false
-    expect(isGuaranteedWinner(ah, view, 'p2')).toBe(false)
     const rv = resolveView(view, 'p2')
     // With resolveView: QC in currentTrick (filtered), QS unplayed (counted); 2-1=1 opponent trump remains → false.
     // (An opponent still holds 8D — AH is correctly identified as NOT a guaranteed winner.)

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -6,7 +6,7 @@
 import {
   isTrump, cardPoints, effectiveSuit, trumpRank, suitRank, schwanzerCardPoints,
 } from './gameEngine.js'
-import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, deducedPartner, deducedNonTrumpVoids, resolveView } from './botInference.js'
+import { currentWinner, beats, handScore, bestVoidBury, teammateWinning, isGuaranteedWinner, cheapestGuaranteedWin, pickBySchmearPriority, resolveView } from './botInference.js'
 
 // ─── Legal card helper ────────────────────────────────────────────────────────
 // Mirrors getLegalCardIds from the frontend; computes which cards can be played.
@@ -344,7 +344,7 @@ export function decidePlay(view, userId) {
       {
         const allIds = Object.keys(view.hands)
         const opponentIds = allIds.filter(id => id !== picker && id !== partner)
-        const nonTrumpVoids = deducedNonTrumpVoids(rv)
+        const nonTrumpVoids = rv.resolvedNonTrumpVoids
         const failCards = realCards.filter(c => !isTrump(c))
         const safeFails = failCards.filter(card => {
           const suit = effectiveSuit(card)
@@ -367,7 +367,7 @@ export function decidePlay(view, userId) {
       // skipped if partner identity is already known from public information (crack/recrack/elimination).
       const { calledSuit } = view
       const nonTrump = realCards.filter(c => !isTrump(c))
-      if (deducedPartner(rv, userId) === null && calledSuit) {
+      if (rv.resolvedPartner === null && calledSuit) {
         const calledSuitCards = nonTrump.filter(c => effectiveSuit(c) === calledSuit)
         if (calledSuitCards.length > 0) return lowestCard(calledSuitCards).id
       }
@@ -377,9 +377,9 @@ export function decidePlay(view, userId) {
       {
         const { calledAce: ca, calledTen: ct, calledKing: ck } = view
         const calledCardId = ca?.aceId ?? ct?.tenId ?? ck?.kingId
-        const knownPartner = deducedPartner(rv, userId)
+        const knownPartner = rv.resolvedPartner
         if (knownPartner !== null) {
-          const nonTrumpVoids = deducedNonTrumpVoids(rv)
+          const nonTrumpVoids = rv.resolvedNonTrumpVoids
           const pickerTeamIds = [picker, knownPartner].filter(Boolean)
           // Candidate fail cards: non-trump, not the called card
           const failLeads = nonTrump.filter(c => c.id !== calledCardId)
@@ -543,7 +543,7 @@ export function decidePlay(view, userId) {
       const playedIdsOpp = new Set(currentTrick.map(p => p.userId))
       const allIdsOpp = Object.keys(view.hands)
       // From opponent POV, "threats" (could overtake teammate) = picker + partner still to play.
-      const deducedOpp = deducedPartner(rv, userId)
+      const deducedOpp = rv.resolvedPartner
       const threatsRemaining = allIdsOpp.filter(id =>
         !playedIdsOpp.has(id) && id !== userId && (id === picker || id === deducedOpp)
       ).length
@@ -596,7 +596,7 @@ export function decidePlay(view, userId) {
 
       // Skipped if partner has already been deduced from public information —
       // the lead-back goal (flush the unknown partner) is then moot.
-      if (deducedPartner(rv, userId) === null && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
+      if (rv.resolvedPartner === null && !ledThisTrickIsCalled && hasCalledSuitFailInHand) {
         const winningSet = realCards.filter(card => {
           for (const play of currentTrick) {
             if (!beats(card, play.card, ledSuit)) return false
@@ -654,7 +654,7 @@ export function decidePlay(view, userId) {
     // points along with the partner's high card.
     if (!isTrump(currentTrick[0].card)) {
       const winner = currentWinner(currentTrick)
-      const deducedForPredicted = deducedPartner(rv, userId)
+      const deducedForPredicted = rv.resolvedPartner
       const pickerTeamWinning = winner && (winner.userId === picker || winner.userId === deducedForPredicted)
       const { calledSuit, partnerRevealed } = view
       const calledSuitLedUnrevealed = !partnerRevealed && !!calledSuit && ledSuit === calledSuit

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -17,6 +17,7 @@ import {
   isGuaranteedWinner,
   cheapestGuaranteedWin,  // NEW
   pickBySchmearPriority,
+  resolveView,
 } from './botInference.js'
 
 const c = (rank, suit) => ({ id: `${rank}${suit}`, rank, suit })
@@ -2584,7 +2585,7 @@ describe('isGuaranteedWinner', () => {
       hand: [c('A','C')],
       trick: [],
     })
-    expect(isGuaranteedWinner(c('A','C'), view, 'p1')).toBe(false)
+    expect(isGuaranteedWinner(c('A','C'), resolveView(view, 'p1'), 'p1')).toBe(false)
   })
 
   it('counts visible buried trump (picker view)', () => {


### PR DESCRIPTION
## Summary

- Extends `resolveView` to pre-compute `resolvedPartner`, `resolvedTrumpVoids`, `resolvedNonTrumpVoids`, and `resolvedTrumpRemaining` once per play decision, eliminating ~14 redundant trick-history scans
- Updates `isGuaranteedWinner` to read `view.resolvedTrumpVoids` / `view.resolvedTrumpRemaining` directly instead of calling `deducedTrumpVoids` and `trumpRemainingElsewhere` internally on every invocation (~7 times per decision)
- Replaces 5 inline `deducedPartner` and 2 `deducedNonTrumpVoids` call sites in `botStrategy.js` with `rv.*` property reads; removes now-unused imports

## Test Plan

- [ ] All 365 tests pass (`npx vitest run`)
- [ ] No behavioral change — pure refactor; existing bot strategy tests cover all affected paths
- [ ] New round-trip consistency tests verify each new `resolveView` field matches its helper's direct output

## Notes

- `resolvedPartner` is intentionally distinct from engine-set `view.partner` — preserves the inferred-vs-confirmed distinction
- Filed https://github.com/andynumber2/sheepshead/issues/182 for `teammateWinning` redundancy (remaining 2 `deducedPartner` calls not covered by this PR)
- Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)