### PR TITLE
fix(bot): select weakest trump for ace-under card when all trump

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -87,7 +87,7 @@ Priority order:
 
 1. **Normal ace call**: suits exist where bot does NOT hold or bury the ace AND holds ≥ 1 fail card of that suit → call the ace of the qualifying suit with the fewest fail cards in hand
    - Fewest fail cards in hand = most likely an opponent holds the ace
-2. **Ace-under call**: no normal ace call possible AND suits exist where bot holds neither the ace nor any fail cards → pick an under card using `lowestCard` (non-trump first by points ascending; fall back to weakest trump by points then trump rank) and declare ace-under
+2. **Ace-under call**: no normal ace call possible AND suits exist where bot holds neither the ace nor any fail cards → pick an under card (cheapest fail card if any; fall back to weakest trump by trump rank) and declare ace-under
 3. **Fallback** → go alone
 
 ### Ten Call (`callMode === 'ten'`)

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -154,7 +154,8 @@ export function decideCall(view, userId) {
 
     if (underSuits.length > 0) {
       const suit = underSuits[0]
-      const underCard = lowestCard(hand)
+      const fails = hand.filter(c => !isTrump(c))
+      const underCard = fails.length > 0 ? lowestCard(fails) : weakestTrump(hand)
       return { type: 'ace_under', suit, underCardId: underCard.id }
     }
 


### PR DESCRIPTION
## Summary
- Fixes under card selection in `decideCall` ace-under branch for all-trump hands
- `lowestCard(hand)` sorted by card points first, picking JD (2 pts, rank 7) over KD (4 pts, rank 10) — but KD is weaker trump and the correct sacrifice
- Now uses cheapest fail card when any exist, otherwise `weakestTrump()` to follow trump-rank order (weakest first)

## Before / After (hand: QC JC JD AD 10D KD)
| | Suggested under card |
|---|---|
| Before (PR #212) | JC (rank 4) |
| After PR #212 | JD (rank 7) — still a Jack |
| After this PR | KD (rank 10) — correct |

🤖 Generated with [Claude Code](https://claude.com/claude-code)