### PR TITLE
cleanup(inference): internalize helpers and normalize nonTrumpVoids to Map (closes #181)

### DIFF
--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -165,7 +165,7 @@ export function bestVoidBury(hand) {
 
 // ─── Void analysis (fail suits) ──────────────────────────────────────────────
 
-// Returns { [userId]: Set<suit> } — a map of player IDs to the set of fail suits
+// Returns Map<userId, Set<suit>> — a map of player IDs to the set of fail suits
 // they are known to be void in, deduced from completed trick history.
 //
 // Logic: for each completed trick where the led card is a visible fail card (not trump),
@@ -174,7 +174,7 @@ export function bestVoidBury(hand) {
 // (both prove void in the led fail suit).
 //
 // Only view.tricks (completed tricks) are scanned — not view.currentTrick.
-export function deducedNonTrumpVoids(view) {
+function deducedNonTrumpVoids(view) {
   const voids = new Map()
   for (const trick of (view.tricks ?? [])) {
     const plays = trick.plays
@@ -205,7 +205,7 @@ export function deducedNonTrumpVoids(view) {
 // in-progress and not yet committed to state. Under-card leads are safe: the
 // under card has hidden: true, so tricks led by the under card are skipped by
 // the existing hidden-led-card guard and never produce false void deductions.
-export function deducedTrumpVoids(view) {
+function deducedTrumpVoids(view) {
   const voids = new Set()
   for (const trick of (view.tricks ?? [])) {
     const plays = trick.plays
@@ -428,7 +428,7 @@ export function knownNonPartners(view, userId) {
 //   4. Otherwise, null.
 //
 // Returns null in alone/leaster/no-picker modes regardless of signals.
-export function deducedPartner(view, userId) {
+function deducedPartner(view, userId) {
   if (!view.picker || view.goingAlone || view.isLeaster) return null
   if (view.partner) return view.partner
   if (view.recrackerId && view.recrackerId !== view.picker) return view.recrackerId

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -175,7 +175,7 @@ export function bestVoidBury(hand) {
 //
 // Only view.tricks (completed tricks) are scanned — not view.currentTrick.
 export function deducedNonTrumpVoids(view) {
-  const voids = {}
+  const voids = new Map()
   for (const trick of (view.tricks ?? [])) {
     const plays = trick.plays
     if (!plays || plays.length === 0) continue
@@ -188,8 +188,8 @@ export function deducedNonTrumpVoids(view) {
       if (!play.card || play.card.hidden) continue  // can't see this card
       if (effectiveSuit(play.card) !== ledSuit) {
         // Did not follow the led fail suit → void in that suit
-        if (!voids[play.userId]) voids[play.userId] = new Set()
-        voids[play.userId].add(ledSuit)
+        if (!voids.has(play.userId)) voids.set(play.userId, new Set())
+        voids.get(play.userId).add(ledSuit)
       }
     }
   }

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { knownNonPartners, deducedPartner, deducedTrumpVoids, isGuaranteedWinner, deducedNonTrumpVoids, knownCardLocations, resolveView, trumpRemainingElsewhere } from './botInference.js'
+import { knownNonPartners, isGuaranteedWinner, knownCardLocations, resolveView, trumpRemainingElsewhere } from './botInference.js'
 
 const c = (id, suit, rank) => ({ id, suit, rank })
 
@@ -117,17 +117,17 @@ describe('knownNonPartners', () => {
 describe('deducedPartner', () => {
   it('returns view.partner when set (engine-revealed)', () => {
     const view = baseView({ partner: 'p2', partnerRevealed: true })
-    expect(deducedPartner(view, 'p3')).toBe('p2')
+    expect(resolveView(view, 'p3').resolvedPartner).toBe('p2')
   })
 
   it('returns recracker when non-picker recracked', () => {
     const view = baseView({ recrackerId: 'p2' })
-    expect(deducedPartner(view, 'p3')).toBe('p2')
+    expect(resolveView(view, 'p3').resolvedPartner).toBe('p2')
   })
 
   it('does not use recracker when picker recracked (falls through)', () => {
     const view = baseView({ recrackerId: 'p1' })  // p1 is picker
-    expect(deducedPartner(view, 'p3')).toBeNull()
+    expect(resolveView(view, 'p3').resolvedPartner).toBeNull()
   })
 
   it('returns the unique remaining seat when 3 of 4 non-picker seats ruled out', () => {
@@ -138,33 +138,33 @@ describe('deducedPartner', () => {
       crackerId: 'p4',
       currentTrick: [{ userId: 'p5', card: c('KH', 'H', 'K') }],
     })
-    expect(deducedPartner(view, 'p3')).toBe('p2')
+    expect(resolveView(view, 'p3').resolvedPartner).toBe('p2')
   })
 
   it('returns null when only 2 of 4 non-picker seats ruled out', () => {
     const view = baseView({ crackerId: 'p4' })
     // p1 picker, p3 self, p4 cracker → 2 ruled out (p3, p4 of the 4 non-picker seats); p2 and p5 remain candidates.
-    expect(deducedPartner(view, 'p3')).toBeNull()
+    expect(resolveView(view, 'p3').resolvedPartner).toBeNull()
   })
 
   it('returns null when no signals fire', () => {
     const view = baseView()
-    expect(deducedPartner(view, 'p3')).toBeNull()
+    expect(resolveView(view, 'p3').resolvedPartner).toBeNull()
   })
 
   it('returns null when picker goes alone (goingAlone === true)', () => {
     const view = baseView({ goingAlone: true, calledSuit: null, calledAce: null, recrackerId: 'p2' })
-    expect(deducedPartner(view, 'p3')).toBeNull()
+    expect(resolveView(view, 'p3').resolvedPartner).toBeNull()
   })
 
   it('returns self when bot is the partner (view.partner === userId)', () => {
     const view = baseView({ partner: 'p2' })
-    expect(deducedPartner(view, 'p2')).toBe('p2')
+    expect(resolveView(view, 'p2').resolvedPartner).toBe('p2')
   })
 
   it('leaster: returns null', () => {
     const view = baseView({ isLeaster: true, picker: null, callMode: null })
-    expect(deducedPartner(view, 'p3')).toBeNull()
+    expect(resolveView(view, 'p3').resolvedPartner).toBeNull()
   })
 })
 
@@ -184,7 +184,7 @@ const fail9 = (suit) => ({ id: `9${suit}`, suit, rank: '9' })
 describe('deducedTrumpVoids', () => {
   it('empty tricks → empty set', () => {
     const view = baseView({ tricks: [] })
-    expect(deducedTrumpVoids(view)).toEqual(new Set())
+    expect(resolveView(view, 'p1').resolvedTrumpVoids).toEqual(new Set())
   })
 
   it('trump led, one player played fail → that player in set', () => {
@@ -200,7 +200,7 @@ describe('deducedTrumpVoids', () => {
         ],
       }],
     })
-    const voids = deducedTrumpVoids(view)
+    const voids = resolveView(view, 'p1').resolvedTrumpVoids
     expect(voids.has('p3')).toBe(true)
     expect(voids.has('p4')).toBe(true)
     expect(voids.has('p5')).toBe(true)
@@ -217,7 +217,7 @@ describe('deducedTrumpVoids', () => {
         ],
       }],
     })
-    const voids = deducedTrumpVoids(view)
+    const voids = resolveView(view, 'p1').resolvedTrumpVoids
     expect(voids.has('p2')).toBe(false)
   })
 
@@ -231,7 +231,7 @@ describe('deducedTrumpVoids', () => {
         ],
       }],
     })
-    const voids = deducedTrumpVoids(view)
+    const voids = resolveView(view, 'p1').resolvedTrumpVoids
     expect(voids.has('p2')).toBe(false)
   })
 
@@ -244,7 +244,7 @@ describe('deducedTrumpVoids', () => {
         ],
       }],
     })
-    const voids = deducedTrumpVoids(view)
+    const voids = resolveView(view, 'p1').resolvedTrumpVoids
     expect(voids.has('p2')).toBe(false)
   })
 
@@ -258,7 +258,7 @@ describe('deducedTrumpVoids', () => {
         { userId: 'p2', card: { id: 'AC', suit: 'C', rank: 'A' } },   // fail — but in-progress
       ],
     })
-    const voids = deducedTrumpVoids(view)
+    const voids = resolveView(view, 'p1').resolvedTrumpVoids
     expect(voids.has('p2')).toBe(false)
   })
 
