### PR TITLE
fix(bot): picker-team leading strategy fixes

### DIFF
--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -117,11 +117,8 @@ Priority order:
 
 #### Picker-team Bot Leading
 
-- Guaranteed non-trump winner available → play highest-value qualifying card
-  - "Guaranteed" = every higher same-suit card is seen AND no opponent can trump it
-- Partner holds ≥ 2 trump AND strongest trump is not a guaranteed winner AND partner holds ≥ 1 fail card → lead lowest-point fail card instead of trump
-  - Preserves trump for later; exception to default lead-trump rule
-- Trump available (and fail-lead exception above did not fire) → lead highest trump
+- Guaranteed winner available → play highest-value qualifying card (by points; trump and non-trump both eligible)
+- Trump available → lead highest trump (partner always leads trump back if able)
 - No trump, bot is partner → lead lowest non-called-suit fail card (never leads called suit unless it's the only option)
 - No trump, bot is not partner, safe fail suits available → lead highest-value card among safe suits
   - "Safe" = no opponent known void in that suit from completed trick history

--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -122,8 +122,7 @@ Priority order:
 - Partner holds ≥ 2 trump AND strongest trump is not a guaranteed winner AND partner holds ≥ 1 fail card → lead lowest-point fail card instead of trump
   - Preserves trump for later; exception to default lead-trump rule
 - Trump available (and fail-lead exception above did not fire) → lead highest trump
-- No trump, bot is partner, last trick had ≤ 3 trump played → lead lowest called-suit card
-- No trump, bot is partner, last trick had > 3 trump played → lead lowest-point fail card
+- No trump, bot is partner → lead lowest non-called-suit fail card (never leads called suit unless it's the only option)
 - No trump, bot is not partner, safe fail suits available → lead highest-value card among safe suits
   - "Safe" = no opponent known void in that suit from completed trick history
 - No trump, not partner, all suits risky → lead highest-value fail card overall

--- a/docs/BOTS.md
+++ b/docs/BOTS.md
@@ -87,7 +87,7 @@ Priority order:
 
 1. **Normal ace call**: suits exist where bot does NOT hold or bury the ace AND holds ≥ 1 fail card of that suit → call the ace of the qualifying suit with the fewest fail cards in hand
    - Fewest fail cards in hand = most likely an opponent holds the ace
-2. **Ace-under call**: no normal ace call possible AND suits exist where bot holds neither the ace nor any fail cards → pick an under card using `lowestCard` (non-trump first by points ascending; fall back to weakest trump by points then trump rank) and declare ace-under
+2. **Ace-under call**: no normal ace call possible AND suits exist where bot holds neither the ace nor any fail cards → pick an under card (cheapest fail card if any; fall back to weakest trump by trump rank) and declare ace-under
 3. **Fallback** → go alone
 
 ### Ten Call (`callMode === 'ten'`)

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -154,7 +154,8 @@ export function decideCall(view, userId) {
 
     if (underSuits.length > 0) {
       const suit = underSuits[0]
-      const underCard = lowestCard(hand)
+      const fails = hand.filter(c => !isTrump(c))
+      const underCard = fails.length > 0 ? lowestCard(fails) : weakestTrump(hand)
       return { type: 'ace_under', suit, underCardId: underCard.id }
     }
 

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -235,17 +235,13 @@ export function decidePlay(view, userId) {
         return best.id
       }
 
-      // Partner with no trump: lead called suit if previous trick was low on trump,
-      // otherwise lead the lowest-point fail card
+      // Partner with no trump: lead lowest non-called-suit fail to avoid tipping
+      // the called suit. Only fall back to called suit if it's the only option.
       if (userId === partner) {
-        const { calledSuit, lastTrick = [] } = view
-        const lastTrumpCount = lastTrick.filter(p => !p.card?.hidden && isTrump(p.card)).length
-        if (lastTrumpCount <= 3) {
-          const calledSuitCards = realCards.filter(c => effectiveSuit(c) === calledSuit)
-          if (calledSuitCards.length > 0) return lowestCard(calledSuitCards).id
-        }
-        const fails = realCards.filter(c => !isTrump(c))
-        return fails.length > 0 ? lowestCard(fails).id : lowestCard(realCards).id
+        const { calledSuit } = view
+        const nonCalledFails = realCards.filter(c => effectiveSuit(c) !== calledSuit)
+        if (nonCalledFails.length > 0) return lowestCard(nonCalledFails).id
+        return lowestCard(realCards).id
       }
 
       // No trump; lead highest-value fail card — but avoid suits where an opponent

--- a/shared/botStrategy.js
+++ b/shared/botStrategy.js
@@ -215,25 +215,15 @@ export function decidePlay(view, userId) {
 
   if (isLeading) {
     if (isPickerTeam) {
-      // Cash any guaranteed non-trump winner: play highest-value first
-      const guaranteedFails = realCards
-        .filter(c => !isTrump(c) && isGuaranteedWinner(c, rv, userId))
+      // Cash guaranteed winners first, highest value (by points) first.
+      // Partner may cash guaranteed trump winners; picker only cashes guaranteed fails.
+      const guaranteedWinners = realCards
+        .filter(c => isGuaranteedWinner(c, rv, userId))
         .sort((a, b) => cardPoints(b) - cardPoints(a))
-      if (guaranteedFails.length > 0) return guaranteedFails[0].id
-      // Lead strongest trump to win tricks and accumulate points.
-      // Partner with 2+ trump: defer to a fail card if the strongest trump is not
-      // a guaranteed winner (preserve trump for later when they can be decisive).
+      if (guaranteedWinners.length > 0) return guaranteedWinners[0].id
+      // Lead strongest trump. Partner always leads trump back if able.
       const best = highestTrump(realCards)
-      if (best) {
-        if (userId === partner) {
-          const myTrumpCount = realCards.filter(c => isTrump(c)).length
-          const fails = realCards.filter(c => !isTrump(c))
-          if (myTrumpCount >= 2 && fails.length > 0 && !isGuaranteedWinner(best, rv, userId)) {
-            return lowestCard(fails).id
-          }
-        }
-        return best.id
-      }
+      if (best) return best.id
 
       // Partner with no trump: lead lowest non-called-suit fail to avoid tipping
       // the called suit. Only fall back to called suit if it's the only option.

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -1366,6 +1366,48 @@ describe('decidePlay — Case 4: partner trump lead-back timing', () => {
   })
 })
 
+describe('decidePlay — partner leading with no trump avoids called suit', () => {
+  // u1=picker, u2=partner (leading), u3..u5=opponents, calledSuit='H'
+  function partnerNoTrumpLeadView({ hand, lastTrick = [] }) {
+    return {
+      phase: 'playing',
+      hands: { u1: [], u2: hand, u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks: [],
+      picker: 'u1',
+      partner: 'u2',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick,
+    }
+  }
+
+  it('leads lowest non-called-suit fail when alternatives exist (never leads called suit)', () => {
+    // Partner holds called-suit fails (7H, 9H) and non-called fails (KS=4pts, 8C=0pts).
+    // Under the old code: lastTrumpCount=0 ≤ 3 → incorrectly returns '7H' (lowest called).
+    // Expected: 8C — lowestCard of non-called fails (0 pts < 4 pts).
+    const hand = [
+      c('7H', 'H', '7'),
+      c('9H', 'H', '9'),
+      c('KS', 'S', 'K'),
+      c('8C', 'C', '8'),
+    ]
+    expect(decidePlay(partnerNoTrumpLeadView({ hand }), 'u2')).toBe('8C')
+  })
+
+  it('leads lowest called-suit fail when all fails are called suit (no choice)', () => {
+    // Partner holds only Hearts (called suit). No non-called alternative. Must lead Hearts.
+    const hand = [
+      c('KH', 'H', 'K'),
+      c('7H', 'H', '7'),
+      c('9H', 'H', '9'),
+    ]
+    expect(decidePlay(partnerNoTrumpLeadView({ hand }), 'u2')).toBe('7H')
+  })
+})
+
 describe('decidePlay — opponent plays cheapest trump when picker-team winner is unbeatable (#169)', () => {
   it('plays lowest trump instead of highest when no trump can beat current winner', () => {
     // Fail led (9H). Picker u2 already played QC (rank 0, highest trump possible).

--- a/shared/botStrategy.test.js
+++ b/shared/botStrategy.test.js
@@ -1264,11 +1264,9 @@ describe('decidePlay — Case 4: partner trump lead-back timing', () => {
     }
   }
 
-  it('defers to lowest-point fail when partner holds 2 weak trump and strongest is not guaranteed', () => {
+  it('leads strongest trump when no guaranteed winner exists', () => {
     // Partner holds 9D + 8D (weak trump) and fail cards (KS=4pts, 7S=0pts).
-    // No tricks have been played, so all higher-rank trump (ranks 0-10) are unseen.
-    // isGuaranteedWinner(9D) = false (QC through 8D rank 0-10 unaccounted for).
-    // Partner has 2+ trump, fails exist → should defer to lowestCard(fails) = 7S.
+    // No tricks played, so no guaranteed winners. Partner always leads trump back.
     const hand = [
       c('9D', 'D', '9'),  // trump rank 11
       c('8D', 'D', '8'),  // trump rank 12
@@ -1276,7 +1274,7 @@ describe('decidePlay — Case 4: partner trump lead-back timing', () => {
       c('7S', 'S', '7'),  // fail, 0 pts
     ]
     const view = partnerLeadView({ hand })
-    expect(decidePlay(view, 'u2')).toBe('7S')
+    expect(decidePlay(view, 'u2')).toBe('9D')
   })
 
   it('leads highest trump when strongest is a guaranteed winner', () => {
@@ -1289,6 +1287,34 @@ describe('decidePlay — Case 4: partner trump lead-back timing', () => {
     ]
     const view = partnerLeadView({ hand })
     expect(decidePlay(view, 'u2')).toBe('QC')
+  })
+
+  it('leads guaranteed trump by points, not by trump strength', () => {
+    // Partner holds QC (rank 0, guaranteed, 3pts) + AD (rank 8, also guaranteed, 11pts).
+    // Ranks 1-7 all seen in tricks → AD is guaranteed.
+    // By trump strength: QC wins. By points: AD wins (11 > 3).
+    // Expected: AD — partner cashes highest-point guaranteed trump first.
+    const hand = [
+      c('QC', 'C', 'Q'),  // trump rank 0, always guaranteed, 3 pts
+      c('AD', 'D', 'A'),  // trump rank 8, guaranteed once ranks 1-7 seen, 11 pts
+      c('KS', 'S', 'K'),  // fail
+    ]
+    const tricks = [{
+      plays: [
+        { userId: 'u3', card: c('QS', 'S', 'Q') },  // rank 1
+        { userId: 'u3', card: c('QH', 'H', 'Q') },  // rank 2
+        { userId: 'u3', card: c('QD', 'D', 'Q') },  // rank 3
+        { userId: 'u3', card: c('JC', 'C', 'J') },  // rank 4
+        { userId: 'u3', card: c('JS', 'S', 'J') },  // rank 5
+      ],
+    }, {
+      plays: [
+        { userId: 'u3', card: c('JH', 'H', 'J') },  // rank 6
+        { userId: 'u3', card: c('JD', 'D', 'J') },  // rank 7
+      ],
+    }]
+    const view = partnerLeadView({ hand, tricks })
+    expect(decidePlay(view, 'u2')).toBe('AD')
   })
 
   it('leads QS when QC was played in a prior trick (QS becomes guaranteed)', () => {
@@ -1339,9 +1365,8 @@ describe('decidePlay — Case 4: partner trump lead-back timing', () => {
     expect(decidePlay(view, 'u2')).toBe('QS')
   })
 
-  it('does not defer for the picker — picker with 2 weak trump still leads highest trump', () => {
+  it('picker leads strongest trump when none are guaranteed', () => {
     // Picker (u1) holds 9D + 8D (weak trump, not guaranteed) and fail cards.
-    // The new deferral logic is partner-only → picker should still lead highest trump (9D).
     const hand = [
       c('9D', 'D', '9'),  // trump rank 11
       c('8D', 'D', '8'),  // trump rank 12
@@ -1363,6 +1388,89 @@ describe('decidePlay — Case 4: partner trump lead-back timing', () => {
       lastTrick: [],
     }
     expect(decidePlay(view, 'u1')).toBe('9D')
+  })
+
+  it('picker leads guaranteed trump by points, not by trump strength', () => {
+    // Picker holds QC (rank 0, guaranteed, 3pts) + AD (rank 8, guaranteed, 11pts) + fail.
+    // Ranks 1-7 all seen in tricks → AD is guaranteed.
+    // Expected: AD (11pts) over QC (3pts).
+    const hand = [
+      c('QC', 'C', 'Q'),  // trump rank 0, always guaranteed, 3 pts
+      c('AD', 'D', 'A'),  // trump rank 8, guaranteed once ranks 1-7 seen, 11 pts
+      c('KS', 'S', 'K'),  // fail
+    ]
+    const tricks = [{
+      plays: [
+        { userId: 'u3', card: c('QS', 'S', 'Q') },
+        { userId: 'u3', card: c('QH', 'H', 'Q') },
+        { userId: 'u3', card: c('QD', 'D', 'Q') },
+        { userId: 'u3', card: c('JC', 'C', 'J') },
+        { userId: 'u3', card: c('JS', 'S', 'J') },
+      ],
+    }, {
+      plays: [
+        { userId: 'u3', card: c('JH', 'H', 'J') },
+        { userId: 'u3', card: c('JD', 'D', 'J') },
+      ],
+    }]
+    const view = {
+      phase: 'playing',
+      hands: { u1: hand, u2: [], u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks,
+      buried: [],
+      picker: 'u1',
+      partner: 'u2',
+      partnerRevealed: true,
+      calledSuit: 'H',
+      calledAce: { aceId: 'AH' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+    expect(decidePlay(view, 'u1')).toBe('AD')
+  })
+})
+
+describe('decidePlay — partner with trump always leads trump, not fails', () => {
+  // u1=picker, u2=partner (leading), u3..u5=opponents, calledSuit='C'
+  // Mirrors game 2 hand 1: partner has trump available and should lead it.
+  function partnerTwoTrumpLeadView({ hand }) {
+    return {
+      phase: 'playing',
+      hands: { u1: [], u2: hand, u3: [], u4: [], u5: [] },
+      currentTrick: [],
+      tricks: [],
+      picker: 'u1',
+      partner: 'u2',
+      partnerRevealed: true,
+      calledSuit: 'C',
+      calledAce: { aceId: 'AC' },
+      isLeaster: false,
+      lastTrick: [],
+    }
+  }
+
+  it('leads strongest trump even with called-suit and non-called fails available', () => {
+    // Partner holds JS+9D (2 unguaranteed trump) and fails [8C(called), 8S, 7S].
+    // Partner always leads trump back — JS is the strongest trump.
+    const hand = [
+      c('JS', 'S', 'J'),  // trump rank 5, not guaranteed
+      c('8C', 'C', '8'),  // fail — called suit
+      c('8S', 'S', '8'),  // fail — non-called
+      c('9D', 'D', '9'),  // trump rank 11
+      c('7S', 'S', '7'),  // fail — non-called
+    ]
+    expect(decidePlay(partnerTwoTrumpLeadView({ hand }), 'u2')).toBe('JS')
+  })
+
+  it('leads strongest trump even when all fails are called suit', () => {
+    const hand = [
+      c('JS', 'S', 'J'),  // trump rank 5
+      c('8C', 'C', '8'),  // fail — called suit
+      c('9C', 'C', '9'),  // fail — called suit
+      c('9D', 'D', '9'),  // trump rank 11
+    ]
+    expect(decidePlay(partnerTwoTrumpLeadView({ hand }), 'u2')).toBe('JS')
   })
 })
 


### PR DESCRIPTION
## Summary

- **Ace-under weakest trump**: when the picker calls ace-under and holds only trump, selects the weakest trump as the under card instead of the lowestCard default
- **Partner/picker leading — guaranteed winners**: guaranteed winner check now covers trump and fail cards for both picker and partner; highest-value card by points is cashed first (e.g. AD before QC even though QC is stronger trump)
- **Partner leading — always leads trump back**: removed the 2+ trump deferral that had the partner play a fail card instead of trump; partner now leads their strongest trump whenever they hold one
- **Partner/picker leading — called-suit avoidance**: when no trump is available, partner leads the lowest non-called-suit fail card and only falls back to the called suit if it is the only option left

Bugs surfaced by inspecting live game replays (game 1 hand 10, game 2 hand 1).

## Test plan

- [ ] `npx vitest run shared/botStrategy.test.js` — all 60 tests pass
- [ ] Start a new game and observe bot leading behavior as picker-team after winning a trick

🤖 Generated with [Claude Code](https://claude.com/claude-code)