### PR TITLE
feat(botInference): extend knownCardLocations with call-based inference

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -194,7 +194,7 @@ of bot team.
 
 | Function | Purpose |
 |---|---|
-| `knownCardLocations` | Returns `Map<userId, Array<card>>` of card objects known by public announcement to be in a player's hand. Phase 1: populated from `view.blitzes` — black blitz → picker holds QC + QS; red blitz → picker holds QH + QD. |
+| `knownCardLocations` | Returns `Map<userId, Array<card>>` of card objects known by public announcement to be in a player's hand. Phase 1: blitzes — black blitz → picker holds QC + QS; red blitz → picker holds QH + QD. Phase 2: ten call → picker holds Ace of called suit. Phase 3: king call → picker holds Ace and Ten of called suit. Phase 4: partner known → partner holds called card (Ace/Ten/King). |
 | `resolveView` | Pre-computation wrapper called once per play decision in `decidePlay`. Returns the view enriched with: `knownLocations` (card locations from blitz declarations), `resolvedPartner` (inferred partner userId or null — distinct from engine-set `view.partner`), `resolvedTrumpVoids` (Set of userIds with no trump remaining), `resolvedNonTrumpVoids` (map of userId → Set of fail suits they cannot follow), and `resolvedTrumpRemaining` (integer count of trump still held by other players). All downstream inference calls receive the enriched view. |
 | `countTrumpPlayed` | Count visible trump in completed tricks and the current trick |
 | `trumpRemainingElsewhere` | Estimate trump still held by other players: `14 − own trump − seen trump − buried trump` |

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -13,23 +13,67 @@ const BLITZ_CARDS = {
 }
 
 // Returns Map<userId, Array<card>> of cards known by public announcement to be in a player's hand.