@@ -273,7 +273,7 @@ describe('deducedTrumpVoids', () => {
         ],
       }],
     })
-    const voids = deducedTrumpVoids(view)
+    const voids = resolveView(view, 'p1').resolvedTrumpVoids
     expect(voids.has('p2')).toBe(false)   // hidden — no deduction
     expect(voids.has('p3')).toBe(true)    // visible fail — deduced void
   })
@@ -569,7 +569,7 @@ describe('isGuaranteedWinner – non-trump extension', () => {
 describe('deducedNonTrumpVoids', () => {
   it('empty tricks → empty Map (no voids)', () => {
     const view = baseView({ tricks: [] })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result).toEqual(new Map())
   })
 
@@ -587,7 +587,7 @@ describe('deducedNonTrumpVoids', () => {
         ],
       }],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2') instanceof Set).toBe(true)
     expect(result.get('p2').has('C')).toBe(true)
     expect(result.get('p3')).toBeUndefined()
@@ -606,7 +606,7 @@ describe('deducedNonTrumpVoids', () => {
         ],
       }],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2')).toBeUndefined()
     expect(result.get('p3')).toBeUndefined()
   })
@@ -622,7 +622,7 @@ describe('deducedNonTrumpVoids', () => {
         ],
       }],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2') instanceof Set).toBe(true)
     expect(result.get('p2').has('H')).toBe(true)
     expect(result.get('p3') instanceof Set).toBe(true)
