### PR TITLE
fix(test): update stale trump-efficiency test after schmear-on-secured-trick change

### DIFF
--- a/shared/gameEngine.test.js
+++ b/shared/gameEngine.test.js
@@ -2422,12 +2422,11 @@ describe('decidePlay trump efficiency — trump trick (Scenario 1)', () => {
 })
 
 describe('decidePlay trump efficiency — fail trick, bot void (Scenario 2)', () => {
-  it('picker plays highest trump to get the lead on a void fail trick', () => {
+  it('picker schmears highest-point trump when trick is secured (all opponents played)', () => {
     // Clubs led. Picker (p1) void in clubs. p3(AC), p4(KC), p5(9C), p2(7S — void in clubs).
     // Current winner: p3 (AC). Picker hand: KD(rank10), JD(rank7), QS(rank1).
-    // All trump beat AC: KD(trump vs non-trump) ✓, JD ✓, QS ✓.
-    // Old lowestCard([KD,JD,QS]): JD=2pts → JD. Bug: picker wants the lead, play strongest.
-    // New: userId===picker → highestTrump(winning) = QS (rank1, lowest index).
+    // All trump beat AC. opponentsRemaining=0 → trick secured → schmear priority applies.
+    // TRUMP_SCHMEAR_PRIORITY: A, 10, K, 9, 8, 7, J, Q → KD(4pts) wins over JD(2pts) and QS(3pts).
     const view = makeTrumpEfficiencyView({
       userId: 'p1', picker: 'p1', partner: 'p2',
       hand: [c('K','D'), c('J','D'), c('Q','S')],
@@ -2438,7 +2437,7 @@ describe('decidePlay trump efficiency — fail trick, bot void (Scenario 2)', ()
         { userId: 'p2', card: c('7','S') },
       ],
     })
-    expect(decidePlay(view, 'p1')).toBe('QS')
+    expect(decidePlay(view, 'p1')).toBe('KD')
   })
 
   it('partner with >1 trump plays highest trump (point diamond) to win and lead back', () => {


### PR DESCRIPTION
## Summary
- PR #195 changed picker behavior on void fail tricks when `opponentsRemaining === 0`: instead of playing the highest trump (`QS`), the bot now uses schmear priority (`KD`, 4 pts) to maximize card points when the trick is already secured.
- The existing test `picker plays highest trump to get the lead on a void fail trick` predated that change and was asserting `QS`, causing it to fail after merge.
- Updated the test description and assertion to reflect the correct new behavior (`KD` via `TRUMP_SCHMEAR_PRIORITY`).

## Test plan
- [ ] `npm test` passes with no failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)