### PR TITLE
fix(botStrategy): check calledSuitLedUnrevealed before guaranteed-takeover (#205)

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -209,10 +209,11 @@ Only trump can win — fail-led trick, bot is partner (void in led suit), picker
   - Fail A/10/K available → dump highest-point fail A/10/K
   - No fail A/10/K → dump trump A/10/K (never J or Q)
   - Neither → play lowest card
-- Not safe AND bot can win with a guaranteed card → play lowest-point guaranteed winning card
 - Not safe AND picker-team overtake is forced (called suit led AND called card not yet played AND no trump in trick yet) → exit Branch 1; [Branch 3](#opp-trump-in) fires via its predicted-win path
   - Partner is forced to play called card on this trick, overtaking any fail winner; schmearing would donate those points to the picker team
   - Branch 2 is also skipped (it requires the called suit was NOT led); Branch 3 is the landing point
+  - Checked before guaranteed-takeover: Branch 3's schmear priority picks a better trump (e.g. 10D over QC) than cheapestGuaranteedWin would
+- Not safe AND bot can win with a guaranteed card → play lowest-point guaranteed winning card
 - Not safe AND bot void in led fail suit AND has trump that beats current winner → trump in with cheapest winning trump
   - Forces picker to spend a higher trump to retake the trick, or steals the trick outright; preserves premium trump (J/Q) for later
 - Not safe AND all other cases → play lowest non-trump (lowest card if only trump remain); do not schmear

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -483,21 +483,23 @@ export function decidePlay(view, userId) {
 
       if (teammateSafe) return schmearOpp(true)
 
-      const winningOpp = realCards.filter(card => {
-        for (const play of currentTrick) {
-          if (!beats(card, play.card, ledSuit)) return false
-        }
-        return true
-      })
-      const takeover = cheapestGuaranteedWin(winningOpp, rv, userId)
-      if (takeover) return takeover.id
-
-      // #163: called suit led + partner forced to play called card + no trump yet →
-      // fall through to trump-in branch (guaranteed win; pickBySchmearPriority applies).
+      // #205: calledSuitLedUnrevealed must be checked BEFORE cheapestGuaranteedWin.
+      // QC is always a guaranteed winner (rank 0), so cheapestGuaranteedWin would return
+      // QC immediately if checked first — bypassing the fall-through to Branch 3's schmear
+      // priority, which picks a cheaper trump (e.g. 10D) and preserves QC for later.
       const calledSuitLedUnrevealed = !view.partnerRevealed && !!view.calledSuit && ledSuit === view.calledSuit
       if (calledSuitLedUnrevealed && noTrumpPlayedYet) {
         // fall through to predicted-win / lead-back branches below
       } else {
+        const winningOpp = realCards.filter(card => {
+          for (const play of currentTrick) {
+            if (!beats(card, play.card, ledSuit)) return false
+          }
+          return true
+        })
+        const takeover = cheapestGuaranteedWin(winningOpp, rv, userId)
+        if (takeover) return takeover.id
+
         // #165 case 2: void in led fail + winning trump available → trump in with cheapest winner.
         // Forces picker to spend more trump or steals the trick outright.
         const voidInFail = !isTrump(currentTrick[0].card) && realCards.some(c => isTrump(c))

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -397,12 +397,12 @@ describe('decidePlay — opponent schmear-anyway fallback overridden when picker
     expect(decidePlay(view, 'u4')).toBe('AD')
   })
 
-  it('regression guard: takeover path still fires when bot holds a guaranteed winner', () => {
-    // Same recrack setup, but bot u4 holds Q♣ (top trump, always guaranteed).
-    // The schmear-branch takeover path (cheapestGuaranteedWin) must still fire
-    // and the bot should win the trick with QC. The predicted-win override
-    // applies only to the schmear-anyway *fallback*, not the takeover.
-    // QC is the cheapest guaranteed winner by points (Q♣=3, A♦=11, K♦=4).
+  it('calledSuitLedUnrevealed takes priority over guaranteed-takeover: plays AD not QC (#205)', () => {
+    // Same recrack setup (u3 is partner), but bot u4 holds QC (rank-0 trump, always guaranteed)
+    // plus AD (11-pt trump). Hearts (called suit) is led; no trump played yet.
+    // calledSuitLedUnrevealed = true → fall through to Branch 3 before cheapestGuaranteedWin.
+    // Branch 3 schmear priority on winning trump [QC, AD, KD]: 'A' rank first → AD (11 pts).
+    // Playing AD is strictly better than QC: more points captured, QC preserved for later.
     const view = {
       phase: 'playing',
       hands: {
@@ -431,7 +431,7 @@ describe('decidePlay — opponent schmear-anyway fallback overridden when picker
       isLeaster: false,
       lastTrick: [],
     }
-    expect(decidePlay(view, 'u4')).toBe('QC')
+    expect(decidePlay(view, 'u4')).toBe('AD')
   })
 })
 
@@ -1924,5 +1924,56 @@ describe('decidePlay — opponent bot: unsafe fallback plays lowest non-trump, n
     // JC is second-strongest trump. 7D (rank 13) cannot beat JC (rank 2). winningTrump = [].
     // Case 2 doesn't fire. Case 3: nonTrump = [KH, 7H]. lowestCard = 7H (0 pts).
     expect(decidePlay(view, 'u4')).toBe('7H')
+  })
+})
+
+describe('decidePlay — opponent bot: calledSuitLedUnrevealed takes priority over guaranteed-takeover (#205)', () => {
+  it('plays schmear-priority trump (10D) not QC when called suit led, partner unplayed, bot holds QC', () => {
+    // Reproduces game 2 hand 1 trick 1: called suit H led. Teammate u7 winning with 10H.
+    // Bot u9 void in H, holds QC (guaranteed winner, rank 0) plus 10D, 9D (cheaper trump).
+    // Partner deduced as u1 (u6/u7/u8 all played non-AH on H-led trick → u1 is last candidate).
+    // calledSuitLedUnrevealed = true, noTrumpPlayedYet = true.
+    // Old (bug): cheapestGuaranteedWin fires first → QC returned (rank-0 shortcut).
+    // New (#205): calledSuitLedUnrevealed checked first → fall through to Branch 3 →
+    //   schmear priority on [QC, 10D, 9D] picks 10D ('10' rank before 'Q').
+    const view = {
+      phase: 'playing',
+      hands: {
+        u1: [],
+        u6: [], u7: [], u8: [],
+        u9: [
+          c('QC', 'C', 'Q'),   // trump rank 0 — strongest; should be preserved
+          c('10D', 'D', '10'), // trump rank 9 — 10 pts, schmear priority '10'
+          c('9D', 'D', '9'),   // trump rank 11 — 0 pts
+          c('AC', 'C', 'A'),   // fail
+          c('9S', 'S', '9'),   // fail
+          c('10C', 'C', '10'), // fail
+        ],
+      },
+      currentTrick: [
+        { userId: 'u6', card: c('9H', 'H', '9') },
+        { userId: 'u7', card: c('10H', 'H', '10') },
+        { userId: 'u8', card: c('7H', 'H', '7') },
+      ],
+      tricks: [],
+      picker: 'u8',
+      partner: null,
+      partnerRevealed: false,
+      callMode: 'ace',
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      calledTen: null,
+      calledKing: null,
+      crackerId: null,
+      recrackerId: null,
+      isLeaster: false,
+      lastTrick: [],
+    }
+    // u6, u7, u8 all played non-AH on H-led trick → knownNonPartners = {u8, u9, u6, u7}.
+    // Only u1 remains → resolvedPartner = u1. u7 (teammate) winning with 10H.
+    // calledSuitLedUnrevealed = true (H led, AH not played, calledSuit = H).
+    // noTrumpPlayedYet = true (9H, 10H, 7H are all fail).
+    // Branch 3 fires: winningTrump = [QC, 10D, 9D]. schmear priority → 10D.
+    expect(decidePlay(view, 'u9')).toBe('10D')
   })
 })


### PR DESCRIPTION
## Summary

- Moves the `calledSuitLedUnrevealed` check **before** `cheapestGuaranteedWin` in opponent-following Branch 1
- Without this fix, QC (rank 0, always a guaranteed winner) is returned immediately by `cheapestGuaranteedWin` when the called suit is led — bypassing the Branch 3 fallthrough that routes to schmear priority
- Branch 3's schmear priority correctly picks a cheaper trump (e.g. 10D, worth 10 pts) and preserves QC for later tricks

Discovered via game 2 hand 1 in local DB: Sophia held QC and played it on the first trick when H (called suit) was led, instead of spending 10D and saving QC.

Stacked on top of #206 (`feature/165-schmear-fallback`). Merge #206 first.

## Test plan

- [ ] New test: `calledSuitLedUnrevealed takes priority over guaranteed-takeover: plays AD not QC (#205)` — verifies bot plays AD (schmear priority) instead of QC when called suit is led unrevealed
- [ ] Updated regression guard: same scenario, now correctly expects AD
- [ ] `npm test` passes (54 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)