@@ -641,7 +641,7 @@ describe('deducedNonTrumpVoids', () => {
         ],
       }],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2')).toBeUndefined()
     expect(result.get('p3')).toBeUndefined()
   })
@@ -655,7 +655,7 @@ describe('deducedNonTrumpVoids', () => {
         ],
       }],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2')).toBeUndefined()
   })
 
@@ -680,7 +680,7 @@ describe('deducedNonTrumpVoids', () => {
         },
       ],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2') instanceof Set).toBe(true)
     expect(result.get('p2').has('C')).toBe(true)
     expect(result.get('p2').has('H')).toBe(false)   // p2 followed hearts in trick 2
@@ -698,7 +698,7 @@ describe('deducedNonTrumpVoids', () => {
         { userId: 'p2', card: { id: 'KH', suit: 'H', rank: 'K' } },  // would imply void
       ],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2')).toBeUndefined()
   })
 
@@ -712,7 +712,7 @@ describe('deducedNonTrumpVoids', () => {
         ],
       }],
     })
-    const result = deducedNonTrumpVoids(view)
+    const result = resolveView(view, 'p1').resolvedNonTrumpVoids
     expect(result.get('p2')).toBeUndefined()   // hidden → no deduction
     expect(result.get('p3') instanceof Set).toBe(true)
     expect(result.get('p3').has('C')).toBe(true)
@@ -801,22 +801,22 @@ describe('resolveView pre-computed inference fields', () => {
     buried: [],
   })
 
