### PR TITLE
fix(bot): use lowestCard for ace-under card selection

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -87,7 +87,7 @@ Priority order:
 
 1. **Normal ace call**: suits exist where bot does NOT hold or bury the ace AND holds ≥ 1 fail card of that suit → call the ace of the qualifying suit with the fewest fail cards in hand
    - Fewest fail cards in hand = most likely an opponent holds the ace
-2. **Ace-under call**: no normal ace call possible AND suits exist where bot holds neither the ace nor any fail cards → pick an under card (cheapest non-trump; fall back to cheapest trump) and declare ace-under
+2. **Ace-under call**: no normal ace call possible AND suits exist where bot holds neither the ace nor any fail cards → pick an under card using `lowestCard` (non-trump first by points ascending; fall back to weakest trump by points then trump rank) and declare ace-under
 3. **Fallback** → go alone
 
 ### Ten Call (`callMode === 'ten'`)

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -154,10 +154,7 @@ export function decideCall(view, userId) {
 
     if (underSuits.length > 0) {
       const suit = underSuits[0]
-      // Pick lowest-value non-trump card as under card; fall back to lowest trump
-      const underCard =
-        hand.filter(c => !isTrump(c)).sort((a, b) => cardPoints(a) - cardPoints(b))[0]
-        ?? [...hand].sort((a, b) => cardPoints(a) - cardPoints(b))[0]
+      const underCard = lowestCard(hand)
       return { type: 'ace_under', suit, underCardId: underCard.id }
     }
 


### PR DESCRIPTION
## Summary
- Replaces manual sort in `decideCall` ace-under branch with the existing `lowestCard()` helper
- `lowestCard` already handles non-trump first → lowest points → weakest trump tiebreaker, so the under card selection now correctly prefers JD over JC when both have 2 pts (JD is trump rank 7; JC is rank 4)
- Updates BOTS.md to reflect the new logic

## Root cause
The old code sorted by `cardPoints` only, with no trump rank tiebreaker. When all cards are trump and two have equal point value (e.g. JC and JD, both 2 pts), array order determined the pick — which could surface a stronger trump as the under card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)