-// Phase 1: populated from view.blitzes only.
-export function knownCardLocations(view) {
+// Phase 1: populated from view.blitzes.
+// Phase 2: Ten call — picker holds Ace of called suit.
+// Phase 3: King call — picker holds Ace and Ten of called suit.
+// Phase 4: Partner holds called card (if resolvedPartner is provided and not going alone).
+export function knownCardLocations(view, resolvedPartner = null) {
   const map = new Map()
+
+  // Phase 1: Blitzes
   for (const { userId, type } of (view.blitzes ?? [])) {
     const cards = BLITZ_CARDS[type]
     if (cards) map.set(userId, [...cards])
   }
+
+  // Phase 2: Ten call
+  if (view.calledTen && view.picker) {
+    const suit = view.calledTen.suit
+    const card = { id: 'A' + suit, rank: 'A', suit }
+    if (map.has(view.picker)) {
+      map.get(view.picker).push(card)
+    } else {
+      map.set(view.picker, [card])
+    }
+  }
+
+  // Phase 3: King call
+  if (view.calledKing && view.picker) {
+    const suit = view.calledKing.suit
+    const ace = { id: 'A' + suit, rank: 'A', suit }
+    const ten = { id: '10' + suit, rank: '10', suit }
+    if (map.has(view.picker)) {
+      map.get(view.picker).push(ace, ten)
+    } else {
+      map.set(view.picker, [ace, ten])
+    }
+  }
+
+  // Phase 4: Partner holds called card
+  if (resolvedPartner && view.calledSuit && !view.goingAlone) {
+    const calledCardId = view.calledAce?.aceId ?? view.calledTen?.tenId ?? view.calledKing?.kingId
+    if (calledCardId) {
+      const rank = calledCardId.startsWith('10') ? '10' : calledCardId[0]
+      const card = { id: calledCardId, rank, suit: view.calledSuit }
+      if (map.has(resolvedPartner)) {
+        map.get(resolvedPartner).push(card)
+      } else {
+        map.set(resolvedPartner, [card])
+      }
+    }
+  }
+
   return map
 }
 
 // Pre-computation wrapper. Runs four inference helpers once and attaches their results
 // so downstream consumers in a single play decision can read them as property lookups.
 export function resolveView(view, userId) {
+  const resolvedPartner = deducedPartner(view, userId)
   return {
     ...view,
-    knownLocations: knownCardLocations(view),
-    resolvedPartner: deducedPartner(view, userId),
+    knownLocations: knownCardLocations(view, resolvedPartner),
+    resolvedPartner,
     resolvedTrumpVoids: deducedTrumpVoids(view),
     resolvedNonTrumpVoids: deducedNonTrumpVoids(view),
     resolvedTrumpRemaining: trumpRemainingElsewhere(view, userId),

--- a/shared/botInference.js
+++ b/shared/botInference.js
@@ -12,6 +12,15 @@ const BLITZ_CARDS = {
   red:   [{ id: 'QH', rank: 'Q', suit: 'H' }, { id: 'QD', rank: 'Q', suit: 'D' }],
 }
 
+// Add cards to map, creating entry if needed.
+function addToMap(map, userId, ...cards) {
+  if (map.has(userId)) {
+    map.get(userId).push(...cards)
+  } else {
+    map.set(userId, [...cards])
+  }
+}
+
 // Returns Map<userId, Array<card>> of cards known by public announcement to be in a player's hand.
 // Phase 1: populated from view.blitzes.
 // Phase 2: Ten call — picker holds Ace of called suit.
@@ -30,11 +39,7 @@ export function knownCardLocations(view, resolvedPartner = null) {
   if (view.calledTen && view.picker) {
     const suit = view.calledTen.suit
     const card = { id: 'A' + suit, rank: 'A', suit }
-    if (map.has(view.picker)) {
-      map.get(view.picker).push(card)
-    } else {
-      map.set(view.picker, [card])
-    }
+    addToMap(map, view.picker, card)
   }
 
   // Phase 3: King call
@@ -42,11 +47,7 @@ export function knownCardLocations(view, resolvedPartner = null) {
     const suit = view.calledKing.suit
     const ace = { id: 'A' + suit, rank: 'A', suit }
     const ten = { id: '10' + suit, rank: '10', suit }
-    if (map.has(view.picker)) {
-      map.get(view.picker).push(ace, ten)
-    } else {
-      map.set(view.picker, [ace, ten])
-    }
+    addToMap(map, view.picker, ace, ten)
   }
 
   // Phase 4: Partner holds called card
@@ -55,11 +56,7 @@ export function knownCardLocations(view, resolvedPartner = null) {
     if (calledCardId) {
       const rank = calledCardId.startsWith('10') ? '10' : calledCardId[0]
       const card = { id: calledCardId, rank, suit: view.calledSuit }
-      if (map.has(resolvedPartner)) {
-        map.get(resolvedPartner).push(card)
-      } else {
-        map.set(resolvedPartner, [card])
-      }
+      addToMap(map, resolvedPartner, card)
     }
   }
 

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -760,6 +760,61 @@ describe('knownCardLocations', () => {
     expect(result.get('p1').map(c => c.id)).toContain('QC')
     expect(result.get('p2').map(c => c.id)).toContain('QH')
   })
+
+  it('Ten call: picker entry contains Ace of called suit', () => {
+    const view = { blitzes: [], picker: 'p1', calledTen: { suit: 'H', tenId: '10H' }, calledSuit: 'H' }
+    const result = knownCardLocations(view, null)
+    expect(result.get('p1')).toContainEqual({ id: 'AH', rank: 'A', suit: 'H' })
+  })
+
+  it('King call: picker entry contains Ace and Ten of called suit', () => {
+    const view = { blitzes: [], picker: 'p1', calledKing: { suit: 'S', kingId: 'KS' }, calledSuit: 'S' }
+    const result = knownCardLocations(view, null)
+    expect(result.get('p1')).toContainEqual({ id: 'AS', rank: 'A', suit: 'S' })
+    expect(result.get('p1')).toContainEqual({ id: '10S', rank: '10', suit: 'S' })
+  })
+
+  it('known partner with ace call: partner entry contains called Ace', () => {
+    const view = { blitzes: [], picker: 'p1', calledAce: { aceId: 'AH' }, calledSuit: 'H' }
+    const result = knownCardLocations(view, 'p2')
+    expect(result.get('p2')).toContainEqual({ id: 'AH', rank: 'A', suit: 'H' })
+  })
+
+  it('known partner with ten call: partner entry contains called Ten', () => {
+    const view = { blitzes: [], picker: 'p1', calledTen: { suit: 'H', tenId: '10H' }, calledSuit: 'H' }
+    const result = knownCardLocations(view, 'p2')
+    expect(result.get('p2')).toContainEqual({ id: '10H', rank: '10', suit: 'H' })
+  })
+
+  it('known partner with king call: partner entry contains called King', () => {
+    const view = { blitzes: [], picker: 'p1', calledKing: { suit: 'C', kingId: 'KC' }, calledSuit: 'C' }
+    const result = knownCardLocations(view, 'p2')
+    expect(result.get('p2')).toContainEqual({ id: 'KC', rank: 'K', suit: 'C' })
+  })
+
+  it('null partner: no called card added to knownLocations', () => {
+    const view = { blitzes: [], picker: 'p1', calledAce: { aceId: 'AH' }, calledSuit: 'H' }
+    const result = knownCardLocations(view, null)
+    expect(result.has('p2')).toBe(false)
+    expect(result.size).toBe(0)
+  })
+
+  it('Ten call stacks with blitz: picker entry has blitz queens plus Ace', () => {
+    const view = { blitzes: [{ userId: 'p1', type: 'black' }], picker: 'p1', calledTen: { suit: 'H', tenId: '10H' }, calledSuit: 'H' }
+    const result = knownCardLocations(view, null)
+    const ids = result.get('p1').map(c => c.id)
+    expect(ids).toContain('QC')
+    expect(ids).toContain('QS')
+    expect(ids).toContain('AH')
+    expect(result.get('p1')).toHaveLength(3)
+  })
+
+  it('going alone: no called card added for partner', () => {
+    const view = { blitzes: [], picker: 'p1', calledAce: { aceId: 'AH' }, calledSuit: 'H', goingAlone: true }
+    const result = knownCardLocations(view, 'p2')
+    expect(result.has('p2')).toBe(false)
+    expect(result.size).toBe(0)
+  })
 })
 
 describe('resolveView', () => {
@@ -1156,5 +1211,45 @@ describe('isGuaranteedWinner – blitz inference (fail case, condition 2)', () =
     // With resolveView: QC in currentTrick (filtered), QS unplayed (counted); 2-1=1 opponent trump remains → false.
     // (An opponent still holds 8D — AH is correctly identified as NOT a guaranteed winner.)
     expect(isGuaranteedWinner(ah, rv, 'p2')).toBe(false)
+  })
+})
+
+describe('resolveView – extended knownCardLocations', () => {
+  const baseViewWithCards = () => ({
+    phase: 'playing',
+    picker: 'p1',
+    partner: null,
+    partnerRevealed: false,
+    callMode: 'ace',
+    calledSuit: 'H',
+    calledAce: { aceId: 'AH' },
+    calledTen: null,
+    calledKing: null,
+    crackerId: null,
+    recrackerId: null,
+    goingAlone: false,
+    isLeaster: false,
+    hands: { p1: [], p2: [], p3: [], p4: [], p5: [] },
+    tricks: [],
+    currentTrick: [],
+    buried: [],
+    blitzes: [],
+  })
+
+  it('resolveView: Ten call populates picker Ace in knownLocations', () => {
+    const view = baseViewWithCards()
+    view.calledTen = { suit: 'H', tenId: '10H' }
+    view.calledAce = null
+    view.calledKing = null
+    const rv = resolveView(view, 'p3')
+    expect(rv.knownLocations.get('p1')).toContainEqual({ id: 'AH', rank: 'A', suit: 'H' })
+  })
+
+  it('resolveView: recracker known as partner → called card in knownLocations', () => {
+    const view = baseViewWithCards()
+    view.recrackerId = 'p2'
+    view.calledAce = { aceId: 'AH' }
+    const rv = resolveView(view, 'p3')
+    expect(rv.knownLocations.get('p2')).toContainEqual({ id: 'AH', rank: 'A', suit: 'H' })
   })
 })

--- a/shared/botInference.test.js
+++ b/shared/botInference.test.js
@@ -784,12 +784,15 @@ describe('knownCardLocations', () => {
     const view = { blitzes: [], picker: 'p1', calledTen: { suit: 'H', tenId: '10H' }, calledSuit: 'H' }
     const result = knownCardLocations(view, 'p2')
     expect(result.get('p2')).toContainEqual({ id: '10H', rank: '10', suit: 'H' })
+    expect(result.get('p1')).toContainEqual({ id: 'AH', rank: 'A', suit: 'H' })
   })
 
   it('known partner with king call: partner entry contains called King', () => {
     const view = { blitzes: [], picker: 'p1', calledKing: { suit: 'C', kingId: 'KC' }, calledSuit: 'C' }
     const result = knownCardLocations(view, 'p2')
     expect(result.get('p2')).toContainEqual({ id: 'KC', rank: 'K', suit: 'C' })
+    expect(result.get('p1')).toContainEqual({ id: 'AC', rank: 'A', suit: 'C' })
+    expect(result.get('p1')).toContainEqual({ id: '10C', rank: '10', suit: 'C' })
   })
 
   it('null partner: no called card added to knownLocations', () => {
@@ -814,6 +817,12 @@ describe('knownCardLocations', () => {
     const result = knownCardLocations(view, 'p2')
     expect(result.has('p2')).toBe(false)
     expect(result.size).toBe(0)
+  })
+
+  it('ace under call: partner entry contains called Ace even when under flag set', () => {
+    const view = { blitzes: [], picker: 'p1', calledAce: { aceId: 'AC', under: true }, calledSuit: 'C' }
+    const result = knownCardLocations(view, 'p2')
+    expect(result.get('p2')).toContainEqual({ id: 'AC', rank: 'A', suit: 'C' })
   })
 })
 


### PR DESCRIPTION
## Summary

- Extends `knownCardLocations(view, resolvedPartner = null)` with three new deterministic inference phases beyond blitz declarations
- Updates `resolveView` to compute `resolvedPartner` first, then pass it into `knownCardLocations` (avoids double-computing partner deduction)
- Updates `docs/BOTS.md` to document all four phases

## New inference phases

| Phase | Trigger | Cards added | Player |
|---|---|---|---|
| 2 | Ten call (`view.calledTen` set) | Ace of called suit | Picker |
| 3 | King call (`view.calledKing` set) | Ace + Ten of called suit | Picker |
| 4 | Partner known (any path) | Called card (Ace/Ten/King) | Partner |

Partner identity for Phase 4 flows from `resolvedPartner`, which `deducedPartner` already resolves via `view.partner`, recrack signal, or elimination — no new deduction logic needed.

## Test plan

- [ ] 11 new tests in `botInference.test.js` covering all new phases, stacking with blitzes, going-alone guard, ace-under call, and resolveView integration
- [ ] All 78 tests pass
- [ ] Cross-phase stacking verified (e.g. Ten call with known partner asserts both picker Ace and partner Ten)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)