-  it('resolvedPartner equals deducedPartner(view, userId)', () => {
+  it('resolvedPartner is null when no partner signals are present', () => {
     const view = buildView()
     const rv = resolveView(view, 'p2')
-    expect(rv.resolvedPartner).toBe(deducedPartner(view, 'p2'))
+    expect(rv.resolvedPartner).toBeNull()
   })
 
-  it('resolvedTrumpVoids equals deducedTrumpVoids(view)', () => {
+  it('resolvedTrumpVoids is an empty Set when no completed tricks', () => {
     const view = buildView()
     const rv = resolveView(view, 'p2')
-    expect(rv.resolvedTrumpVoids).toEqual(deducedTrumpVoids(view))
+    expect(rv.resolvedTrumpVoids).toEqual(new Set())
   })
 
-  it('resolvedNonTrumpVoids equals deducedNonTrumpVoids(view)', () => {
+  it('resolvedNonTrumpVoids is an empty Map when no completed tricks', () => {
     const view = buildView()
     const rv = resolveView(view, 'p2')
-    expect(rv.resolvedNonTrumpVoids).toEqual(deducedNonTrumpVoids(view))
+    expect(rv.resolvedNonTrumpVoids).toEqual(new Map())
   })
 
   it('resolvedTrumpRemaining equals trumpRemainingElsewhere(view, userId)', () => {

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -567,10 +567,10 @@ describe('isGuaranteedWinner – non-trump extension', () => {
 // Fail cards: suit ∈ {C,H,S}, rank ≠ Q/J; trump = all Qs, all Js, all diamonds.
 
 describe('deducedNonTrumpVoids', () => {
-  it('empty tricks → empty object (no voids)', () => {
+  it('empty tricks → empty Map (no voids)', () => {
     const view = baseView({ tricks: [] })
     const result = deducedNonTrumpVoids(view)
-    expect(Object.keys(result)).toHaveLength(0)
+    expect(result).toEqual(new Map())
   })
 
   it('fail suit led, one player played a different fail suit → that player void in led suit', () => {
@@ -588,11 +588,11 @@ describe('deducedNonTrumpVoids', () => {
       }],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2'] instanceof Set).toBe(true)
-    expect(result['p2'].has('C')).toBe(true)
-    expect(result['p3']).toBeUndefined()
-    expect(result['p4']).toBeUndefined()
-    expect(result['p5']).toBeUndefined()
+    expect(result.get('p2') instanceof Set).toBe(true)
+    expect(result.get('p2').has('C')).toBe(true)
+    expect(result.get('p3')).toBeUndefined()
+    expect(result.get('p4')).toBeUndefined()
+    expect(result.get('p5')).toBeUndefined()
   })
 
   it('fail suit led, player followed suit → NOT void in that suit', () => {
@@ -607,8 +607,8 @@ describe('deducedNonTrumpVoids', () => {
       }],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2']).toBeUndefined()
-    expect(result['p3']).toBeUndefined()
+    expect(result.get('p2')).toBeUndefined()
+    expect(result.get('p3')).toBeUndefined()
   })
 
   it('fail suit led, player trumped in → void in led fail suit', () => {
@@ -623,10 +623,10 @@ describe('deducedNonTrumpVoids', () => {
       }],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2'] instanceof Set).toBe(true)
-    expect(result['p2'].has('H')).toBe(true)
-    expect(result['p3'] instanceof Set).toBe(true)
-    expect(result['p3'].has('H')).toBe(true)
+    expect(result.get('p2') instanceof Set).toBe(true)
+    expect(result.get('p2').has('H')).toBe(true)
+    expect(result.get('p3') instanceof Set).toBe(true)
+    expect(result.get('p3').has('H')).toBe(true)
   })
 
   it('trump led → no void deduction for any player', () => {
@@ -642,8 +642,8 @@ describe('deducedNonTrumpVoids', () => {
       }],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2']).toBeUndefined()
-    expect(result['p3']).toBeUndefined()
+    expect(result.get('p2')).toBeUndefined()
+    expect(result.get('p3')).toBeUndefined()
   })
 
   it('hidden led card → skip that trick', () => {
@@ -656,7 +656,7 @@ describe('deducedNonTrumpVoids', () => {
       }],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2']).toBeUndefined()
+    expect(result.get('p2')).toBeUndefined()
   })
 
   it('multiple tricks accumulate voids across suits', () => {
@@ -681,12 +681,12 @@ describe('deducedNonTrumpVoids', () => {
       ],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2'] instanceof Set).toBe(true)
-    expect(result['p2'].has('C')).toBe(true)
-    expect(result['p2'].has('H')).toBe(false)   // p2 followed hearts in trick 2
-    expect(result['p3'] instanceof Set).toBe(true)
-    expect(result['p3'].has('H')).toBe(true)
-    expect(result['p3'].has('C')).toBe(false)   // p3 followed clubs in trick 1
+    expect(result.get('p2') instanceof Set).toBe(true)
+    expect(result.get('p2').has('C')).toBe(true)
+    expect(result.get('p2').has('H')).toBe(false)   // p2 followed hearts in trick 2
+    expect(result.get('p3') instanceof Set).toBe(true)
+    expect(result.get('p3').has('H')).toBe(true)
+    expect(result.get('p3').has('C')).toBe(false)   // p3 followed clubs in trick 1
   })
 
   it('currentTrick is ignored — only completed tricks are scanned', () => {
@@ -699,7 +699,7 @@ describe('deducedNonTrumpVoids', () => {
       ],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2']).toBeUndefined()
+    expect(result.get('p2')).toBeUndefined()
   })
 
   it('hidden non-led play in fail-led trick → skip that play, no void deduction', () => {
@@ -713,9 +713,9 @@ describe('deducedNonTrumpVoids', () => {
       }],
     })
     const result = deducedNonTrumpVoids(view)
-    expect(result['p2']).toBeUndefined()   // hidden → no deduction
-    expect(result['p3'] instanceof Set).toBe(true)
-    expect(result['p3'].has('C')).toBe(true)
+    expect(result.get('p2')).toBeUndefined()   // hidden → no deduction
+    expect(result.get('p3') instanceof Set).toBe(true)
+    expect(result.get('p3').has('C')).toBe(true)
   })
 })
 

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -348,7 +348,7 @@ export function decidePlay(view, userId) {
         const failCards = realCards.filter(c => !isTrump(c))
         const safeFails = failCards.filter(card => {
           const suit = effectiveSuit(card)
-          return !opponentIds.some(id => nonTrumpVoids[id]?.has(suit))
+          return !opponentIds.some(id => nonTrumpVoids.get(id)?.has(suit))
         })
         if (safeFails.length > 0) return highestValueCard(safeFails).id
         return highestValueCard(realCards).id
@@ -386,7 +386,7 @@ export function decidePlay(view, userId) {
           // Find cards in suits where at least one picker-team member is void
           const voidSuitCards = failLeads.filter(card => {
             const suit = effectiveSuit(card)
-            return pickerTeamIds.some(id => nonTrumpVoids[id]?.has(suit))
+            return pickerTeamIds.some(id => nonTrumpVoids.get(id)?.has(suit))
           })
           if (voidSuitCards.length > 0) return lowestCard(voidSuitCards).id
         }

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -1038,7 +1038,7 @@ describe('decidePlay — Wire 2: opponent leads into picker-team void to flush t
     // Picker (u2) followed all suits normally — no void in spades.
     // Partner (u3, deduced via recrack) is void in spades.
     // Bot holds: KS (spades, partner void) and 8H (hearts, no void).
-    // Wire 2 should fire because pickerTeamIds.some(id => nonTrumpVoids[id]?.has('S'))
+    // Wire 2 should fire because pickerTeamIds.some(id => nonTrumpVoids.get(id)?.has('S'))
     // is satisfied by u3 (partner), even though u2 (picker) is not void.
     const tricks = [{
       plays: [
@@ -1054,7 +1054,7 @@ describe('decidePlay — Wire 2: opponent leads into picker-team void to flush t
       c('8H', 'H', '8'),   // hearts (no picker-team void)
     ]
     const view = wire2BaseView({ hand, tricks })
-    // deducedPartner = u3 (recrack). nonTrumpVoids[u3] has 'S'. Picker u2 NOT void.
+    // deducedPartner = u3 (recrack). nonTrumpVoids.get(u3) has 'S'. Picker u2 NOT void.
     // Wire 2 fires on 'S'. voidSuitCards = [KS]. lowestCard([KS]) = KS.
     expect(decidePlay(view, 'u4')).toBe('KS')
   })
@@ -1115,7 +1115,7 @@ describe('decidePlay — Wire 2: opponent leads into picker-team void to flush t
     // knownNonPartners: u2 (picker), u4 (self), u1 (played non-called before AH), u3 (same)
     // → 4 ruled out of 5 non-picker seats? Wait: 5 seats total, picker=u2, non-picker = u1,u3,u4,u5.
     // ruled = {u2, u4, u1, u3} → candidates = [u5] → deducedPartner = u5.
-    // nonTrumpVoids[u5] has 'S'. pickerTeamIds = [u2, u5]. Wire 2 fires on KS.
+    // nonTrumpVoids.get(u5) has 'S'. pickerTeamIds = [u2, u5]. Wire 2 fires on KS.
     expect(decidePlay(view, 'u4')).toBe('KS')
   })
 })


### PR DESCRIPTION
## Summary

Post-#176 cleanup from issue #181. The three inference helpers (`deducedPartner`, `deducedTrumpVoids`, `deducedNonTrumpVoids`) were already used exclusively through `resolveView` in production code — this branch formalizes that.

- **Option B (internalize):** Removed `export` from the three helpers. They are now private implementation details of `resolveView`. 25 unit tests migrated from calling helpers directly to asserting on `resolveView(...).resolvedX`.
- **Option C (Map normalization):** `deducedNonTrumpVoids` now returns `Map<userId, Set<suit>>` instead of a plain object `{ [userId]: Set<suit> }`, consistent with how `knownLocations` uses a real `Map`. Two consumers in `botStrategy.js` updated to `.get(id)?.has(suit)`.

No behavioral changes — all 374 tests pass.

## Test Plan
- [x] All 366 backend tests pass
- [x] All 8 frontend tests pass
- [x] `deducedNonTrumpVoids` tests assert on Map semantics
- [x] No direct imports of the three helpers remain outside `botInference.js`

🤖 Generated with Claude Code