### PR TITLE
test(botStrategy): add regression guard for QS guaranteed-winner path

### DIFF
--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -1294,6 +1294,31 @@ describe('decidePlay — Case 4: partner trump lead-back timing', () => {
     expect(decidePlay(view, 'u2')).toBe('QC')
   })
 
+  it('leads QS when QC was played in a prior trick (QS becomes guaranteed)', () => {
+    // Partner holds QS (rank 1) + 8D + fail cards. QC (rank 0) was played in trick 1
+    // by an opponent, so it appears in view.tricks and seenRanks picks up rank 0.
+    // isGuaranteedWinner(QS) = true → deferral guard does not fire → leads QS.
+    const hand = [
+      c('QS', 'S', 'Q'),  // trump rank 1 — guaranteed once QC is seen
+      c('8D', 'D', '8'),  // trump rank 12
+      c('KS', 'S', 'K'),  // fail, 4 pts
+      c('7S', 'S', '7'),  // fail, 0 pts
+    ]
+    const tricks = [
+      {
+        plays: [
+          { userId: 'u3', card: c('QC', 'C', 'Q') },  // QC (rank 0) played by opponent
+          { userId: 'u1', card: c('JC', 'C', 'J') },
+          { userId: 'u2', card: c('9H', 'H', '9') },
+          { userId: 'u4', card: c('8H', 'H', '8') },
+          { userId: 'u5', card: c('7H', 'H', '7') },
+        ],
+      },
+    ]
+    const view = partnerLeadView({ hand, tricks })
+    expect(decidePlay(view, 'u2')).toBe('QS')
+  })
+
   it('leads trump unconditionally when partner has exactly 1 trump (even if not guaranteed)', () => {
     // Partner holds 9D (weak trump, not guaranteed) + fail cards.
     // Only 1 trump → lead it unconditionally (no deferral).


### PR DESCRIPTION
## Summary

- Adds a missing Case 4 test: partner holds QS as best trump, QC was played in a prior trick, partner has 2+ trump and fail cards → should lead QS (not defer to fail)
- Confirms `isGuaranteedWinner(QS)` returns `true` once rank 0 (QC) appears in `view.tricks`, so the deferral guard does not fire

## Context

Issue #190 suspected a regression in partner trump-lead behavior after the ES6 Map refactors. Investigation found no bug: the deferral guard from #132 is working as intended, and the Map changes don't touch the trump path of `isGuaranteedWinner`. This test closes the gap by explicitly covering the "trump becomes guaranteed after a higher trump is played" scenario.

Closes #190

## Test plan

- [ ] `npx vitest run shared/botStrategy.test.js` — all Case 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)