### PR TITLE
refactor(inference): teammateWinning reads resolvedPartner from resolved view

### DIFF
--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -450,7 +450,7 @@ export function teammateWinning(view, userId) {
   const { currentTrick, picker } = view
   if (!currentTrick || currentTrick.length === 0) return false
 
-  const partner = deducedPartner(view, userId)
+  const partner = view.resolvedPartner
 
   const winner = currentWinner(currentTrick)
   if (!winner) return false

--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -1641,7 +1641,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [{ userId: 'p1', card: c('Q','C') }],
       picker: 'p1',
-      partner: 'p2',
+      resolvedPartner: 'p2',
     }
     expect(teammateWinning(view, 'p2')).toBe(true)
   })
@@ -1650,7 +1650,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [{ userId: 'p2', card: c('Q','C') }],
       picker: 'p1',
-      partner: 'p2',
+      resolvedPartner: 'p2',
     }
     expect(teammateWinning(view, 'p1')).toBe(true)
   })
@@ -1659,7 +1659,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [{ userId: 'p3', card: c('Q','C') }],
       picker: 'p1',
-      partner: 'p2',
+      resolvedPartner: 'p2',
     }
     expect(teammateWinning(view, 'p1')).toBe(false)
   })
@@ -1668,7 +1668,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [{ userId: 'p4', card: c('Q','C') }],
       picker: 'p1',
-      partner: 'p2',
+      resolvedPartner: 'p2',
     }
     expect(teammateWinning(view, 'p3')).toBe(true)
   })
@@ -1677,7 +1677,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [{ userId: 'p4', card: c('Q','C') }],
       picker: 'p1',
-      partner: null,
+      resolvedPartner: null,
     }
     expect(teammateWinning(view, 'p3')).toBe(false)
   })
@@ -1686,7 +1686,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [{ userId: 'p3', card: c('A','S') }],
       picker: 'p1',
-      partner: null,
+      resolvedPartner: null,
       goingAlone: true,
       isLeaster: false,
     }
@@ -1698,7 +1698,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [{ userId: 'p1', card: c('Q','C') }],
       picker: 'p1',
-      partner: null,
+      resolvedPartner: null,
       goingAlone: true,
       isLeaster: false,
     }
@@ -1710,7 +1710,7 @@ describe('teammateWinning', () => {
     const view = {
       currentTrick: [],
       picker: 'p1',
-      partner: 'p2',
+      resolvedPartner: 'p2',
     }
     expect(teammateWinning(view, 'p1')).toBe(false)
   })


### PR DESCRIPTION
## Summary
- Eliminates 2 redundant `deducedPartner` trick-history scans per play decision
- `teammateWinning` now reads `view.resolvedPartner` directly instead of calling `deducedPartner(view, userId)`
- Updates 8 test fixtures to use `resolvedPartner` instead of `partner`, confirming the resolved-view contract

Closes #182

## Test plan
- [ ] All 366 tests pass (`npx vitest run`)
- [ ] `teammateWinning` unit tests verify all cases: picker-team winning, opponent-team winning, partner null, going alone, empty trick

🤖 Generated with [Claude Code](https://claude.com/claude-code)