### PR TITLE
feat(botStrategy): schmear trump A/10/K fallback when no high-point fail (#189)

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -123,7 +123,7 @@ A recurring concept below is a **guaranteed winner**: a card the bot holds that 
 #### Picker-team bot following
 1. **Schmear** (teammate is currently winning):
    - First check whether the teammate's win is **safe**: either no non-picker-team opponents remain to play, or the teammate's winning card is itself a guaranteed winner.
-   - **Safe**: dump the highest-value non-trump card. If only trump are available, play the lowest card (don't burn trump to schmear).
+   - **Safe**: dump the highest-point fail card (A/10/K). If no fail A/10/K is available, fall back to trump A/10/K (never J or Q). If neither exists, play the lowest card.
    - **Not safe, bot is the partner**: schmear anyway. The partner trusts the picker's implied trump strength to clean up any overtake.
    - **Not safe, bot is the picker**: try to secure the trick instead:
      1. If the hand contains a guaranteed-winning card among the cards that would win the trick, play the lowest-point such card.
@@ -143,7 +143,7 @@ A recurring concept below is a **guaranteed winner**: a card the bot holds that 
 1. **Schmear** (a confirmed teammate is currently winning):
    - Teammate identity rules: (a) if a partner identity has been deduced from public information, any non-picker-team winner is a teammate; (b) if the **picker went alone** (`goingAlone === true`), any non-picker winner is automatically a teammate (there is no partner to flush out); (c) if the partner is still unknown in a normal call, teammate status cannot be confirmed — skip the schmear branch.
 
-   - **Safe** (no picker or partner remains to play, or the teammate's winning card is itself a guaranteed winner): dump the highest-priority non-trump per the **schmear priority** (see below). If only trump available, play the lowest card.
+   - **Safe** (no picker or partner remains to play, or the teammate's winning card is itself a guaranteed winner): dump the highest-point fail card (A/10/K). If no fail A/10/K is available, fall back to trump A/10/K (never J or Q). If neither exists, play the lowest card.
    - **Not safe**: if the bot can take the trick with a guaranteed-winning card, play the lowest-point such card. Else, if the **picker-team overtake is forced** (called suit led, called card not yet played this trick, no trump played in this trick yet), fall through to the trump-in branch below — the partner's forced called card will overtake any current fail-suit winner, so schmearing high points just donates them to the picker team. Otherwise schmear anyway — no speculative trump burn when a guaranteed takeover isn't available.
 2. **Force-take to enable called-suit lead-back**: When the partner is **not yet known** (neither revealed nor deducible), the current trick is **not** led with the called suit, the bot holds **at least one non-trump card of the called suit** in hand (a card that can be led back next trick), and the bot can take the current trick:
    - Compute **potential opponents remaining** = count of non-self players still to play this trick. With partner identity not yet deduced, no other defender is confirmed as a teammate, so every yet-to-play seat is treated as a picker-team threat.

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -402,15 +402,28 @@ export function decidePlay(view, userId) {
   const ledSuit = first.declaredSuit ?? effectiveSuit(first.card)
 
   if (isPickerTeam) {
-    // Schmear: dump highest-point non-trump on teammate's winning trick,
+    // Schmear: dump highest-point card on teammate's winning trick,
     // unless an opponent still to play could trump over the teammate.
+    // When safe=true (trick confirmed safe), fall back to trump A/10/K if no high-point fail.
+    // Never schmear J or Q regardless of safety.
     if (teammateWinning(rv, userId)) {
-      const schmear = () => {
+      const schmear = (safe = false) => {
         const nonTrump = realCards.filter(c => !isTrump(c))
-        // Pass the bot's full hand (not realCards) so the suit-count tiebreak counts
-        // suits across the entire remaining hand, not just legal plays.
-        const pick = pickBySchmearPriority(nonTrump, 'fail', view.hands[userId])
-        return (pick ?? lowestCard(realCards)).id  // helper returns null when no non-trump available — don't burn trump
+        const highPointFail = nonTrump.filter(c => c.rank === 'A' || c.rank === '10' || c.rank === 'K')
+        if (highPointFail.length > 0) {
+          // Pass the bot's full hand (not realCards) so the suit-count tiebreak counts
+          // suits across the entire remaining hand, not just legal plays.
+          const pick = pickBySchmearPriority(highPointFail, 'fail', view.hands[userId])
+          if (pick) return pick.id
+        }
+        if (safe) {
+          const trumpFallback = realCards.filter(c => isTrump(c) && (c.rank === 'A' || c.rank === '10' || c.rank === 'K'))
+          if (trumpFallback.length > 0) {
+            const pick = pickBySchmearPriority(trumpFallback, 'trump', view.hands[userId])
+            if (pick) return pick.id
+          }
+        }
+        return lowestCard(realCards).id
       }
 
       const winnerPlay = currentWinner(currentTrick)
@@ -423,7 +436,7 @@ export function decidePlay(view, userId) {
       const teammateSafe = opponentsRemainingLocal === 0 ||
         isGuaranteedWinner(winnerPlay.card, rv, userId)
 
-      if (teammateSafe) return schmear()
+      if (teammateSafe) return schmear(true)
 
       // Not safe — opponent could overtake.
       if (userId === partner) {
@@ -533,10 +546,21 @@ export function decidePlay(view, userId) {
     // Opponent: schmear on confirmed teammate wins — unless picker-team still to play
     // could trump over the teammate, in which case attempt a guaranteed takeover.
     if (teammateWinning(rv, userId)) {
-      const schmearOpp = () => {
+      const schmearOpp = (safe = false) => {
         const nonTrump = realCards.filter(c => !isTrump(c))
-        const pick = pickBySchmearPriority(nonTrump, 'fail', view.hands[userId])
-        return (pick ?? lowestCard(realCards)).id
+        const highPointFail = nonTrump.filter(c => c.rank === 'A' || c.rank === '10' || c.rank === 'K')
+        if (highPointFail.length > 0) {
+          const pick = pickBySchmearPriority(highPointFail, 'fail', view.hands[userId])
+          if (pick) return pick.id
+        }
+        if (safe) {
+          const trumpFallback = realCards.filter(c => isTrump(c) && (c.rank === 'A' || c.rank === '10' || c.rank === 'K'))
+          if (trumpFallback.length > 0) {
+            const pick = pickBySchmearPriority(trumpFallback, 'trump', view.hands[userId])
+            if (pick) return pick.id
+          }
+        }
+        return lowestCard(realCards).id
       }
 
       const winnerPlay = currentWinner(currentTrick)
@@ -551,7 +575,7 @@ export function decidePlay(view, userId) {
       const teammateSafe = threatsRemaining === 0 ||
         isGuaranteedWinner(winnerPlay.card, rv, userId)
 
-      if (teammateSafe) return schmearOpp()
+      if (teammateSafe) return schmearOpp(true)
 
       const ledSuitOpp = currentTrick[0].declaredSuit ?? effectiveSuit(currentTrick[0].card)
       const winningOpp = realCards.filter(card => {

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -1554,3 +1554,107 @@ describe('decidePlay — shed weakest trump when forced to follow and cannot win
     expect(decidePlay(view, 'u3')).toBe('KD')
   })
 })
+
+describe('decidePlay — schmear falls back to trump A/10/K when no high-point fail (#189)', () => {
+  // Clubs-led trick. Picker (u3) plays QC (unbeatable trump). Partner bot (u5) plays last, void in clubs.
+  function pickerWinningView(partnerHand) {
+    return {
+      phase: 'playing',
+      hands: {
+        u1: [], u2: [], u3: [], u4: [],
+        u5: partnerHand,
+      },
+      currentTrick: [
+        { userId: 'u1', card: c('6C', 'C', '6') },
+        { userId: 'u2', card: c('7C', 'C', '7') },
+        { userId: 'u3', card: c('QC', 'C', 'Q') },
+        { userId: 'u4', card: c('8C', 'C', '8') },
+      ],
+      tricks: [],
+      picker: 'u3',
+      partner: 'u5',
+      partnerRevealed: true,
+      callMode: 'ace',
+      calledSuit: 'S',
+      calledAce: { aceId: 'AS' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,
+      isLeaster: false,
+      lastTrick: [],
+    }
+  }
+
+  it('partner schmears trump A when no fail A/10/K is available', () => {
+    // Hand has AD (trump) and two 0-pt fail cards. No high-point fail exists.
+    // Pre-fix: bot throws 9S (0 pts). Post-fix: bot schmears AD (11 pts trump).
+    const view = pickerWinningView([
+      c('AD', 'D', 'A'),
+      c('9S', 'S', '9'),
+      c('8H', 'H', '8'),
+    ])
+    expect(decidePlay(view, 'u5')).toBe('AD')
+  })
+
+  it('partner prefers fail over trump even when fail has fewer points', () => {
+    // KS (4 pts fail) is preferred over AD (11 pts trump) — fail always comes first.
+    const view = pickerWinningView([
+      c('AD', 'D', 'A'),
+      c('KS', 'S', 'K'),
+      c('8H', 'H', '8'),
+    ])
+    expect(decidePlay(view, 'u5')).toBe('KS')
+  })
+
+  it('partner never schmears a Jack as trump fallback', () => {
+    // Only trump available is JD (rank J — excluded from trump schmear). Falls to lowest fail.
+    const view = pickerWinningView([
+      c('JD', 'D', 'J'),
+      c('9S', 'S', '9'),
+      c('8H', 'H', '8'),
+    ])
+    expect(decidePlay(view, 'u5')).toBe('9S')
+  })
+})
+
+describe('decidePlay — opponent schmear falls back to trump A/10/K when no high-point fail (#189)', () => {
+  it('opponent schmears trump A when no fail A/10/K is available', () => {
+    // Hearts led (fail). Picker (u2) and partner (u3) have played. Opponent u4 trumped in
+    // with QS (winning). Opponent bot u1 plays last, void in hearts.
+    // Hand has AD (trump) and two 0-pt fail cards. No high-point fail exists.
+    // Pre-fix: bot throws 9S (0 pts). Post-fix: bot schmears AD (11 pts trump).
+    const view = {
+      phase: 'playing',
+      hands: {
+        u2: [], u3: [], u4: [],
+        u1: [
+          c('AD', 'D', 'A'),
+          c('9S', 'S', '9'),
+          c('8C', 'C', '8'),
+        ],
+        u5: [],
+      },
+      currentTrick: [
+        { userId: 'u2', card: c('7H', 'H', '7') },
+        { userId: 'u3', card: c('6H', 'H', '6') },
+        { userId: 'u4', card: c('QS', 'S', 'Q') },
+        { userId: 'u5', card: c('8H', 'H', '8') },
+      ],
+      tricks: [],
+      picker: 'u2',
+      partner: 'u3',
+      partnerRevealed: true,
+      callMode: 'ace',
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,
+      isLeaster: false,
+      lastTrick: [],
+    }
+    expect(decidePlay(view, 'u1')).toBe('AD')
+  })
+})


### PR DESCRIPTION
## Summary

- When a teammate's trick is confirmed safe (no opponent threats remain or the winning card is unbeatable), bots now fall back to **trump A/10/K** as a schmear target if no fail A/10/K exists
- Fail A/10/K is always preferred over trump; Jacks and Queens are never burned regardless of safety
- Applies symmetrically to both picker-team and opponent-team schmear paths
- Unsafe schmear paths (partner trusting picker, opponent fallback without a safe guarantee) are unchanged — trump is still preserved there

## Test plan

- [ ] `partner schmears trump A when no fail A/10/K is available` — the exact #189 worked example: holds `[AD, 9S, 8H]`, plays last on picker's QC win → AD
- [ ] `partner prefers fail over trump even when fail has fewer points` — holds `[AD, KS, 8H]` → KS (4pt fail beats 11pt trump)
- [ ] `partner never schmears a Jack as trump fallback` — holds `[JD, 9S, 8H]`, no A/10/K trump → 9S
- [ ] `opponent schmears trump A when no fail A/10/K is available` — same logic for opponent-team path
- [ ] All 382 existing tests pass

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)